### PR TITLE
[cherry-pick] Add option parameter to ConnectConfig and ConnectParam (#1810)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
@@ -434,13 +434,16 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
      */
     private R<ConnectResponse> connect(ConnectParam connectParam) {
         ExceptionUtils.checkNotNull(connectParam, connectParam.getClass().getSimpleName());
-        ClientInfo info = ClientInfo.newBuilder()
+        ClientInfo.Builder infoBuilder = ClientInfo.newBuilder()
                 .setSdkType("Java")
                 .setSdkVersion(getSDKVersion())
                 .setUser(connectParam.getUserName())
                 .setHost(getHostName())
-                .setLocalTime(getLocalTimeStr())
-                .build();
+                .setLocalTime(getLocalTimeStr());
+        if (connectParam.getOption() != null && !connectParam.getOption().isEmpty()) {
+            infoBuilder.putAllReserved(connectParam.getOption());
+        }
+        ClientInfo info = infoBuilder.build();
         ConnectRequest req = ConnectRequest.newBuilder().setClientInfo(info).build();
         ConnectResponse resp = this.blockingStub.withWaitForReady()
                 .withDeadlineAfter(connectParam.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)

--- a/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
@@ -25,6 +25,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -56,6 +58,7 @@ public class ConnectParam {
     private final String userName;
     private final ThreadLocal<String> clientRequestId;
     private final String proxyAddress;
+    private final Map<String, String> option;
 
     protected ConnectParam(Builder builder) {
         if (builder == null) {
@@ -82,6 +85,7 @@ public class ConnectParam {
         this.userName = builder.userName;
         this.clientRequestId = builder.clientRequestId;
         this.proxyAddress = builder.proxyAddress;
+        this.option = builder.option;
     }
 
     public static Builder newBuilder() {
@@ -172,6 +176,10 @@ public class ConnectParam {
         return proxyAddress;
     }
 
+    public Map<String, String> getOption() {
+        return option;
+    }
+
     @Override
     public String toString() {
         return "ConnectParam{" +
@@ -233,6 +241,7 @@ public class ConnectParam {
         private ThreadLocal<String> clientRequestId;
 
         private String proxyAddress;
+        private Map<String, String> option = new HashMap<>();
 
         protected Builder() {
         }
@@ -319,6 +328,10 @@ public class ConnectParam {
 
         public String getProxyAddress() {
             return proxyAddress;
+        }
+
+        public Map<String, String> getOption() {
+            return option;
         }
 
         /**
@@ -614,6 +627,17 @@ public class ConnectParam {
          */
         public Builder withProxyAddress(String proxyAddress) {
             this.proxyAddress = proxyAddress;
+            return this;
+        }
+
+        /**
+         * Sets the option map that will be forwarded to the server via ClientInfo.reserved field.
+         *
+         * @param option a map of key-value pairs
+         * @return <code>Builder</code>
+         */
+        public Builder withOption(Map<String, String> option) {
+            this.option = option;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -23,6 +23,8 @@ import io.milvus.common.utils.URLParser;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.net.ssl.SSLContext;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -49,6 +51,7 @@ public class ConnectConfig {
     private Boolean secure = false;
     private long idleTimeoutMs = TimeUnit.MILLISECONDS.convert(24, TimeUnit.HOURS);
     private boolean enablePrecheck = false;  // default value is false
+    private Map<String, String> option = new HashMap<>();
 
     private SSLContext sslContext;
     // clientRequestId maintains a map for different threads, each thread can assign a specific id.
@@ -81,6 +84,7 @@ public class ConnectConfig {
         this.sslContext = builder.sslContext;
         this.clientRequestId = builder.clientRequestId;
         this.enablePrecheck = builder.enablePrecheck;
+        this.option = builder.option;
     }
 
     public static ConnectConfigBuilder builder() {
@@ -167,6 +171,10 @@ public class ConnectConfig {
     public boolean isEnablePrecheck() {
         return enablePrecheck;
     }
+
+    public Map<String, String> getOption() {
+        return option;
+    }
     // Setters
     public void setUri(String uri) {
         if (uri == null) {
@@ -241,6 +249,10 @@ public class ConnectConfig {
 
     public void setEnablePrecheck(boolean enablePrecheck) {
         this.enablePrecheck = enablePrecheck;
+    }
+
+    public void setOption(Map<String, String> option) {
+        this.option = option;
     }
 
     public void setIdleTimeoutMs(long idleTimeoutMs) {
@@ -339,6 +351,7 @@ public class ConnectConfig {
         private SSLContext sslContext;
         private ThreadLocal<String> clientRequestId;
         private boolean enablePrecheck = false;
+        private Map<String, String> option = new HashMap<>();
 
         public ConnectConfigBuilder uri(String uri) {
             if (uri == null) {
@@ -448,6 +461,11 @@ public class ConnectConfig {
 
         public ConnectConfigBuilder clientRequestId(ThreadLocal<String> clientRequestId) {
             this.clientRequestId = clientRequestId;
+            return this;
+        }
+
+        public ConnectConfigBuilder option(Map<String, String> option) {
+            this.option = option;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -219,13 +219,16 @@ public class MilvusClientV2 {
             userName = ""; // ClientInfo.setUser() requires non-null value
         }
 
-        ClientInfo info = ClientInfo.newBuilder()
+        ClientInfo.Builder infoBuilder = ClientInfo.newBuilder()
                 .setSdkType("Java")
                 .setSdkVersion(clientUtils.getSDKVersion())
                 .setUser(userName)
                 .setHost(clientUtils.getHostName())
-                .setLocalTime(clientUtils.getLocalTimeStr())
-                .build();
+                .setLocalTime(clientUtils.getLocalTimeStr());
+        if (connectConfig.getOption() != null && !connectConfig.getOption().isEmpty()) {
+            infoBuilder.putAllReserved(connectConfig.getOption());
+        }
+        ClientInfo info = infoBuilder.build();
         ConnectRequest req = ConnectRequest.newBuilder().setClientInfo(info).build();
         ConnectResponse resp = blockingStub.withDeadlineAfter(connectConfig.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
                 .connect(req);


### PR DESCRIPTION
Add a Map<String, String> option field to ConnectConfig (V2) and ConnectParam (V1) that gets forwarded to ClientInfo.reserved when connecting to the server. This aligns with the pymilvus client which recently added the same capability.