### PR TITLE
Add workflow to generate javadoc

### DIFF
--- a/.github/workflows/generate_javadoc.yml
+++ b/.github/workflows/generate_javadoc.yml
@@ -1,0 +1,28 @@
+# This workflow will generate Javadoc using Maven and then publish it to GitHub packages when a release is created.
+
+name: Generate and update Javadoc
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  generateJavadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Java 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Generate javadoc
+      run: mvn javadoc:javadoc
+    - name: Deploy on milvus-io.github.io
+      uses: peaceiris/actions-gh-pages@v3
+      with: 
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        external_repository: milvus-io/milvus-io.github.io
+        publish_branch: master  # default: gh-pages
+        publish_dir: ./target/site/apidocs
+        destination_dir: milvus-sdk-java/javadoc/${{github.event.release.tag_name}}


### PR DESCRIPTION
Signed-off-by: shiyu22 <shiyu.chen@zilliz.com>

## About the Action
This workflow will generate Javadoc using Maven and then publish it to GitHub packages when a release is created.

## Create SSH Deploy Key
When deploying the static files(Javadoc) to GitHub Pages with [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages), you need to create SSH deploy key in both `milvus-sdk-java` and `milvus-io.github.io` repository.

1. [Create SSH Deploy Key](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key) 
    ```bash
    $ ssh-keygen -t rsa -b 4096 -C "$(git config user.email)"
    ```
2. Set your keys to the repository
   When need set your **private key** to the repository which includes this action(`milvus-sdk-java`) and set your **public key** to your external repository(`milvus-io.github.io`). Check for [more details](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-external-repository-external_repository).