### PR TITLE
Resolve Netty version conflicts using netty-shaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <dependencies>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/io/milvus/client/MilvusServiceClient.java
+++ b/src/main/java/io/milvus/client/MilvusServiceClient.java
@@ -60,9 +60,9 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Callable;
 
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 
 
 public class MilvusServiceClient extends AbstractMilvusGrpcClient {


### PR DESCRIPTION
When using the milvus-java-sdk within a Spring project, I encountered multiple compatibility issues with different versions of Netty. Regardless of which version of Netty was prioritized, runtime errors occurred. The only viable solution was to use a shaded version of Netty. This issue was not present in older versions of the milvus-java-sdk, which used a shaded version of Netty. It's unclear why the shading was removed from the pom file in later versions. Consequently, upgrading to the latest version of the milvus-java-sdk led to the aforementioned problems.