### PR TITLE
Fix unclosed okhttp response in default heartbeat listener

### DIFF
--- a/src/main/java/io/milvus/connection/ClusterListener.java
+++ b/src/main/java/io/milvus/connection/ClusterListener.java
@@ -34,8 +34,7 @@ public class ClusterListener implements Listener {
                 serverSetting.getServerAddress().getHealthPort());
 
         boolean isRunning = false;
-        try {
-            Response response = get(url);
+        try (Response response = get(url)) {
             isRunning = checkResponse(response);
             if (isRunning) {
                 logger.debug("Host [{}] heartbeat Success of Milvus Cluster Listener.",


### PR DESCRIPTION
Threre's a possible connection leak in ClusterListener. It checks status 200 and response body str as "OK".  
Not sure if okhttp will handle it but better we do.