### PR TITLE
[issue 1147] Fix dimension calculation in BinaryVector by replacing position() with limit()

### DIFF
--- a/src/main/java/io/milvus/param/ParamUtils.java
+++ b/src/main/java/io/milvus/param/ParamUtils.java
@@ -187,7 +187,7 @@ public class ParamUtils {
 
                     // check dimension
                     ByteBuffer v = (ByteBuffer)value;
-                    int real_dim = calculateBinVectorDim(dataType, v.position());
+                    int real_dim = calculateBinVectorDim(dataType, v.limit());
                     if (real_dim != dim) {
                         String msg = "Incorrect dimension for field '%s': the no.%d vector's dimension: %d is not equal to field's dimension: %d";
                         throw new ParamException(String.format(msg, fieldSchema.getName(), i, real_dim, dim));


### PR DESCRIPTION
The code has been modified to use ByteBuffer.limit() instead of position() in calculateBinVectorDim. The limit() method correctly reflects the length of the data in bytes, ensuring the dimension is calculated accurately and matches the field’s schema.

**Issue Reference**
This PR resolves the issue related to incorrect dimension checking as discussed in [Issue #<Issue_Number>](https://github.com/milvus-io/milvus-sdk-java/issues/1147).