### PR TITLE
Remove isConnect() API

### DIFF
--- a/examples/src/main/java/MilvusClientExample.java
+++ b/examples/src/main/java/MilvusClientExample.java
@@ -78,9 +78,6 @@ public class MilvusClientExample {
       throw e;
     }
 
-    // Check whether we are connected
-    boolean connected = client.isConnected();
-
     // Create a collection with the following collection mapping
     final String collectionName = "example"; // collection name
     final long dimension = 128; // dimension of each vector

--- a/src/main/java/io/milvus/client/MilvusClient.java
+++ b/src/main/java/io/milvus/client/MilvusClient.java
@@ -60,12 +60,6 @@ public interface MilvusClient {
   Response connect(ConnectParam connectParam) throws ConnectFailedException;
 
   /**
-   * @return <code>true</code> if the client is connected to Milvus server and the channel's
-   *     connectivity state is READY.
-   */
-  boolean isConnected();
-
-  /**
    * Disconnects from Milvus server
    *
    * @return <code>Response</code>

--- a/src/main/java/io/milvus/client/MilvusGrpcClient.java
+++ b/src/main/java/io/milvus/client/MilvusGrpcClient.java
@@ -115,15 +115,6 @@ public class MilvusGrpcClient implements MilvusClient {
   }
 
   @Override
-  public boolean isConnected() {
-    if (channel == null) {
-      return false;
-    }
-    ConnectivityState connectivityState = channel.getState(false);
-    return connectivityState == ConnectivityState.READY;
-  }
-
-  @Override
   public Response disconnect() throws InterruptedException {
     if (!channelIsReadyOrIdle()) {
       logWarning("You are not connected to Milvus server");

--- a/src/test/java/io/milvus/client/MilvusGrpcClientTest.java
+++ b/src/test/java/io/milvus/client/MilvusGrpcClientTest.java
@@ -116,8 +116,6 @@ class MilvusClientTest {
             .build();
     client.connect(connectParam);
     TimeUnit.SECONDS.sleep(2);
-    // Channel should be idle
-    assertFalse(client.isConnected());
     // A new RPC would take the channel out of idle mode
     assertTrue(client.listCollections().ok());
   }
@@ -160,11 +158,6 @@ class MilvusClientTest {
     MilvusClient client = new MilvusGrpcClient();
     ConnectParam connectParam = new ConnectParam.Builder().withHost("250.250.250.250").build();
     assertThrows(ConnectFailedException.class, () -> client.connect(connectParam));
-  }
-
-  @org.junit.jupiter.api.Test
-  void isConnected() {
-    assertTrue(client.isConnected());
   }
 
   @org.junit.jupiter.api.Test


### PR DESCRIPTION
Signed-off-by: sahuang <xiaohai.xu@zilliz.com>

According to discussions from Issue #117 as well as further discussions with fellow engineers, we decided to remove isConnect() API from the next SDK release. Reasons being that it is not recommended to check whether connectivity is set successfully by `ConnectivityState` (it is an experimental API). Instead, the client can just start sending RPC requests. This will wake up the connection and enable subsequent communications.