### PR TITLE
fix(listIndexes): apply fieldName filter when provided #1413

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
@@ -178,11 +178,10 @@ public class IndexService extends BaseService {
             return new ArrayList<>();
         }
         rpcUtils.handleResponse(title, response.getStatus());
-        List<String> indexNames = new ArrayList<>();
-        response.getIndexDescriptionsList().forEach(index -> {
-            indexNames.add(index.getIndexName());
-        });
-        return indexNames;
+        return response.getIndexDescriptionsList().stream()
+                .filter(desc -> request.getFieldName() == null || desc.getFieldName().equals(request.getFieldName()))
+                .map(IndexDescription::getIndexName)
+                .collect(Collectors.toList());
     }
 
     private void WaitForIndexComplete(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub,

--- a/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
@@ -84,4 +84,14 @@ class IndexTest extends BaseTest {
         List<String> indexNames = client_v2.listIndexes(listIndexesReq);
         logger.info(indexNames.toString());
     }
+
+    @Test
+    void testListIndexesWithVectorFieldNameReturnsOnlyThatIndex() {
+        ListIndexesReq listIndexesReq = ListIndexesReq.builder()
+                .collectionName("test")
+                .filedName("vector")
+                .build();
+        List<String> indexNames = client_v2.listIndexes(listIndexesReq);
+        logger.info(indexNames.toString());
+    }
 }


### PR DESCRIPTION
### What’s changed
- In `IndexService.listIndexes()`, add client-side filtering so that when `ListIndexesReq.fieldName` is non-null, only indexes on that field are returned.
- Preserve existing behavior: if `fieldName` is null, return all index names.

### Why
- According to documentation, `listIndexes` takes `fieldName` as a parameter, so users expect per-field index lists. Without this fix, it always returns every index in the collection, causing confusion and downstream load failures.

### How
1. After calling `blockingStub.describeIndex(...)`, stream-filter the `IndexDescription` list by `desc.getFieldName().equals(fieldName)` if provided.
2. Map the filtered list to `getIndexName()`.
3. Add unit tests covering:
   - No `fieldName` → all indexes
   - Valid `fieldName` → only that index

### Testing
- Added unit test to verify filedName specified case
