### PR TITLE
Fix a bug: incorrect outputFields of query/search with milvus v2.5.8

### DIFF
--- a/examples/src/main/java/io/milvus/v1/BulkWriterExample.java
+++ b/examples/src/main/java/io/milvus/v1/BulkWriterExample.java
@@ -79,6 +79,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 
@@ -647,38 +648,8 @@ public class BulkWriterExample {
         List<QueryResultsWrapper.RowRecord> rowRecords = query(expr, Lists.newArrayList("*"));
         System.out.println("Query results:");
         for (QueryResultsWrapper.RowRecord record : rowRecords) {
-            JsonObject rowObject = new JsonObject();
-            // scalar field
-            rowObject.addProperty("id", (Long)record.get("id"));
-            rowObject.addProperty("bool", (Boolean) record.get("bool"));
-            rowObject.addProperty("int8", (Integer) record.get("int8"));
-            rowObject.addProperty("int16", (Integer) record.get("int16"));
-            rowObject.addProperty("int32", (Integer) record.get("int32"));
-            rowObject.addProperty("float", (Float) record.get("float"));
-            rowObject.addProperty("double", (Double) record.get("double"));
-            rowObject.addProperty("varchar", (String) record.get("varchar"));
-            rowObject.add("json", (JsonElement) record.get("json"));
-
-            // vector field
-            rowObject.add("float_vector", GSON_INSTANCE.toJsonTree(record.get("float_vector")));
-            rowObject.add("binary_vector", GSON_INSTANCE.toJsonTree(((ByteBuffer)record.get("binary_vector")).array()));
-            rowObject.add("float16_vector", GSON_INSTANCE.toJsonTree(((ByteBuffer)record.get("float16_vector")).array()));
-            rowObject.add("sparse_vector", GSON_INSTANCE.toJsonTree(record.get("sparse_vector")));
-
-            // array field
-            rowObject.add("array_bool", GSON_INSTANCE.toJsonTree(record.get("array_bool")));
-            rowObject.add("array_int8", GSON_INSTANCE.toJsonTree(record.get("array_int8")));
-            rowObject.add("array_int16", GSON_INSTANCE.toJsonTree(record.get("array_int16")));
-            rowObject.add("array_int32", GSON_INSTANCE.toJsonTree(record.get("array_int32")));
-            rowObject.add("array_int64", GSON_INSTANCE.toJsonTree(record.get("array_int64")));
-            rowObject.add("array_varchar", GSON_INSTANCE.toJsonTree(record.get("array_varchar")));
-            rowObject.add("array_float", GSON_INSTANCE.toJsonTree(record.get("array_float")));
-            rowObject.add("array_double", GSON_INSTANCE.toJsonTree(record.get("array_double")));
-
-            // dynamic field
-            rowObject.addProperty("dynamic", (String) record.get("dynamic"));
-
-            System.out.println(rowObject);
+            Map<String, Object> fieldValues = record.getFieldValues();
+            System.out.println(fieldValues);
         }
     }
 

--- a/examples/src/main/java/io/milvus/v1/JsonFieldExample.java
+++ b/examples/src/main/java/io/milvus/v1/JsonFieldExample.java
@@ -48,8 +48,7 @@ public class JsonFieldExample {
         R<QueryResults> queryRet = client.query(QueryParam.newBuilder()
                 .withCollectionName(COLLECTION_NAME)
                 .withExpr(expr)
-                .addOutField(ID_FIELD)
-                .addOutField(JSON_FIELD)
+                .withOutFields(Arrays.asList(ID_FIELD, JSON_FIELD, "dynamic1", "dynamic2"))
                 .build());
         QueryResultsWrapper queryWrapper = new QueryResultsWrapper(queryRet.getData());
         System.out.println("\nQuery with expression: " + expr);
@@ -87,7 +86,7 @@ public class JsonFieldExample {
         );
 
         CollectionSchemaParam collectionSchemaParam = CollectionSchemaParam.newBuilder()
-                .withEnableDynamicField(false)
+                .withEnableDynamicField(true)
                 .withFieldTypes(fieldsSchema)
                 .build();
 
@@ -140,7 +139,14 @@ public class JsonFieldExample {
             }
             metadata.add("flags", gson.toJsonTree(Arrays.asList(i, i + 1, i + 2)));
             row.add(JSON_FIELD, metadata);
-            System.out.println(metadata);
+//            System.out.println(metadata);
+
+            // dynamic fields
+            if (i%2 == 0) {
+                row.addProperty("dynamic1", (double)i/3);
+            } else {
+                row.addProperty("dynamic2", "ok");
+            }
 
             client.insert(InsertParam.newBuilder()
                     .withCollectionName(COLLECTION_NAME)
@@ -166,5 +172,6 @@ public class JsonFieldExample {
         queryWithExpr(client, "JSON_CONTAINS(metadata[\"flags\"], 9)");
         queryWithExpr(client, "JSON_CONTAINS_ANY(metadata[\"flags\"], [8, 9, 10])");
         queryWithExpr(client, "JSON_CONTAINS_ALL(metadata[\"flags\"], [8, 9, 10])");
+        queryWithExpr(client, "dynamic1 < 2.0");
     }
 }

--- a/examples/src/main/java/io/milvus/v2/BulkWriterExample.java
+++ b/examples/src/main/java/io/milvus/v2/BulkWriterExample.java
@@ -786,6 +786,8 @@ public class BulkWriterExample {
             comparePrint(collectionSchema, originalEntity, fetchedEntity, "binary_vector");
             comparePrint(collectionSchema, originalEntity, fetchedEntity, "float16_vector");
             comparePrint(collectionSchema, originalEntity, fetchedEntity, "sparse_vector");
+
+            System.out.println(fetchedEntity);
         }
         System.out.println("Result is correct!");
     }

