### PR TITLE
feat: add projectId and regionId support for cloud import interfaces

### DIFF
--- a/examples/src/main/java/io/milvus/v2/bulkwriter/BulkWriterRemoteExample.java
+++ b/examples/src/main/java/io/milvus/v2/bulkwriter/BulkWriterRemoteExample.java
@@ -125,6 +125,8 @@ public class BulkWriterRemoteExample {
         public static final String CLOUD_ENDPOINT = "https://api.cloud.zilliz.com";
         public static final String API_KEY = "_api_key_for_cluster_org_";
         public static final String CLUSTER_ID = "_your_cloud_cluster_id_";
+        public static final String PROJECT_ID = "_your_cloud_project_id_";
+        public static final String REGION_ID = "_your_cloud_region_id_";
         public static final String COLLECTION_NAME = "_collection_name_on_the_cluster_id_";
         // If partition_name is not specified, use ""
         public static final String PARTITION_NAME = "_partition_name_on_the_collection_";
@@ -881,6 +883,31 @@ public class BulkWriterRemoteExample {
 
         System.out.println("\n===================== list import jobs ====================");
         CloudListImportJobsRequest listImportJobsRequest = CloudListImportJobsRequest.builder().clusterId(CloudImportConsts.CLUSTER_ID).currentPage(1).pageSize(10).apiKey(CloudImportConsts.API_KEY).build();
+        String listImportJobsResult = BulkImportUtils.listImportJobs(CloudImportConsts.CLOUD_ENDPOINT, listImportJobsRequest);
+        System.out.println(listImportJobsResult);
+    }
+
+    private static void exampleCloudImportPdb() {
+        System.out.println("\n===================== import files to cloud project database ====================");
+        List<String> objectUrls = Lists.newArrayList(CloudImportConsts.OBJECT_URL);
+        CloudImportRequest request = CloudImportRequest.builder()
+                .objectUrls(Lists.newArrayList(Collections.singleton(objectUrls))).accessKey(CloudImportConsts.OBJECT_ACCESS_KEY).secretKey(CloudImportConsts.OBJECT_SECRET_KEY)
+                .projectId(CloudImportConsts.PROJECT_ID).regionId(CloudImportConsts.REGION_ID).collectionName(CloudImportConsts.COLLECTION_NAME).partitionName(CloudImportConsts.PARTITION_NAME)
+                .apiKey(CloudImportConsts.API_KEY)
+                .build();
+        String bulkImportResult = BulkImportUtils.bulkImport(CloudImportConsts.CLOUD_ENDPOINT, request);
+        System.out.println(bulkImportResult);
+
+        System.out.println("\n===================== get import job progress ====================");
+
+        JsonObject bulkImportObject = convertJsonObject(bulkImportResult);
+        String jobId = bulkImportObject.getAsJsonObject("data").get("jobId").getAsString();
+        CloudDescribeImportRequest getImportProgressRequest = CloudDescribeImportRequest.builder().projectId(CloudImportConsts.PROJECT_ID).regionId(CloudImportConsts.REGION_ID).jobId(jobId).apiKey(CloudImportConsts.API_KEY).build();
+        String getImportProgressResult = BulkImportUtils.getImportProgress(CloudImportConsts.CLOUD_ENDPOINT, getImportProgressRequest);
+        System.out.println(getImportProgressResult);
+
+        System.out.println("\n===================== list import jobs ====================");
+        CloudListImportJobsRequest listImportJobsRequest = CloudListImportJobsRequest.builder().projectId(CloudImportConsts.PROJECT_ID).regionId(CloudImportConsts.REGION_ID).currentPage(1).pageSize(10).apiKey(CloudImportConsts.API_KEY).build();
         String listImportJobsResult = BulkImportUtils.listImportJobs(CloudImportConsts.CLOUD_ENDPOINT, listImportJobsRequest);
         System.out.println(listImportJobsResult);
     }

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/describe/CloudDescribeImportRequest.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/describe/CloudDescribeImportRequest.java
@@ -22,6 +22,16 @@ package io.milvus.bulkwriter.request.describe;
 public class CloudDescribeImportRequest extends BaseDescribeImportRequest {
     private static final long serialVersionUID = -6479634844757426430L;
     private String clusterId;
+
+    /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String projectId;
+
+    /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String regionId;
     private String jobId;
 
     public CloudDescribeImportRequest() {
@@ -32,9 +42,18 @@ public class CloudDescribeImportRequest extends BaseDescribeImportRequest {
         this.jobId = jobId;
     }
 
+    public CloudDescribeImportRequest(String clusterId, String projectId, String regionId, String jobId) {
+        this.clusterId = clusterId;
+        this.projectId = projectId;
+        this.regionId = regionId;
+        this.jobId = jobId;
+    }
+
     protected CloudDescribeImportRequest(CloudDescribeImportRequestBuilder builder) {
         super(builder);
         this.clusterId = builder.clusterId;
+        this.projectId = builder.projectId;
+        this.regionId = builder.regionId;
         this.jobId = builder.jobId;
     }
 
@@ -44,6 +63,22 @@ public class CloudDescribeImportRequest extends BaseDescribeImportRequest {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getRegionId() {
+        return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+        this.regionId = regionId;
     }
 
     public String getJobId() {
@@ -58,6 +93,8 @@ public class CloudDescribeImportRequest extends BaseDescribeImportRequest {
     public String toString() {
         return "CloudDescribeImportRequest{" +
                 "clusterId='" + clusterId + '\'' +
+                ", projectId='" + projectId + '\'' +
+                ", regionId='" + regionId + '\'' +
                 ", jobId='" + jobId + '\'' +
                 '}';
     }
@@ -68,15 +105,29 @@ public class CloudDescribeImportRequest extends BaseDescribeImportRequest {
 
     public static class CloudDescribeImportRequestBuilder extends BaseDescribeImportRequestBuilder<CloudDescribeImportRequestBuilder> {
         private String clusterId;
+        private String projectId;
+        private String regionId;
         private String jobId;
 
         private CloudDescribeImportRequestBuilder() {
             this.clusterId = "";
+            this.projectId = "";
+            this.regionId = "";
             this.jobId = "";
         }
 
         public CloudDescribeImportRequestBuilder clusterId(String clusterId) {
             this.clusterId = clusterId;
+            return this;
+        }
+
+        public CloudDescribeImportRequestBuilder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        public CloudDescribeImportRequestBuilder regionId(String regionId) {
+            this.regionId = regionId;
             return this;
         }
 

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/import_/CloudImportRequest.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/import_/CloudImportRequest.java
@@ -31,6 +31,16 @@ public class CloudImportRequest extends BaseImportRequest {
     private String clusterId;
 
     /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String projectId;
+
+    /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String regionId;
+
+    /**
      * For Free & Serverless deployments: specifying this parameter is not supported.
      * For Dedicated deployments: this parameter can be specified; defaults to the "default" database.
      */
@@ -110,9 +120,25 @@ public class CloudImportRequest extends BaseImportRequest {
         this.token = token;
     }
 
+    public CloudImportRequest(String clusterId, String projectId, String regionId, String dbName, String collectionName, String partitionName,
+                              List<List<String>> objectUrls, String accessKey, String secretKey, String token) {
+        this.clusterId = clusterId;
+        this.projectId = projectId;
+        this.regionId = regionId;
+        this.dbName = dbName;
+        this.collectionName = collectionName;
+        this.partitionName = partitionName;
+        this.objectUrls = objectUrls;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.token = token;
+    }
+
     protected CloudImportRequest(CloudImportRequestBuilder builder) {
         super(builder);
         this.clusterId = builder.clusterId;
+        this.projectId = builder.projectId;
+        this.regionId = builder.regionId;
         this.dbName = builder.dbName;
         this.collectionName = builder.collectionName;
         this.partitionName = builder.partitionName;
@@ -129,6 +155,22 @@ public class CloudImportRequest extends BaseImportRequest {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getRegionId() {
+        return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+        this.regionId = regionId;
     }
 
     public String getDbName() {
@@ -199,6 +241,8 @@ public class CloudImportRequest extends BaseImportRequest {
     public String toString() {
         return "CloudImportRequest{" +
                 "clusterId='" + clusterId + '\'' +
+                ", projectId='" + projectId + '\'' +
+                ", regionId='" + regionId + '\'' +
                 ", dbName='" + dbName + '\'' +
                 ", collectionName='" + collectionName + '\'' +
                 ", partitionName='" + partitionName + '\'' +
@@ -216,6 +260,8 @@ public class CloudImportRequest extends BaseImportRequest {
 
     public static class CloudImportRequestBuilder extends BaseImportRequestBuilder<CloudImportRequestBuilder> {
         private String clusterId;
+        private String projectId;
+        private String regionId;
         private String dbName;
         private String collectionName;
         private String partitionName;
@@ -227,6 +273,8 @@ public class CloudImportRequest extends BaseImportRequest {
 
         private CloudImportRequestBuilder() {
             this.clusterId = "";
+            this.projectId = "";
+            this.regionId = "";
             this.dbName = "";
             this.collectionName = "";
             this.partitionName = "";
@@ -239,6 +287,16 @@ public class CloudImportRequest extends BaseImportRequest {
 
         public CloudImportRequestBuilder clusterId(String clusterId) {
             this.clusterId = clusterId;
+            return this;
+        }
+
+        public CloudImportRequestBuilder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        public CloudImportRequestBuilder regionId(String regionId) {
+            this.regionId = regionId;
             return this;
         }
 

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/list/CloudListImportJobsRequest.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/request/list/CloudListImportJobsRequest.java
@@ -22,6 +22,16 @@ package io.milvus.bulkwriter.request.list;
 public class CloudListImportJobsRequest extends BaseListImportJobsRequest {
     private static final long serialVersionUID = -3380786382584854649L;
     private String clusterId;
+
+    /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String projectId;
+
+    /**
+     * For project database deployments: use projectId and regionId instead of clusterId.
+     */
+    private String regionId;
     private Integer pageSize;
     private Integer currentPage;
 
@@ -37,6 +47,8 @@ public class CloudListImportJobsRequest extends BaseListImportJobsRequest {
     protected CloudListImportJobsRequest(CloudListImportJobsRequestBuilder builder) {
         super(builder);
         this.clusterId = builder.clusterId;
+        this.projectId = builder.projectId;
+        this.regionId = builder.regionId;
         this.pageSize = builder.pageSize;
         this.currentPage = builder.currentPage;
     }
@@ -47,6 +59,22 @@ public class CloudListImportJobsRequest extends BaseListImportJobsRequest {
 
     public void setClusterId(String clusterId) {
         this.clusterId = clusterId;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getRegionId() {
+        return regionId;
+    }
+
+    public void setRegionId(String regionId) {
+        this.regionId = regionId;
     }
 
     public Integer getPageSize() {
@@ -69,8 +97,10 @@ public class CloudListImportJobsRequest extends BaseListImportJobsRequest {
     public String toString() {
         return "CloudListImportJobsRequest{" +
                 "clusterId='" + clusterId + '\'' +
-                "pageSize=" + pageSize +
-                "currentPage=" + currentPage +
+                ", projectId='" + projectId + '\'' +
+                ", regionId='" + regionId + '\'' +
+                ", pageSize=" + pageSize +
+                ", currentPage=" + currentPage +
                 '}';
     }
 
@@ -80,17 +110,31 @@ public class CloudListImportJobsRequest extends BaseListImportJobsRequest {
 
     public static class CloudListImportJobsRequestBuilder extends BaseListImportJobsRequestBuilder<CloudListImportJobsRequestBuilder> {
         private String clusterId;
+        private String projectId;
+        private String regionId;
         private Integer pageSize;
         private Integer currentPage;
 
         private CloudListImportJobsRequestBuilder() {
             this.clusterId = "";
+            this.projectId = "";
+            this.regionId = "";
             this.pageSize = 0;
             this.currentPage = 0;
         }
 
         public CloudListImportJobsRequestBuilder clusterId(String clusterId) {
             this.clusterId = clusterId;
+            return this;
+        }
+
+        public CloudListImportJobsRequestBuilder projectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
+
+        public CloudListImportJobsRequestBuilder regionId(String regionId) {
+            this.regionId = regionId;
             return this;
         }
 


### PR DESCRIPTION
## Summary
Add project database (pdb) support for cloud import related interfaces.

## Changes
- `CloudImportRequest`: add `projectId` and `regionId` fields
- `CloudDescribeImportRequest`: add `projectId` and `regionId` fields
- `CloudListImportJobsRequest`: add `projectId` and `regionId` fields
- Add `exampleCloudImportPdb()` example methods for v1 and v2