### PR TITLE
[cherry-pick] Add identifier interceptor to align with pymilvus behavior (#1811)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
@@ -25,6 +25,7 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.stub.MetadataUtils;
+import io.milvus.common.interceptor.IdentifierInterceptor;
 import io.milvus.common.utils.ExceptionUtils;
 import io.milvus.exception.MilvusException;
 import io.milvus.exception.ServerException;
@@ -71,8 +72,8 @@ import java.util.concurrent.TimeUnit;
 public class MilvusServiceClient extends AbstractMilvusGrpcClient {
 
     private ManagedChannel channel;
-    private final MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub;
-    private final MilvusServiceGrpc.MilvusServiceFutureStub futureStub;
+    private MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub;
+    private MilvusServiceGrpc.MilvusServiceFutureStub futureStub;
     private final long rpcDeadlineMs;
     private long timeoutMs = 0;
     private RetryParam retryParam = RetryParam.newBuilder().build();
@@ -186,6 +187,7 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
         assert channel != null;
 
         try {
+            // Use a temporary stub to call Connect RPC and obtain the server-assigned identifier
             blockingStub = MilvusServiceGrpc.newBlockingStub(channel);
             futureStub = MilvusServiceGrpc.newFutureStub(channel);
 
@@ -198,6 +200,14 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
                 logError(msg);
                 throw new RuntimeException(msg);
             }
+
+            // Wrap channel with identifier interceptor so that every subsequent RPC
+            // carries the identifier in gRPC metadata, aligning with pymilvus behavior.
+            long identifier = resp.getData().getIdentifier();
+            Channel interceptedChannel = ClientInterceptors.intercept(channel,
+                    new IdentifierInterceptor(identifier));
+            blockingStub = MilvusServiceGrpc.newBlockingStub(interceptedChannel);
+            futureStub = MilvusServiceGrpc.newFutureStub(interceptedChannel);
         } catch (Exception e) {
             // close the channel if connect() throws exception, avoid leakage
             try {

--- a/sdk-core/src/main/java/io/milvus/common/interceptor/IdentifierInterceptor.java
+++ b/sdk-core/src/main/java/io/milvus/common/interceptor/IdentifierInterceptor.java
@@ -1,0 +1,39 @@
+package io.milvus.common.interceptor;
+
+import io.grpc.*;
+
+/**
+ * A gRPC client interceptor that injects the server-assigned connection identifier
+ * into every outgoing RPC request's metadata.
+ *
+ * <p>The identifier is obtained from {@code ConnectResponse.getIdentifier()} during
+ * the initial Connect RPC, and is used by the server (especially kite-coordinator)
+ * to associate subsequent requests with the connection-level state (e.g. cluster_id
+ * binding for resource group routing).
+ *
+ * <p>This aligns Java SDK behavior with pymilvus, which implements the same mechanism
+ * via {@code header_adder_interceptor}.
+ */
+public class IdentifierInterceptor implements ClientInterceptor {
+    private static final Metadata.Key<String> IDENTIFIER_KEY =
+            Metadata.Key.of("identifier", Metadata.ASCII_STRING_MARSHALLER);
+
+    private final String identifier;
+
+    public IdentifierInterceptor(long identifier) {
+        this.identifier = String.valueOf(identifier);
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                next.newCall(method, callOptions)) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                headers.put(IDENTIFIER_KEY, identifier);
+                super.start(responseListener, headers);
+            }
+        };
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -19,7 +19,10 @@
 
 package io.milvus.v2.client;
 
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
+import io.milvus.common.interceptor.IdentifierInterceptor;
 import io.milvus.grpc.ClientInfo;
 import io.milvus.grpc.ConnectRequest;
 import io.milvus.grpc.ConnectResponse;
@@ -168,7 +171,13 @@ public class MilvusClientV2 {
 
         try {
             blockingStub = MilvusServiceGrpc.newBlockingStub(channel).withWaitForReady();
-            connect(connectConfig, blockingStub);
+            long identifier = connect(connectConfig, blockingStub);
+
+            // Wrap channel with identifier interceptor so that every subsequent RPC
+            // carries the identifier in gRPC metadata, aligning with pymilvus behavior.
+            Channel interceptedChannel = ClientInterceptors.intercept(channel,
+                    new IdentifierInterceptor(identifier));
+            blockingStub = MilvusServiceGrpc.newBlockingStub(interceptedChannel).withWaitForReady();
 
             if (connectConfig.getDbName() != null) {
                 // check if database exists
@@ -213,7 +222,7 @@ public class MilvusClientV2 {
      * 3. sdk language type and version
      * 4. the client's local time
      */
-    private void connect(ConnectConfig connectConfig, MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub) {
+    private long connect(ConnectConfig connectConfig, MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub) {
         String userName = connectConfig.getUsername();
         if (userName == null) {
             userName = ""; // ClientInfo.setUser() requires non-null value
@@ -232,6 +241,7 @@ public class MilvusClientV2 {
         if (resp.getStatus().getCode() != 0 || !resp.getStatus().getErrorCode().equals(io.milvus.grpc.ErrorCode.Success)) {
             throw new RuntimeException("Failed to initialize connection. Error: " + resp.getStatus().getReason());
         }
+        return resp.getIdentifier();
     }
 
     public void retryConfig(RetryConfig retryConfig) {

--- a/sdk-core/src/test/java/io/milvus/common/interceptor/IdentifierInterceptorTest.java
+++ b/sdk-core/src/test/java/io/milvus/common/interceptor/IdentifierInterceptorTest.java
@@ -1,0 +1,132 @@
+package io.milvus.common.interceptor;
+
+import io.grpc.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdentifierInterceptorTest {
+
+    private static final Metadata.Key<String> IDENTIFIER_KEY =
+            Metadata.Key.of("identifier", Metadata.ASCII_STRING_MARSHALLER);
+
+    @Test
+    void testIdentifierInjectedIntoMetadata() {
+        long identifier = 465795948303613954L;
+        IdentifierInterceptor interceptor = new IdentifierInterceptor(identifier);
+
+        final String[] capturedValue = {null};
+
+        Channel mockChannel = new Channel() {
+            @Override
+            public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                    MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+                return new ClientCall<RequestT, ResponseT>() {
+                    @Override
+                    public void start(ClientCall.Listener<ResponseT> responseListener, Metadata headers) {
+                        capturedValue[0] = headers.get(IDENTIFIER_KEY);
+                    }
+
+                    @Override
+                    public void request(int numMessages) {}
+
+                    @Override
+                    public void cancel(String message, Throwable cause) {}
+
+                    @Override
+                    public void halfClose() {}
+
+                    @Override
+                    public void sendMessage(RequestT message) {}
+                };
+            }
+
+            @Override
+            public String authority() {
+                return "test";
+            }
+        };
+
+        MethodDescriptor<Object, Object> method = MethodDescriptor.newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("test/method")
+                .setRequestMarshaller(new NoopMarshaller())
+                .setResponseMarshaller(new NoopMarshaller())
+                .build();
+
+        ClientCall<Object, Object> call = interceptor.interceptCall(method, CallOptions.DEFAULT, mockChannel);
+        call.start(new ClientCall.Listener<Object>() {}, new Metadata());
+
+        assertEquals("465795948303613954", capturedValue[0]);
+    }
+
+    @Test
+    void testExistingHeadersPreserved() {
+        IdentifierInterceptor interceptor = new IdentifierInterceptor(100L);
+
+        Metadata.Key<String> customKey = Metadata.Key.of("custom-header", Metadata.ASCII_STRING_MARSHALLER);
+        final String[] capturedIdentifier = {null};
+        final String[] capturedCustom = {null};
+
+        Channel mockChannel = new Channel() {
+            @Override
+            public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                    MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+                return new ClientCall<RequestT, ResponseT>() {
+                    @Override
+                    public void start(ClientCall.Listener<ResponseT> responseListener, Metadata headers) {
+                        capturedIdentifier[0] = headers.get(IDENTIFIER_KEY);
+                        capturedCustom[0] = headers.get(customKey);
+                    }
+
+                    @Override
+                    public void request(int numMessages) {}
+
+                    @Override
+                    public void cancel(String message, Throwable cause) {}
+
+                    @Override
+                    public void halfClose() {}
+
+                    @Override
+                    public void sendMessage(RequestT message) {}
+                };
+            }
+
+            @Override
+            public String authority() {
+                return "test";
+            }
+        };
+
+        MethodDescriptor<Object, Object> method = MethodDescriptor.newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("test/method")
+                .setRequestMarshaller(new NoopMarshaller())
+                .setResponseMarshaller(new NoopMarshaller())
+                .build();
+
+        ClientCall<Object, Object> call = interceptor.interceptCall(method, CallOptions.DEFAULT, mockChannel);
+
+        Metadata existingHeaders = new Metadata();
+        existingHeaders.put(customKey, "my-value");
+        call.start(new ClientCall.Listener<Object>() {}, existingHeaders);
+
+        assertEquals("100", capturedIdentifier[0]);
+        assertEquals("my-value", capturedCustom[0]);
+    }
+
+    private static class NoopMarshaller implements MethodDescriptor.Marshaller<Object> {
+        @Override
+        public InputStream stream(Object value) {
+            return null;
+        }
+
+        @Override
+        public Object parse(InputStream stream) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Extract identifier from ConnectResponse after successful Connect RPC and inject it into every subsequent gRPC request's metadata via a ClientInterceptor. This is required for kite-coordinator to resolve cluster_id from connection bindings established at Connect time.

Both V1 (MilvusServiceClient) and V2 (MilvusClientV2) clients are updated.