### PR TITLE
fix milvus-io/milvus-sdk-java#1434

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/SearchReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/SearchReq.java
@@ -73,4 +73,8 @@ public class SearchReq {
     //     Boolean, Long, Double, String, List<Boolean>, List<Long>, List<Double>, List<String>
     @Builder.Default
     private Map<String, Object> filterTemplateValues = new HashMap<>();
+
+    public int getTopK() {
+        return topK > 0 ? topK : (int) limit;
+    }
 }

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/request/SearchReqTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/request/SearchReqTest.java
@@ -1,0 +1,19 @@
+package io.milvus.v2.service.vector.request;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SearchReqTest {
+
+    @Test
+    public void testSearchReqEmptyTopKWithLimit() {
+        SearchReq searchReq=SearchReq.builder()
+                .collectionName("test_collection")
+                .limit(10)
+                .filter("some filter string")
+                .build();
+        assertEquals(10, searchReq.getTopK());
+
+    }
+}


### PR DESCRIPTION
Uses limit as topK value if topK is not set.