### PR TITLE
Support GRPC name resolver and load balancing

### DIFF
--- a/src/main/java/io/milvus/client/ConnectParam.java
+++ b/src/main/java/io/milvus/client/ConnectParam.java
@@ -19,13 +19,17 @@
 
 package io.milvus.client;
 
+import io.grpc.ManagedChannelBuilder;
+
 import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 /** Contains parameters for connecting to Milvus server */
 public class ConnectParam {
+  private final String target;
   private final String host;
   private final int port;
+  private final String defaultLoadBalancingPolicy;
   private final long connectTimeoutNanos;
   private final long keepAliveTimeNanos;
   private final long keepAliveTimeoutNanos;
@@ -33,13 +37,19 @@ public class ConnectParam {
   private final long idleTimeoutNanos;
 
   private ConnectParam(@Nonnull Builder builder) {
+    this.target = builder.target;
     this.host = builder.host;
     this.port = builder.port;
+    this.defaultLoadBalancingPolicy = builder.defaultLoadBalancingPolicy;
     this.connectTimeoutNanos = builder.connectTimeoutNanos;
     this.keepAliveTimeNanos = builder.keepAliveTimeNanos;
     this.keepAliveTimeoutNanos = builder.keepAliveTimeoutNanos;
     this.keepAliveWithoutCalls = builder.keepAliveWithoutCalls;
     this.idleTimeoutNanos = builder.idleTimeoutNanos;
+  }
+
+  public String getTarget() {
+    return target;
   }
 
   public String getHost() {
@@ -48,6 +58,10 @@ public class ConnectParam {
 
   public int getPort() {
     return port;
+  }
+
+  public String getDefaultLoadBalancingPolicy() {
+    return defaultLoadBalancingPolicy;
   }
 
   public long getConnectTimeout(@Nonnull TimeUnit timeUnit) {
@@ -73,13 +87,28 @@ public class ConnectParam {
   /** Builder for <code>ConnectParam</code> */
   public static class Builder {
     // Optional parameters - initialized to default values
+    private String target = null;
     private String host = "localhost";
     private int port = 19530;
+    private String defaultLoadBalancingPolicy = "round_robin";
     private long connectTimeoutNanos = TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
     private long keepAliveTimeNanos = Long.MAX_VALUE; // Disabling keepalive
     private long keepAliveTimeoutNanos = TimeUnit.NANOSECONDS.convert(20, TimeUnit.SECONDS);
     private boolean keepAliveWithoutCalls = false;
     private long idleTimeoutNanos = TimeUnit.NANOSECONDS.convert(24, TimeUnit.HOURS);
+
+    /**
+     * Optional. Defaults to null. Will be used in precedence to host and port.
+     *
+     * @param target a GRPC target string
+     * @return <code>Builder</code>
+     *
+     * @see ManagedChannelBuilder#forTarget(String)
+     */
+    public Builder withTarget(@Nonnull String target) {
+      this.target = target;
+      return this;
+    }
 
     /**
      * Optional. Defaults to "localhost".
@@ -103,6 +132,17 @@ public class ConnectParam {
         throw new IllegalArgumentException("Port is out of range!");
       }
       this.port = port;
+      return this;
+    }
+
+    /**
+     * Optional. Defaults to "round_robin".
+     *
+     * @param defaultLoadBalancingPolicy the default load-balancing policy name
+     * @return <code>Builder</code>
+     */
+    public Builder withDefaultLoadBalancingPolicy(String defaultLoadBalancingPolicy) {
+      this.defaultLoadBalancingPolicy = defaultLoadBalancingPolicy;
       return this;
     }
 

--- a/src/main/java/io/milvus/client/MilvusClient.java
+++ b/src/main/java/io/milvus/client/MilvusClient.java
@@ -20,6 +20,7 @@
 package io.milvus.client;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.Metadata;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.io.IOException;
@@ -49,6 +50,16 @@ public interface MilvusClient {
         }
       }
       return properties.getProperty("version");
+    }
+  }.get();
+
+  Metadata commonHeaders = new Supplier<Metadata>() {
+    @Override
+    public Metadata get() {
+      Metadata metadata = new Metadata();
+      Metadata.Key<String> key = Metadata.Key.of("Milvus-Client-Version", Metadata.ASCII_STRING_MARSHALLER);
+      metadata.put(key, clientVersion);
+      return metadata;
     }
   }.get();
 

--- a/src/main/java/io/milvus/client/MilvusGrpcClient.java
+++ b/src/main/java/io/milvus/client/MilvusGrpcClient.java
@@ -53,9 +53,13 @@ public class MilvusGrpcClient extends AbstractMilvusGrpcClient {
   private final MilvusServiceGrpc.MilvusServiceFutureStub futureStub;
 
   public MilvusGrpcClient(ConnectParam connectParam) {
-    channel = ManagedChannelBuilder.forAddress(connectParam.getHost(), connectParam.getPort())
-        .usePlaintext()
+    ManagedChannelBuilder builder = connectParam.getTarget() != null
+        ? ManagedChannelBuilder.forTarget(connectParam.getTarget())
+        : ManagedChannelBuilder.forAddress(connectParam.getHost(), connectParam.getPort());
+
+    channel = builder.usePlaintext()
         .maxInboundMessageSize(Integer.MAX_VALUE)
+        .defaultLoadBalancingPolicy(connectParam.getDefaultLoadBalancingPolicy())
         .keepAliveTime(connectParam.getKeepAliveTime(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS)
         .keepAliveTimeout(connectParam.getKeepAliveTimeout(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS)
         .keepAliveWithoutCalls(connectParam.isKeepAliveWithoutCalls())

--- a/src/main/java/io/milvus/client/MilvusGrpcClient.java
+++ b/src/main/java/io/milvus/client/MilvusGrpcClient.java
@@ -67,7 +67,7 @@ public class MilvusGrpcClient extends AbstractMilvusGrpcClient {
     try {
       Response response = getServerVersion();
       if (response.ok()) {
-        String serverVersion = getServerVersion().getMessage();
+        String serverVersion = response.getMessage();
         if (!serverVersion.matches("^" + SUPPORTED_SERVER_VERSION + "(\\..*)?$")) {
           throw new UnsupportedServerVersion(connectParam.getHost(), SUPPORTED_SERVER_VERSION, serverVersion);
         }

--- a/src/main/java/io/milvus/client/MilvusGrpcClient.java
+++ b/src/main/java/io/milvus/client/MilvusGrpcClient.java
@@ -32,6 +32,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
 import io.milvus.client.exception.InitializationException;
 import io.milvus.client.exception.UnsupportedServerVersion;
 import io.milvus.grpc.*;
@@ -65,8 +66,8 @@ public class MilvusGrpcClient extends AbstractMilvusGrpcClient {
         .keepAliveWithoutCalls(connectParam.isKeepAliveWithoutCalls())
         .idleTimeout(connectParam.getIdleTimeout(TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS)
         .build();
-    blockingStub = MilvusServiceGrpc.newBlockingStub(channel);
-    futureStub = MilvusServiceGrpc.newFutureStub(channel);
+    blockingStub = MetadataUtils.attachHeaders(MilvusServiceGrpc.newBlockingStub(channel), commonHeaders);
+    futureStub = MetadataUtils.attachHeaders(MilvusServiceGrpc.newFutureStub(channel), commonHeaders);
 
     try {
       Response response = getServerVersion();

--- a/src/test/java/io/milvus/client/StaticNameResolverProvider.java
+++ b/src/test/java/io/milvus/client/StaticNameResolverProvider.java
@@ -1,0 +1,68 @@
+package io.milvus.client;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.NameResolverProvider;
+
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StaticNameResolverProvider extends NameResolverProvider {
+  private String name;
+  private List<SocketAddress> addresses;
+
+  public StaticNameResolverProvider(String name, SocketAddress... addresses) {
+    this.name = name;
+    this.addresses = Arrays.asList(addresses);
+  }
+
+  @Override
+  public String getDefaultScheme() {
+    return "static";
+  }
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    return 0;
+  }
+
+  @Override
+  public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+    if (!getDefaultScheme().equals(targetUri.getScheme())) {
+      return null;
+    }
+    return new NameResolver() {
+      @Override
+      public String getServiceAuthority() {
+        return "localhost";
+      }
+
+      @Override
+      public void start(Listener2 listener) {
+        List<EquivalentAddressGroup> addrs = addresses.stream()
+            .map(addr -> new EquivalentAddressGroup(Collections.singletonList(addr)))
+            .collect(Collectors.toList());
+
+        listener.onResult(
+            ResolutionResult.newBuilder()
+                .setAddresses(addrs)
+                .setAttributes(Attributes.EMPTY)
+                .build());
+      }
+
+      @Override
+      public void shutdown() {
+      }
+    };
+  }
+}


### PR DESCRIPTION
Support GRPC name resolver and load balancing, which are necessary for HA. Version check should be moved to somewhere   after a connection is created, but I did not find a way to do it with grpc-java. So I propose an alternative by sending the client version via GRPC header, and version check would then be performed by the server.