### PR TITLE
Adding ability to use javax SSLContext directly when setting up connectConfig.

### DIFF
--- a/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 
+import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
@@ -56,6 +57,8 @@ public class ConnectConfig {
     private Boolean secure = false;
     @Builder.Default
     private long idleTimeoutMs = TimeUnit.MILLISECONDS.convert(24, TimeUnit.HOURS);
+
+    private SSLContext sslContext;
 
     public String getHost() {
         URI uri = URI.create(this.uri);


### PR DESCRIPTION
Additionally fixing check in schema converter: 
- The describe collection method tries to get the max_length of the field, but for the field type `JSON` it is an empty value causing an issue when converting the schema.