### PR TITLE
Adding in Proxy setting for connection to milvus.

### DIFF
--- a/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
@@ -46,6 +46,7 @@ import io.milvus.param.index.*;
 import io.milvus.param.partition.*;
 import io.milvus.param.resourcegroup.*;
 import io.milvus.param.role.*;
+import io.milvus.v2.utils.ClientUtils;
 import io.grpc.ProxiedSocketAddress;
 import io.grpc.ProxyDetector;
 import lombok.NonNull;
@@ -118,20 +119,7 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
                         .intercept(clientInterceptors);
                 // Add proxy configuration if proxy address is set
                 if (StringUtils.isNotEmpty(connectParam.getProxyAddress())) {
-                    String[] hostPort = connectParam.getProxyAddress().split(":");
-                    if (hostPort.length == 2) {
-                        String proxyHost = hostPort[0];
-                        int proxyPort = Integer.parseInt(hostPort[1]);
-                        builder.proxyDetector(new ProxyDetector() {
-                            @Override
-                            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
-                                return HttpConnectProxiedSocketAddress.newBuilder()
-                                    .setProxyAddress(new InetSocketAddress(proxyHost, proxyPort))
-                                    .setTargetAddress((InetSocketAddress) targetServerAddress)
-                                    .build();
-                            }
-                        });
-                    }
+                    ClientUtils.configureProxy(builder, connectParam.getProxyAddress());
                 }
                 if(connectParam.isSecure()){
                     builder.useTransportSecurity();
@@ -156,21 +144,8 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
                 
                 // Add proxy configuration if proxy address is set
                 if (StringUtils.isNotEmpty(connectParam.getProxyAddress())) {
-                    String[] hostPort = connectParam.getProxyAddress().split(":");
-                    if (hostPort.length == 2) {
-                        String proxyHost = hostPort[0];
-                        int proxyPort = Integer.parseInt(hostPort[1]);
-                        builder.proxyDetector(new ProxyDetector() {
-                            @Override
-                            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
-                                return HttpConnectProxiedSocketAddress.newBuilder()
-                                    .setProxyAddress(new InetSocketAddress(proxyHost, proxyPort))
-                                    .setTargetAddress((InetSocketAddress) targetServerAddress)
-                                    .build();
-                            }
-                        });
-                    }
-                }         
+                    ClientUtils.configureProxy(builder, connectParam.getProxyAddress());
+                }     
                 if(connectParam.isSecure()){
                     builder.useTransportSecurity();
                 }
@@ -188,6 +163,9 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
                         .keepAliveWithoutCalls(connectParam.isKeepAliveWithoutCalls())
                         .idleTimeout(connectParam.getIdleTimeoutMs(), TimeUnit.MILLISECONDS)
                         .intercept(clientInterceptors);
+                if (StringUtils.isNotEmpty(connectParam.getProxyAddress())) {
+                    ClientUtils.configureProxy(builder, connectParam.getProxyAddress());
+                }
                 if(connectParam.isSecure()){
                     builder.useTransportSecurity();
                 }

