### PR TITLE
MetricType was not initialized in SearchIterator#executeNextSearch (#881), and cast errors occured in SearchIterator#checkRmRangeSearchParameters (#887)

### DIFF
--- a/src/main/java/io/milvus/orm/iterator/SearchIterator.java
+++ b/src/main/java/io/milvus/orm/iterator/SearchIterator.java
@@ -229,6 +229,7 @@ public class SearchIterator {
                 .withOutFields(searchIteratorParam.getOutFields())
                 .withRoundDecimal(searchIteratorParam.getRoundDecimal())
                 .withParams(JacksonUtils.toJsonString(params))
+                .withMetricType(MetricType.valueOf(searchIteratorParam.getMetricType()))
                 .withIgnoreGrowing(searchIteratorParam.isIgnoreGrowing());
 
         if (!StringUtils.isNullOrEmpty(searchIteratorParam.getGroupByFieldName())) {


### PR DESCRIPTION
MetricType was not initialized in SearchIterator#executeNextSearch (#881)