### PR TITLE
[cherry-pick] Add collectionId support for describeCollection and batchDescribeColl…

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -372,9 +372,15 @@ public class CollectionService extends BaseService {
     public DescribeCollectionResp describeCollection(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, DescribeCollectionReq request) {
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
-        String title = String.format("Describe collection: '%s' in database: '%s'", collectionName, dbName);
-        DescribeCollectionRequest.Builder builder = DescribeCollectionRequest.newBuilder()
-                .setCollectionName(collectionName);
+        Long collectionId = request.getCollectionId();
+        String title = String.format("Describe collection: '%s'(id: %s) in database: '%s'", collectionName, collectionId, dbName);
+        DescribeCollectionRequest.Builder builder = DescribeCollectionRequest.newBuilder();
+        if (StringUtils.isNotEmpty(collectionName)) {
+            builder.setCollectionName(collectionName);
+        }
+        if (collectionId != null) {
+            builder.setCollectionID(collectionId);
+        }
         if (StringUtils.isNotEmpty(dbName)) {
             builder.setDbName(dbName);
         }
@@ -387,9 +393,15 @@ public class CollectionService extends BaseService {
     public List<DescribeCollectionResp> batchDescribeCollections(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, BatchDescribeCollectionReq request) {
         String dbName = request.getDatabaseName();
         List<String> collectionNames = request.getCollectionNames();
-        String title = String.format("Batch describe collections: '%s' in database: '%s'", collectionNames, dbName);
-        BatchDescribeCollectionRequest.Builder builder = BatchDescribeCollectionRequest.newBuilder()
-                .addAllCollectionName(collectionNames);
+        List<Long> collectionIds = request.getCollectionIds();
+        String title = String.format("Batch describe collections: '%s'(ids: %s) in database: '%s'", collectionNames, collectionIds, dbName);
+        BatchDescribeCollectionRequest.Builder builder = BatchDescribeCollectionRequest.newBuilder();
+        if (CollectionUtils.isNotEmpty(collectionNames)) {
+            builder.addAllCollectionName(collectionNames);
+        }
+        if (CollectionUtils.isNotEmpty(collectionIds)) {
+            builder.addAllCollectionID(collectionIds);
+        }
         if (StringUtils.isNotEmpty(dbName)) {
             builder.setDbName(dbName);
         }

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/request/BatchDescribeCollectionReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/request/BatchDescribeCollectionReq.java
@@ -24,11 +24,13 @@ import java.util.List;
 public class BatchDescribeCollectionReq {
     private String databaseName;
     private List<String> collectionNames;
+    private List<Long> collectionIds;
 
     // Private constructor for builder
     private BatchDescribeCollectionReq(BatchDescribeCollectionReqBuilder builder) {
         this.databaseName = builder.databaseName;
         this.collectionNames = builder.collectionNames;
+        this.collectionIds = builder.collectionIds;
     }
 
     // Static method to create builder
@@ -45,6 +47,10 @@ public class BatchDescribeCollectionReq {
         return collectionNames;
     }
 
+    public List<Long> getCollectionIds() {
+        return collectionIds;
+    }
+
     // Setter methods
     public void setDatabaseName(String databaseName) {
         this.databaseName = databaseName;
@@ -54,11 +60,16 @@ public class BatchDescribeCollectionReq {
         this.collectionNames = collectionNames;
     }
 
+    public void setCollectionIds(List<Long> collectionIds) {
+        this.collectionIds = collectionIds;
+    }
+
     @Override
     public String toString() {
         return "BatchDescribeCollectionReq{" +
                 "databaseName='" + databaseName + '\'' +
                 ", collectionNames=" + collectionNames +
+                ", collectionIds=" + collectionIds +
                 '}';
     }
 
@@ -66,6 +77,7 @@ public class BatchDescribeCollectionReq {
     public static class BatchDescribeCollectionReqBuilder {
         private String databaseName;
         private List<String> collectionNames;
+        private List<Long> collectionIds;
 
         public BatchDescribeCollectionReqBuilder databaseName(String databaseName) {
             this.databaseName = databaseName;
@@ -74,6 +86,11 @@ public class BatchDescribeCollectionReq {
 
         public BatchDescribeCollectionReqBuilder collectionNames(List<String> collectionNames) {
             this.collectionNames = collectionNames;
+            return this;
+        }
+
+        public BatchDescribeCollectionReqBuilder collectionIds(List<Long> collectionIds) {
+            this.collectionIds = collectionIds;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/request/DescribeCollectionReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/request/DescribeCollectionReq.java
@@ -22,10 +22,12 @@ package io.milvus.v2.service.collection.request;
 public class DescribeCollectionReq {
     private String databaseName;
     private String collectionName;
+    private Long collectionId;
 
     private DescribeCollectionReq(DescribeCollectionReqBuilder builder) {
         this.databaseName = builder.databaseName;
         this.collectionName = builder.collectionName;
+        this.collectionId = builder.collectionId;
     }
 
     public String getDatabaseName() {
@@ -44,11 +46,20 @@ public class DescribeCollectionReq {
         this.collectionName = collectionName;
     }
 
+    public Long getCollectionId() {
+        return collectionId;
+    }
+
+    public void setCollectionId(Long collectionId) {
+        this.collectionId = collectionId;
+    }
+
     @Override
     public String toString() {
         return "DescribeCollectionReq{" +
                 "databaseName='" + databaseName + '\'' +
                 ", collectionName='" + collectionName + '\'' +
+                ", collectionId=" + collectionId +
                 '}';
     }
 
@@ -59,6 +70,7 @@ public class DescribeCollectionReq {
     public static class DescribeCollectionReqBuilder {
         private String databaseName;
         private String collectionName;
+        private Long collectionId;
 
         private DescribeCollectionReqBuilder() {
         }
@@ -70,6 +82,11 @@ public class DescribeCollectionReq {
 
         public DescribeCollectionReqBuilder collectionName(String collectionName) {
             this.collectionName = collectionName;
+            return this;
+        }
+
+        public DescribeCollectionReqBuilder collectionId(Long collectionId) {
+            this.collectionId = collectionId;
             return this;
         }
 

--- a/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
@@ -114,6 +114,10 @@ public class BaseTest {
         when(blockingStub.truncateCollection(any())).thenReturn(TruncateCollectionResponse.newBuilder().setStatus(successStatus).build());
         when(blockingStub.hasCollection(any())).thenReturn(trueResponse);
         when(blockingStub.describeCollection(any())).thenReturn(describeCollectionResponse);
+        when(blockingStub.batchDescribeCollection(any())).thenReturn(BatchDescribeCollectionResponse.newBuilder()
+                .setStatus(successStatus)
+                .addResponses(describeCollectionResponse)
+                .build());
         when(blockingStub.renameCollection(any())).thenReturn(successStatus);
         when(blockingStub.getCollectionStatistics(any())).thenReturn(GetCollectionStatisticsResponse.newBuilder().addStats(KeyValuePair.newBuilder().setKey("row_count").setValue("10").build()).setStatus(successStatus).build());
         when(blockingStub.getLoadingProgress(any())).thenReturn(GetLoadingProgressResponse.newBuilder().setStatus(successStatus).setProgress(100).build());

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
@@ -33,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -163,6 +165,53 @@ class CollectionTest extends BaseTest {
                 .build();
         DescribeCollectionResp resp = client_v2.describeCollection(req);
         logger.info("resp: {}", resp);
+    }
+
+    @Test
+    void testDescribeCollectionById() {
+        DescribeCollectionReq req = DescribeCollectionReq.builder()
+                .collectionId(123456L)
+                .build();
+        DescribeCollectionResp resp = client_v2.describeCollection(req);
+        logger.info("resp: {}", resp);
+    }
+
+    @Test
+    void testDescribeCollectionByNameAndId() {
+        DescribeCollectionReq req = DescribeCollectionReq.builder()
+                .collectionName("test2")
+                .collectionId(123456L)
+                .build();
+        DescribeCollectionResp resp = client_v2.describeCollection(req);
+        logger.info("resp: {}", resp);
+    }
+
+    @Test
+    void testBatchDescribeCollectionsByNames() {
+        BatchDescribeCollectionReq req = BatchDescribeCollectionReq.builder()
+                .collectionNames(Arrays.asList("test", "test2"))
+                .build();
+        List<DescribeCollectionResp> resps = client_v2.batchDescribeCollection(req);
+        logger.info("resp: {}", resps);
+    }
+
+    @Test
+    void testBatchDescribeCollectionsByIds() {
+        BatchDescribeCollectionReq req = BatchDescribeCollectionReq.builder()
+                .collectionIds(Arrays.asList(123456L, 789012L))
+                .build();
+        List<DescribeCollectionResp> resps = client_v2.batchDescribeCollection(req);
+        logger.info("resp: {}", resps);
+    }
+
+    @Test
+    void testBatchDescribeCollectionsByNamesAndIds() {
+        BatchDescribeCollectionReq req = BatchDescribeCollectionReq.builder()
+                .collectionNames(Collections.singletonList("test"))
+                .collectionIds(Collections.singletonList(789012L))
+                .build();
+        List<DescribeCollectionResp> resps = client_v2.batchDescribeCollection(req);
+        logger.info("resp: {}", resps);
     }
 
     @Test


### PR DESCRIPTION
…ection (#1809)

The V2 client previously only supported collectionName for describe operations. This adds collectionId as an optional parameter, aligning with the gRPC layer which already supports it.