--- a/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
@@ -59,6 +59,7 @@ public class ConnectParam {
     private final String serverName;
     private final String userName;
     private final ThreadLocal<String> clientRequestId;
+    private final String proxyAddress;
 
     protected ConnectParam(@NonNull Builder builder) {
         this.host = builder.host;
@@ -81,6 +82,7 @@ public class ConnectParam {
         this.serverName = builder.serverName;
         this.userName = builder.userName;
         this.clientRequestId = builder.clientRequestId;
+        this.proxyAddress = builder.proxyAddress;
     }
 
     public static Builder newBuilder() {
@@ -120,6 +122,8 @@ public class ConnectParam {
 
         //used to set client_request_id in the grpc header uniquely for every request
         private ThreadLocal<String> clientRequestId;
+        
+        private String proxyAddress;
 
         protected Builder() {
         }
@@ -357,6 +361,17 @@ public class ConnectParam {
 
         public Builder withClientRequestId(@NonNull ThreadLocal<String> clientRequestId) {
             this.clientRequestId = clientRequestId;
+            return this;
+        }
+        
+        /**
+         * Sets the proxy address for connections through a proxy server.
+         * 
+         * @param proxyAddress proxy server address in format "host:port"
+         * @return <code>Builder</code>
+         */
+        public Builder withProxyAddress(String proxyAddress) {
+            this.proxyAddress = proxyAddress;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -56,6 +56,7 @@ public class ConnectConfig {
     private String caPemPath;
     private String serverPemPath;
     private String serverName;
+    private String proxyAddress;
     @Builder.Default
     private Boolean secure = false;
     @Builder.Default
@@ -96,5 +97,9 @@ public class ConnectConfig {
             return true;
         }
         return secure;
+    }
+
+    public String  getProxyAddress(){
+        return proxyAddress;
     }
 }

--- a/sdk-core/src/main/java/io/milvus/v2/utils/ClientUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/ClientUtils.java
@@ -33,6 +33,9 @@ import io.grpc.stub.MetadataUtils;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.grpc.*;
 import io.milvus.v2.client.ConnectConfig;
+import io.grpc.HttpConnectProxiedSocketAddress;
+import io.grpc.ProxiedSocketAddress;
+import io.grpc.ProxyDetector;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -46,6 +49,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 public class ClientUtils {
     Logger logger = LoggerFactory.getLogger(ClientUtils.class);
@@ -73,6 +78,24 @@ public class ClientUtils {
                         .keepAliveWithoutCalls(connectConfig.isKeepAliveWithoutCalls())
                         .idleTimeout(connectConfig.getIdleTimeoutMs(), TimeUnit.MILLISECONDS)
                         .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata));
+                if (StringUtils.isNotEmpty(connectConfig.getProxyAddress())) {
+                    String[] hostPort = connectConfig.getProxyAddress().split(":");
+                    if (hostPort.length == 2) {
+                        String proxyHost = hostPort[0];
+                        int proxyPort = Integer.parseInt(hostPort[1]);
+
+                        builder.proxyDetector(new ProxyDetector() {
+                            @Override
+                            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
+                                return HttpConnectProxiedSocketAddress.newBuilder()
+                                        .setProxyAddress(new InetSocketAddress(proxyHost, proxyPort))
+                                        .setTargetAddress((InetSocketAddress) targetServerAddress)
+                                        .build();
+                            }
+                        });
+                    }
+                }
+
                 if(connectConfig.isSecure()) {
                     builder.useTransportSecurity();
                 }
@@ -95,6 +118,25 @@ public class ClientUtils {
                         .keepAliveWithoutCalls(connectConfig.isKeepAliveWithoutCalls())
                         .idleTimeout(connectConfig.getIdleTimeoutMs(), TimeUnit.MILLISECONDS)
                         .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata));
+
+                if (StringUtils.isNotEmpty(connectConfig.getProxyAddress())) {
+                    String[] hostPort = connectConfig.getProxyAddress().split(":");
+                    if (hostPort.length == 2) {
+                        String proxyHost = hostPort[0];
+                        int proxyPort = Integer.parseInt(hostPort[1]);
+
+                        builder.proxyDetector(new ProxyDetector() {
+                            @Override
+                            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
+                                return HttpConnectProxiedSocketAddress.newBuilder()
+                                        .setProxyAddress(new InetSocketAddress(proxyHost, proxyPort))
+                                        .setTargetAddress((InetSocketAddress) targetServerAddress)
+                                        .build();
+                            }
+                        });
+                    }
+                }
+
                 if(connectConfig.isSecure()){
                     builder.useTransportSecurity();
                 }
@@ -116,6 +158,24 @@ public class ClientUtils {
                         .keepAliveWithoutCalls(connectConfig.isKeepAliveWithoutCalls())
                         .idleTimeout(connectConfig.getIdleTimeoutMs(), TimeUnit.MILLISECONDS)
                         .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata));
+                
+                if (StringUtils.isNotEmpty(connectConfig.getProxyAddress())) {
+                    String[] hostPort = connectConfig.getProxyAddress().split(":");
+                    if (hostPort.length == 2) {
+                        String proxyHost = hostPort[0];
+                        int proxyPort = Integer.parseInt(hostPort[1]);
+
+                        builder.proxyDetector(new ProxyDetector() {
+                            @Override
+                            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
+                                return HttpConnectProxiedSocketAddress.newBuilder()
+                                        .setProxyAddress(new InetSocketAddress(proxyHost, proxyPort))
+                                        .setTargetAddress((InetSocketAddress) targetServerAddress)
+                                        .build();
+                            }
+                        });
+                    }
+                }
                 if (connectConfig.getSecure()) {
                     builder.useTransportSecurity();
                 }


### PR DESCRIPTION
https://github.com/milvus-io/milvus-sdk-java/issues/1335
Add HTTP proxy support for Milvus Java SDK

- Added proxyAddress field to ConnectParam for explicit proxy configuration
- Implemented withProxyAddress builder method for setting proxy host:port
- Added proxy detector configuration when building gRPC channels
- Supports HTTP proxying for TLS-enabled connections

This change allows users to route Milvus connections through an HTTP proxy
by explicitly setting the proxy address in the ConnectParam.
