### PR TITLE
Support runAnalyzer() interface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
 
   standaloneslave:
     container_name: milvus-javasdk-test-slave-standalone
-    image: milvusdb/milvus:v2.5.8
+    image: milvusdb/milvus:v2.5.11
     command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcdslave:2379

--- a/pom.xml
+++ b/pom.xml
@@ -99,13 +99,13 @@
         <maven.deploy.plugin.version>3.1.3</maven.deploy.plugin.version>
         <junit.platform.version>1.1.0</junit.platform.version>
         <junit.jupiter.engine.version>5.10.1</junit.jupiter.engine.version>
-        <gson.version>2.10.1</gson.version>
+        <gson.version>2.13.1</gson.version>
         <kotlin.version>1.9.10</kotlin.version>
         <mockito.version>4.11.0</mockito.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <apache.commons.pool2.version>2.12.0</apache.commons.pool2.version>
         <guava.version>32.1.3-jre</guava.version>
-        <errorprone.version>2.21.1</errorprone.version>
+        <errorprone.version>2.38.0</errorprone.version>
 
         <!--for BulkWriter-->
         <plexus.version>3.0.24</plexus.version>

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -382,7 +382,7 @@ public class MilvusClientV2 {
     /**
      * Get information of all replicas from a collection.
      *
-     * @param request {@link DescribeReplicasReq}
+     * @param request describe replicas request
      */
     public DescribeReplicasResp describeReplicas(DescribeReplicasReq request) {
         return rpcUtils.retry(()->collectionService.describeReplicas(this.getRpcStub(), request));
@@ -528,8 +528,8 @@ public class MilvusClientV2 {
      * Get queryIterator based on scalar field(s) filtered by boolean expression.
      * Note that the order of the returned entities cannot be guaranteed.
      *
-     * @param request {@link QueryIteratorReq}
-     * @return {status:result code,data: QueryIterator}
+     * @param request query iterator request
+     * @return QueryIterator
      */
     public QueryIterator queryIterator(QueryIteratorReq request) {
         return rpcUtils.retry(()->vectorService.queryIterator(this.getRpcStub(), request));
@@ -538,8 +538,8 @@ public class MilvusClientV2 {
     /**
      * Get searchIterator based on a vector field. Use expression to do filtering before search.
      *
-     * @param request {@link SearchIteratorReq}
-     * @return {status:result code, data: SearchIterator}
+     * @param request search iterator request
+     * @return SearchIterator
      */
     public SearchIterator searchIterator(SearchIteratorReq request) {
         return rpcUtils.retry(()->vectorService.searchIterator(this.getRpcStub(), request));
@@ -548,11 +548,22 @@ public class MilvusClientV2 {
     /**
      * Get searchIteratorV2 based on a vector field. Use expression to do filtering before search.
      *
-     * @param request {@link SearchIteratorReqV2}
-     * @return {status:result code, data: SearchIteratorV2}
+     * @param request search iterator request V2
+     * @return SearchIteratorV2
      */
     public SearchIteratorV2 searchIteratorV2(SearchIteratorReqV2 request) {
         return rpcUtils.retry(()->vectorService.searchIteratorV2(this.getRpcStub(), request));
+    }
+
+    /**
+     * Run analyzer. Return result tokens of analysis.
+     * Milvus server supports this interface from v2.5.11
+     *
+     * @param request run analyzer request
+     * @return RunAnalyzerResp
+     */
+    public RunAnalyzerResp runAnalyzer(RunAnalyzerReq request) {
+        return rpcUtils.retry(()->vectorService.runAnalyzer(this.getRpcStub(), request));
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/RunAnalyzerReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/RunAnalyzerReq.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.vector.request;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+import java.util.*;
+
+@Data
+@SuperBuilder
+public class RunAnalyzerReq {
+    @Builder.Default
+    private List<String> texts = new ArrayList<>();
+    @Builder.Default
+    private Map<String, Object> analyzerParams = new HashMap<>();
+    @Builder.Default
+    private Boolean withDetail = Boolean.FALSE;
+    @Builder.Default
+    private Boolean withHash = Boolean.FALSE;
+}

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/RunAnalyzerResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/RunAnalyzerResp.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.vector.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@SuperBuilder
+public class RunAnalyzerResp {
+    @Builder.Default
+    List<AnalyzerResult> results = new ArrayList<>();
+
+    @Data
+    @SuperBuilder
+    public static final class AnalyzerResult {
+        @Builder.Default
+        List<AnalyzerToken> tokens = new ArrayList<>();
+    }
+
+    @Data
+    @SuperBuilder
+    public static final class AnalyzerToken {
+        private String token;
+        private Long startOffset;
+        private Long endOffset;
+        private Long position;
+        private Long positionLength;
+        private Long hash;
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/client/MilvusClientDockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/client/MilvusClientDockerTest.java
@@ -75,7 +75,7 @@ class MilvusClientDockerTest {
     private static final TestUtils utils = new TestUtils(DIMENSION);
 
     @Container
-    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.8");
+    private static final MilvusContainer milvus = new MilvusContainer("milvusdb/milvus:v2.5.11");
 
     @BeforeAll
     public static void setUp() {


### PR DESCRIPTION
This patch upgrades Gson version from 2.10.0 to 2.13.1 because 2.10.0 has a bug in toJson() method for complex Map<> object.
The version of errorprone is upgraded to 2.38.0 because Gson 2.13.1 requires it.