### PR TITLE
Update gRPC keepalive defaults to 10s interval, 5s timeout, enable without calls (#1758)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
@@ -209,9 +209,9 @@ public class ConnectParam {
         private String uri;
         private String token;
         private long connectTimeoutMs = 10000;
-        private long keepAliveTimeMs = 55000;
-        private long keepAliveTimeoutMs = 20000;
-        private boolean keepAliveWithoutCalls = false;
+        private long keepAliveTimeMs = 10000;
+        private long keepAliveTimeoutMs = 5000;
+        private boolean keepAliveWithoutCalls = true;
         private long rpcDeadlineMs = 0; // Disabling deadline
 
         private String clientKeyPath;
@@ -396,7 +396,7 @@ public class ConnectParam {
 
         /**
          * Sets the keep-alive time value of client channel. The keep-alive value must be greater than zero.
-         * Default is 55000 ms.
+         * Default is 10000 ms.
          *
          * @param keepAliveTime keep-alive value
          * @param timeUnit      keep-alive unit
@@ -412,7 +412,7 @@ public class ConnectParam {
 
         /**
          * Sets the keep-alive timeout value of client channel. The timeout value must be greater than zero.
-         * Default value is 20000 ms
+         * Default value is 5000 ms
          *
          * @param keepAliveTimeout timeout value
          * @param timeUnit         timeout unit

--- a/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -35,9 +35,9 @@ public class ConnectConfig {
     private String password;
     private String dbName;
     private long connectTimeoutMs = 10000;
-    private long keepAliveTimeMs = 55000;
-    private long keepAliveTimeoutMs = 20000;
-    private boolean keepAliveWithoutCalls = false;
+    private long keepAliveTimeMs = 10000;
+    private long keepAliveTimeoutMs = 5000;
+    private boolean keepAliveWithoutCalls = true;
     private long rpcDeadlineMs = 0; // Disabling deadline
 
     private String clientKeyPath;
@@ -324,9 +324,9 @@ public class ConnectConfig {
         private String password;
         private String dbName;
         private long connectTimeoutMs = 10000;
-        private long keepAliveTimeMs = 55000;
-        private long keepAliveTimeoutMs = 20000;
-        private boolean keepAliveWithoutCalls = false;
+        private long keepAliveTimeMs = 10000;
+        private long keepAliveTimeoutMs = 5000;
+        private boolean keepAliveWithoutCalls = true;
         private long rpcDeadlineMs = 0;
         private String clientKeyPath;
         private String clientPemPath;

--- a/sdk-core/src/test/java/io/milvus/client/MilvusServiceClientTest.java
+++ b/sdk-core/src/test/java/io/milvus/client/MilvusServiceClientTest.java
@@ -284,6 +284,17 @@ class MilvusServiceClientTest {
     }
 
     @Test
+    void connectParamDefaults() {
+        ConnectParam connectParam = ConnectParam.newBuilder()
+                .withHost("dummyHost")
+                .withPort(19530)
+                .build();
+        assertEquals(10000, connectParam.getKeepAliveTimeMs());
+        assertEquals(5000, connectParam.getKeepAliveTimeoutMs());
+        assertTrue(connectParam.isKeepAliveWithoutCalls());
+    }
+
+    @Test
     void testConnect() {
         ConnectParam connectParam = ConnectParam.newBuilder()
                 .withHost("localhost")

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -486,6 +486,16 @@ public class MilvusClientV2Test extends BaseTest {
     }
 
     @Test
+    void connectConfigDefaults() {
+        ConnectConfig config = ConnectConfig.builder()
+                .uri("http://dummyHost:19530")
+                .build();
+        Assertions.assertEquals(10000, config.getKeepAliveTimeMs());
+        Assertions.assertEquals(5000, config.getKeepAliveTimeoutMs());
+        Assertions.assertTrue(config.isKeepAliveWithoutCalls());
+    }
+
+    @Test
     void testV2BuilderClasses() {
         CheckConfig config = new CheckConfig();
 


### PR DESCRIPTION
Change keepAliveTimeMs from 55s to 10s, keepAliveTimeoutMs from 20s to 5s, and enable keepAliveWithoutCalls by default in both ConnectParam (V1) and ConnectConfig (V2).