### PR TITLE
[cherry-pick] remove defaultIndexName & support jsonPath index

### DIFF
--- a/examples/src/main/java/io/milvus/v2/SimpleExample.java
+++ b/examples/src/main/java/io/milvus/v2/SimpleExample.java
@@ -117,13 +117,13 @@ public class SimpleExample {
 
         expressionTemplateValues.forEach((key, value) -> {
             SearchReq request = SearchReq.builder()
-                .collectionName(collectionName)
-                .data(Collections.singletonList(new FloatVec(new float[]{1.0f, 1.0f, 1.0f, 1.0f})))
-                .topK(10)
-                .filter(key)
-                .filterTemplateValues(value)
-                .outputFields(Collections.singletonList("*"))
-                .build();
+                    .collectionName(collectionName)
+                    .data(Collections.singletonList(new FloatVec(new float[]{1.0f, 1.0f, 1.0f, 1.0f})))
+                    .topK(10)
+                    .filter(key)
+                    .filterTemplateValues(value)
+                    .outputFields(Collections.singletonList("*"))
+                    .build();
             SearchResp statusR = client.search(request);
             List<List<SearchResp.SearchResult>> searchResults2 = statusR.getSearchResults();
             System.out.println("\nSearch with template results:");

--- a/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
+++ b/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
@@ -38,13 +38,6 @@ public class IndexParam {
     private MetricType metricType;
     private Map<String, Object> extraParams;
 
-    public String getIndexName() {
-        if(indexName == null) {
-            return fieldName;
-        }
-        return indexName;
-    }
-
     public enum MetricType {
         INVALID,
         // Only for float vectors


### PR DESCRIPTION
1. JsonPath supports creating multiple indexes.
2. Removed the default indexName from the SDK; the default behavior of indexName is controlled by the milvus.