### PR TITLE
Varchar index name compatible with 2.2.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   standalone:
     container_name: milvus-javasdk-test-standalone
-    image: milvusdb/milvus:v2.2.10
+    image: milvusdb/milvus:v2.2.11
     command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcd:2379
@@ -75,7 +75,7 @@ services:
 
   standaloneslave:
     container_name: milvus-javasdk-test-slave-standalone
-    image: milvusdb/milvus:v2.2.10
+    image: milvusdb/milvus:v2.2.11
     command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcdslave:2379

--- a/src/main/java/io/milvus/param/index/CreateIndexParam.java
+++ b/src/main/java/io/milvus/param/index/CreateIndexParam.java
@@ -56,7 +56,11 @@ public class CreateIndexParam {
         this.indexName = builder.indexName;
         this.indexType = builder.indexType;
         if (builder.indexType != IndexType.INVALID) {
-            this.extraParam.put(Constant.INDEX_TYPE, builder.indexType.name());
+            String indexName = builder.indexType.name();
+            if (builder.indexType == IndexType.TRIE) {
+                indexName = "Trie"; // from v2.2.12, the server side requires "Trie"
+            }
+            this.extraParam.put(Constant.INDEX_TYPE, indexName);
         }
         if (builder.metricType != MetricType.INVALID) {
             this.extraParam.put(Constant.METRIC_TYPE, builder.metricType.name());


### PR DESCRIPTION
In milvus v2.2.12, varchar index name is required to be "Tire", not "TIRE"