### PR TITLE
Fix the issue of default conversion to 0 when id is not of type long

### DIFF
--- a/src/main/java/io/milvus/response/SearchResultsWrapper.java
+++ b/src/main/java/io/milvus/response/SearchResultsWrapper.java
@@ -61,7 +61,6 @@ public class SearchResultsWrapper extends RowRecordWrapper {
         List<IDScore> idScore = getIDScore(indexOfTarget);
         for (int i = 0; i < topK; ++i) {
             QueryResultsWrapper.RowRecord record = new QueryResultsWrapper.RowRecord();
-            record.put("id", idScore.get(i).getLongID());
             record.put("distance", idScore.get(i).getScore());
             buildRowRecord(record, i);
             records.add(record);


### PR DESCRIPTION
Hello everyone, when I tried to set the primary key to varchar type, I found that after using embedding for retrieval, all returned result IDs were 0. After investigation, it was found that all IDs were forcibly converted to 0 here Work hard to merge the code in a timely manner to fix this issue, and recommend a MILVUS Mybatis style ORM library that integrates with Spring Boot using this SDK, which can help Java developers get started better:

https://github.com/JDK-Plus/spring-boot-starter-milvus