--- a/examples/src/main/java/io/milvus/v2/JsonFieldExample.java
+++ b/examples/src/main/java/io/milvus/v2/JsonFieldExample.java
@@ -47,7 +47,7 @@ public class JsonFieldExample {
         QueryResp queryRet = client.query(QueryReq.builder()
                 .collectionName(COLLECTION_NAME)
                 .filter(expr)
-                .outputFields(Arrays.asList(ID_FIELD, JSON_FIELD))
+                .outputFields(Arrays.asList(ID_FIELD, JSON_FIELD, "dynamic1", "dynamic2"))
                 .build());
         System.out.println("\nQuery with expression: " + expr);
         List<QueryResp.QueryResult> records = queryRet.getQueryResults();
@@ -70,6 +70,7 @@ public class JsonFieldExample {
 
         // Create collection
         CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
+                .enableDynamicField(true)
                 .build();
         collectionSchema.addField(AddFieldReq.builder()
                 .fieldName(ID_FIELD)
@@ -119,7 +120,14 @@ public class JsonFieldExample {
             }
             metadata.add("flags", gson.toJsonTree(Arrays.asList(i, i + 1, i + 2)));
             row.add(JSON_FIELD, metadata);
-            System.out.println(metadata);
+//            System.out.println(metadata);
+
+            // dynamic fields
+            if (i%2 == 0) {
+                row.addProperty("dynamic1", (double)i/3);
+            } else {
+                row.addProperty("dynamic2", "ok");
+            }
 
             client.insert(InsertReq.builder()
                     .collectionName(COLLECTION_NAME)
@@ -143,6 +151,7 @@ public class JsonFieldExample {
         queryWithExpr(client, "JSON_CONTAINS(metadata[\"flags\"], 9)");
         queryWithExpr(client, "JSON_CONTAINS_ANY(metadata[\"flags\"], [8, 9, 10])");
         queryWithExpr(client, "JSON_CONTAINS_ALL(metadata[\"flags\"], [8, 9, 10])");
+        queryWithExpr(client, "dynamic1 < 2.0");
 
         client.close();
     }

--- a/examples/src/main/java/io/milvus/v2/TextMatchExample.java
+++ b/examples/src/main/java/io/milvus/v2/TextMatchExample.java
@@ -11,6 +11,7 @@ import io.milvus.v2.common.IndexParam;
 import io.milvus.v2.service.collection.request.AddFieldReq;
 import io.milvus.v2.service.collection.request.CreateCollectionReq;
 import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.utility.request.FlushReq;
 import io.milvus.v2.service.vector.request.InsertReq;
 import io.milvus.v2.service.vector.request.QueryReq;
 import io.milvus.v2.service.vector.request.SearchReq;
@@ -144,6 +145,9 @@ public class TextMatchExample {
                 .consistencyLevel(ConsistencyLevel.STRONG)
                 .build());
         System.out.printf("%d rows in collection\n", (long)countR.getQueryResults().get(0).getEntity().get("count(*)"));
+
+        // TEXT_MATCH requires the data is persisted
+        client.flush(FlushReq.builder().collectionNames(Collections.singletonList(COLLECTION_NAME)).build());
 
         // Query by keyword filtering expression
         queryWithFilter(client, "TEXT_MATCH(text, \"distance\")");

--- a/sdk-core/src/test/java/io/milvus/client/MilvusClientDockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/client/MilvusClientDockerTest.java
@@ -78,7 +78,7 @@ class MilvusClientDockerTest {
     private static final TestUtils utils = new TestUtils(DIMENSION);
 
     @Container
-    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.7");
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.8");
 
     @BeforeAll
     public static void setUp() {

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
@@ -80,7 +80,7 @@ class MilvusClientV2DockerTest {
     private static final TestUtils utils = new TestUtils(DIMENSION);
 
     @Container
-    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.7");
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.8");
 
     @BeforeAll
     public static void setUp() {
@@ -1934,7 +1934,7 @@ class MilvusClientV2DockerTest {
         QueryResp queryResp = client.query(QueryReq.builder()
                 .collectionName(randomCollectionName)
                 .filter("id >= 0")
-                .outputFields(Lists.newArrayList("*"))
+                .outputFields(Arrays.asList("desc", "flag"))
                 .consistencyLevel(ConsistencyLevel.STRONG)
                 .build());
         List<QueryResp.QueryResult> queryResults = queryResp.getQueryResults();


### PR DESCRIPTION
In milvus v2.5.8, the returned QueryResults is changed, the output_fields member doesn't contain the primary key name.
in milvus versions <= v2.5.7, the QueryResults.output_fields always contains the primary key name. And Java SDK uses the QueryResults.output_fields to fetch data.

So, with milvus v2.5.8, the Java SDK query() cannot get the primary key values. This pr is to follow the logic of pymilvus. In pymilvus,  the QueryResults.output_fields is ignored.