### PR TITLE
Add forcePromote and forceDrop parameters

### DIFF
--- a/sdk-core/src/main/java/io/milvus/client/AbstractMilvusGrpcClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/AbstractMilvusGrpcClient.java
@@ -2634,6 +2634,7 @@ public abstract class AbstractMilvusGrpcClient implements MilvusClient {
         try {
             DropRoleRequest request = DropRoleRequest.newBuilder()
                     .setRoleName(requestParam.getRoleName())
+                    .setForceDrop(requestParam.isForceDrop())
                     .build();
 
             Status response = blockingStub().dropRole(request);

--- a/sdk-core/src/main/java/io/milvus/param/role/DropRoleParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/role/DropRoleParam.java
@@ -25,12 +25,14 @@ import io.milvus.param.ParamUtils;
 public class DropRoleParam {
 
     private final String roleName;
+    private final boolean forceDrop;
 
     private DropRoleParam(DropRoleParam.Builder builder) {
         if (builder == null) {
             throw new IllegalArgumentException("Builder cannot be null");
         }
         this.roleName = builder.roleName;
+        this.forceDrop = builder.forceDrop;
     }
 
     public static DropRoleParam.Builder newBuilder() {
@@ -41,10 +43,15 @@ public class DropRoleParam {
         return roleName;
     }
 
+    public boolean isForceDrop() {
+        return forceDrop;
+    }
+
     @Override
     public String toString() {
         return "DropRoleParam{" +
                 "roleName='" + roleName + '\'' +
+                ", forceDrop=" + forceDrop +
                 '}';
     }
 
@@ -53,6 +60,7 @@ public class DropRoleParam {
      */
     public static final class Builder {
         private String roleName;
+        private boolean forceDrop;
 
         private Builder() {
         }
@@ -68,6 +76,17 @@ public class DropRoleParam {
                 throw new IllegalArgumentException("Role name cannot be null");
             }
             this.roleName = roleName;
+            return this;
+        }
+
+        /**
+         * Sets the forceDrop flag. If true, the role will be force dropped.
+         *
+         * @param forceDrop forceDrop
+         * @return <code>Builder</code>
+         */
+        public DropRoleParam.Builder withForceDrop(boolean forceDrop) {
+            this.forceDrop = forceDrop;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
@@ -30,6 +30,7 @@ public class CDCService extends BaseService {
     public UpdateReplicateConfigurationResp updateReplicateConfiguration(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, UpdateReplicateConfigurationReq requestParam) {
         UpdateReplicateConfigurationRequest request = UpdateReplicateConfigurationRequest.newBuilder()
                 .setReplicateConfiguration(requestParam.getReplicateConfiguration().toGRPC())
+                .setForcePromote(requestParam.isForcePromote())
                 .build();
 
         String title = "UpdateReplicateConfiguration";

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/UpdateReplicateConfigurationReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/UpdateReplicateConfigurationReq.java
@@ -21,6 +21,7 @@ package io.milvus.v2.service.cdc.request;
 
 public class UpdateReplicateConfigurationReq {
     private ReplicateConfiguration replicateConfiguration;
+    private boolean forcePromote;
 
     public static UpdateReplicateConfigurationReqBuilder builder() {
         return new UpdateReplicateConfigurationReqBuilder();
@@ -28,6 +29,7 @@ public class UpdateReplicateConfigurationReq {
 
     private UpdateReplicateConfigurationReq(UpdateReplicateConfigurationReqBuilder builder) {
         this.replicateConfiguration = builder.replicateConfiguration;
+        this.forcePromote = builder.forcePromote;
     }
 
     public ReplicateConfiguration getReplicateConfiguration() {
@@ -38,18 +40,33 @@ public class UpdateReplicateConfigurationReq {
         this.replicateConfiguration = replicateConfiguration;
     }
 
+    public boolean isForcePromote() {
+        return forcePromote;
+    }
+
+    public void setForcePromote(boolean forcePromote) {
+        this.forcePromote = forcePromote;
+    }
+
     @Override
     public String toString() {
         return "UpdateReplicateConfigurationReq{" +
                 "replicateConfiguration=" + replicateConfiguration +
+                ", forcePromote=" + forcePromote +
                 '}';
     }
 
     public static class UpdateReplicateConfigurationReqBuilder {
         private ReplicateConfiguration replicateConfiguration;
+        private boolean forcePromote;
 
         public UpdateReplicateConfigurationReqBuilder replicateConfiguration(ReplicateConfiguration replicateConfiguration) {
             this.replicateConfiguration = replicateConfiguration;
+            return this;
+        }
+
+        public UpdateReplicateConfigurationReqBuilder forcePromote(boolean forcePromote) {
+            this.forcePromote = forcePromote;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/rbac/RBACService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/rbac/RBACService.java
@@ -88,6 +88,7 @@ public class RBACService extends BaseService {
         String title = String.format("Drop role: '%s'", request.getRoleName());
         DropRoleRequest dropRoleRequest = DropRoleRequest.newBuilder()
                 .setRoleName(request.getRoleName())
+                .setForceDrop(request.isForceDrop())
                 .build();
         Status status = blockingStub.dropRole(dropRoleRequest);
         rpcUtils.handleResponse(title, status);

--- a/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/DropRoleReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/DropRoleReq.java
@@ -21,9 +21,11 @@ package io.milvus.v2.service.rbac.request;
 
 public class DropRoleReq {
     private String roleName;
+    private boolean forceDrop;
 
     private DropRoleReq(DropRoleReqBuilder builder) {
         this.roleName = builder.roleName;
+        this.forceDrop = builder.forceDrop;
     }
 
     public String getRoleName() {
@@ -34,10 +36,19 @@ public class DropRoleReq {
         this.roleName = roleName;
     }
 
+    public boolean isForceDrop() {
+        return forceDrop;
+    }
+
+    public void setForceDrop(boolean forceDrop) {
+        this.forceDrop = forceDrop;
+    }
+
     @Override
     public String toString() {
         return "DropRoleReq{" +
                 "roleName='" + roleName + '\'' +
+                ", forceDrop=" + forceDrop +
                 '}';
     }
 
@@ -47,12 +58,18 @@ public class DropRoleReq {
 
     public static class DropRoleReqBuilder {
         private String roleName;
+        private boolean forceDrop;
 
         private DropRoleReqBuilder() {
         }
 
         public DropRoleReqBuilder roleName(String roleName) {
             this.roleName = roleName;
+            return this;
+        }
+
+        public DropRoleReqBuilder forceDrop(boolean forceDrop) {
+            this.forceDrop = forceDrop;
             return this;
         }
 


### PR DESCRIPTION
## Summary
- Add `forcePromote` parameter to `UpdateReplicateConfigurationRequest` (v2 CDC service)
- Add `forceDrop` parameter to `DropRoleRequest` (v1 & v2 RBAC service)

Cherry-pick of #1790 to 2.6 branch.

## Test plan
- [x] Compilation passes
- [ ] Integration test with Milvus server

🤖 Generated with [Claude Code](https://claude.com/claude-code)