### PR TITLE
[cherry-pick] support nullable vectors in Java SDK to 2.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   standalone:
     container_name: milvus-javasdk-standalone-1
-    image: milvusdb/milvus:v2.6.15
+    image: milvusdb/milvus:2.6-20260519-ab427b8b
     command: [ "milvus", "run", "standalone" ]
     environment:
       - COMMON_STORAGETYPE=local
@@ -24,7 +24,7 @@ services:
 
   standaloneslave:
     container_name: milvus-javasdk-standalone-2
-    image: milvusdb/milvus:v2.6.15
+    image: milvusdb/milvus:2.6-20260519-ab427b8b
     command: [ "milvus", "run", "standalone" ]
     environment:
       - COMMON_STORAGETYPE=local

--- a/examples/src/main/java/io/milvus/v2/NullableVectorExample.java
+++ b/examples/src/main/java/io/milvus/v2/NullableVectorExample.java
@@ -1,0 +1,299 @@
+package io.milvus.v2;
+
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import io.milvus.common.utils.JsonUtils;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddCollectionFieldReq;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.collection.request.ReleaseCollectionReq;
+import io.milvus.v2.service.index.request.CreateIndexReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.response.InsertResp;
+import io.milvus.v2.service.vector.response.QueryResp;
+import io.milvus.v2.service.vector.response.SearchResp;
+
+import java.util.*;
+
+public class NullableVectorExample {
+    private static final int DIMENSION = 8;
+    private static final Random RANDOM = new Random();
+
+    private static List<Float> generateFloatVector() {
+        List<Float> vector = new ArrayList<>();
+        for (int i = 0; i < DIMENSION; i++) {
+            vector.add(RANDOM.nextFloat());
+        }
+        return vector;
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        ConnectConfig config = ConnectConfig.builder()
+                .uri("http://localhost:19530")
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        System.out.println("Connected to Milvus\n");
+
+        insertNullVectors(client);
+        addNullableVectorField(client);
+
+        client.close(5L);
+        System.out.println("Done!");
+    }
+
+    private static void insertNullVectors(MilvusClientV2 client) throws InterruptedException {
+        String collectionName = "java_sdk_example_insert_null_vectors";
+        System.out.println("=== Demo 1: Insert null vectors ===");
+
+        // Drop collection if exists
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        // Create collection with nullable vector field
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .autoID(false)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("name")
+                .dataType(DataType.VarChar)
+                .maxLength(100)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("embedding")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .isNullable(true)  // Enable nullable for vector field
+                .build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .build());
+        System.out.println("Created collection with nullable vector field");
+
+        // Create index
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("embedding")
+                .metricType(IndexParam.MetricType.L2)
+                .indexType(IndexParam.IndexType.FLAT)
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(indexParam))
+                .build());
+
+        // Load collection
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        // Prepare test data: 100 rows, ~50% null vectors
+        int totalRows = 100;
+        int nullPercent = 50;
+        List<JsonObject> data = new ArrayList<>();
+        int nullCount = 0;
+        int validCount = 0;
+
+        for (int i = 1; i <= totalRows; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", (long) i);
+            row.addProperty("name", "item_" + i);
+
+            boolean isNull = RANDOM.nextInt(100) < nullPercent;
+            if (isNull) {
+                row.add("embedding", JsonNull.INSTANCE);
+                nullCount++;
+            } else {
+                row.add("embedding", JsonUtils.toJsonTree(generateFloatVector()));
+                validCount++;
+            }
+            data.add(row);
+        }
+
+        // Insert data
+        InsertResp insertResp = client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(data)
+                .build());
+        System.out.println("Inserted " + insertResp.getInsertCnt() + " rows: " + validCount + " valid, " + nullCount + " null");
+
+        Thread.sleep(1000);
+
+        // Query all data
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id >= 0")
+                .outputFields(Arrays.asList("id", "embedding"))
+                .limit(totalRows + 10)
+                .build());
+
+        int queryNullCount = 0;
+        int queryValidCount = 0;
+        for (QueryResp.QueryResult result : queryResp.getQueryResults()) {
+            Object embedding = result.getEntity().get("embedding");
+            if (embedding == null) {
+                queryNullCount++;
+            } else {
+                queryValidCount++;
+            }
+        }
+        System.out.println("Query result: " + queryValidCount + " valid, " + queryNullCount + " null");
+
+        // Search - only returns non-null vectors
+        SearchResp searchResp = client.search(SearchReq.builder()
+                .collectionName(collectionName)
+                .data(Collections.singletonList(new FloatVec(generateFloatVector())))
+                .annsField("embedding")
+                .topK(10)
+                .outputFields(Arrays.asList("id", "embedding"))
+                .build());
+
+        List<List<SearchResp.SearchResult>> searchResults = searchResp.getSearchResults();
+        if (!searchResults.isEmpty()) {
+            System.out.println("Search returned " + searchResults.get(0).size() + " hits (only non-null vectors)");
+        }
+
+        // Cleanup
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println("Dropped collection\n");
+    }
+
+    private static void addNullableVectorField(MilvusClientV2 client) throws InterruptedException {
+        String collectionName = "java_sdk_example_add_vector_field";
+        System.out.println("=== Demo 2: Add nullable vector field to existing collection ===");
+
+        // Drop collection if exists
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        // Create collection with one vector field (Milvus requires at least one)
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .autoID(false)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("name")
+                .dataType(DataType.VarChar)
+                .maxLength(100)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("embedding_v1")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .build());
+        System.out.println("Created collection with one vector field");
+
+        // Create index and load
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("embedding_v1")
+                .metricType(IndexParam.MetricType.L2)
+                .indexType(IndexParam.IndexType.FLAT)
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(indexParam))
+                .build());
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        // Insert some data first
+        List<JsonObject> data = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", (long) i);
+            row.addProperty("name", "item_" + i);
+            row.add("embedding_v1", JsonUtils.toJsonTree(generateFloatVector()));
+            data.add(row);
+        }
+        client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(data)
+                .build());
+        System.out.println("Inserted 10 rows");
+
+        // Release before adding field
+        client.releaseCollection(ReleaseCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        // Add a second nullable vector field to existing collection
+        client.addCollectionField(AddCollectionFieldReq.builder()
+                .collectionName(collectionName)
+                .fieldName("embedding_v2")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .isNullable(true)  // Must be nullable when adding to existing collection
+                .build());
+        System.out.println("Added nullable vector field 'embedding_v2'");
+
+        // Create index for the new field
+        IndexParam newIndexParam = IndexParam.builder()
+                .fieldName("embedding_v2")
+                .metricType(IndexParam.MetricType.L2)
+                .indexType(IndexParam.IndexType.FLAT)
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(newIndexParam))
+                .build());
+
+        // Load collection
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        Thread.sleep(1000);
+
+        // Query to verify old rows have null for the new field
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id >= 0")
+                .outputFields(Arrays.asList("id", "embedding_v1", "embedding_v2"))
+                .limit(10)
+                .build());
+
+        System.out.println("Query result (old rows have null for new field):");
+        for (QueryResp.QueryResult result : queryResp.getQueryResults()) {
+            Map<String, Object> entity = result.getEntity();
+            long id = (Long) entity.get("id");
+            Object v1 = entity.get("embedding_v1");
+            Object v2 = entity.get("embedding_v2");
+            System.out.println("  id=" + id + ", embedding_v1=" + (v1 == null ? "null" : "has value")
+                    + ", embedding_v2=" + (v2 == null ? "null" : "has value"));
+        }
+
+        // Cleanup
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println("Dropped collection\n");
+    }
+}

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/BulkWriter.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/BulkWriter.java
@@ -398,6 +398,10 @@ public abstract class BulkWriter implements AutoCloseable {
 
     private Pair<Object, Integer> verifyVector(JsonElement object, CreateCollectionReq.FieldSchema field) {
         Object vector = DataUtils.checkFieldValue(field, object);
+        if (vector == null) {
+            return Pair.of(null, 0);
+        }
+
         io.milvus.v2.common.DataType dataType = field.getDataType();
         switch (dataType) {
             case FloatVector:

--- a/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/BulkWriterTest.java
+++ b/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/BulkWriterTest.java
@@ -25,6 +25,7 @@ import io.milvus.bulkwriter.common.clientenum.BulkFileType;
 import io.milvus.bulkwriter.common.utils.GeneratorUtils;
 import io.milvus.bulkwriter.common.utils.ParquetReaderUtils;
 import io.milvus.bulkwriter.common.utils.V2AdapterUtils;
+import io.milvus.common.utils.Float16Utils;
 import io.milvus.common.utils.JsonUtils;
 import io.milvus.exception.MilvusException;
 import io.milvus.param.Constant;
@@ -49,6 +50,14 @@ import java.util.*;
 
 public class BulkWriterTest {
     private static final int DIMENSION = 32;
+    private static final List<String> NULLABLE_VECTOR_FIELDS = Arrays.asList(
+            "float_vector",
+            "binary_vector",
+            "sparse_vector",
+            "float16_vector",
+            "bfloat16_vector",
+            "int8_vector"
+    );
     private static final TestUtils utils = new TestUtils(DIMENSION);
 
     private static CollectionSchemaParam buildV1Schema(boolean enableDynamicField) {
@@ -728,6 +737,156 @@ public class BulkWriterTest {
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }
+    }
+
+    @Test
+    void testWriteCSVNullableVectorsUseDefaultNullKey() {
+        try {
+            LocalBulkWriter localBulkWriter = newNullableVectorCsvWriter(null);
+            JsonObject nullRow = buildNullableVectorRow(1, true);
+            JsonObject valueRow = buildNullableVectorRow(2, false);
+            localBulkWriter.appendRow(nullRow);
+            localBulkWriter.appendRow(valueRow);
+            localBulkWriter.commit(false);
+
+            List<String> lines = Files.readAllLines(Paths.get(localBulkWriter.getBatchFiles().get(0).get(0)), StandardCharsets.UTF_8);
+            Assertions.assertEquals(3, lines.size());
+            Map<String, String> nullValues = readPipeDelimitedRow(lines.get(0), lines.get(1));
+            Map<String, String> valueValues = readPipeDelimitedRow(lines.get(0), lines.get(2));
+
+            for (String field : NULLABLE_VECTOR_FIELDS) {
+                Assertions.assertEquals("", nullValues.get(field));
+                Assertions.assertNotEquals("null", stripCsvQuotes(valueValues.get(field)));
+                Assertions.assertNotEquals("\"null\"", valueValues.get(field));
+            }
+            Assertions.assertEquals("[1.0,2.0,3.0,4.0]", stripCsvQuotes(valueValues.get("float_vector")));
+            Assertions.assertEquals("[1]", stripCsvQuotes(valueValues.get("binary_vector")));
+            Assertions.assertEquals("{\"1\":0.5}", stripCsvQuotes(valueValues.get("sparse_vector")));
+            Assertions.assertEquals("[1.0,2.0,3.0,4.0]", stripCsvQuotes(valueValues.get("float16_vector")));
+            Assertions.assertEquals("[1.0,2.0,3.0,4.0]", stripCsvQuotes(valueValues.get("bfloat16_vector")));
+            Assertions.assertEquals("[1, 2, 3, 4]", stripCsvQuotes(valueValues.get("int8_vector")));
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    void testWriteCSVNullableVectorsUseCustomNullKey() {
+        try {
+            final String nullKey = "NULL";
+            LocalBulkWriter localBulkWriter = newNullableVectorCsvWriter(nullKey);
+            localBulkWriter.appendRow(buildNullableVectorRow(1, true));
+            localBulkWriter.commit(false);
+
+            List<String> lines = Files.readAllLines(Paths.get(localBulkWriter.getBatchFiles().get(0).get(0)), StandardCharsets.UTF_8);
+            Assertions.assertEquals(2, lines.size());
+            Map<String, String> nullValues = readPipeDelimitedRow(lines.get(0), lines.get(1));
+
+            for (String field : NULLABLE_VECTOR_FIELDS) {
+                Assertions.assertEquals(String.format("\"%s\"", nullKey), nullValues.get(field));
+            }
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+
+    private static LocalBulkWriter newNullableVectorCsvWriter(String nullKey) throws IOException {
+        LocalBulkWriterParam.Builder builder = LocalBulkWriterParam.newBuilder()
+                .withCollectionSchema(buildNullableVectorSchema())
+                .withLocalPath("/tmp/bulk_writer")
+                .withFileType(BulkFileType.CSV)
+                .withConfig("sep", "|");
+        if (nullKey != null) {
+            builder.withConfig("nullkey", nullKey);
+        }
+        return new LocalBulkWriter(builder.build());
+    }
+
+    private static CreateCollectionReq.CollectionSchema buildNullableVectorSchema() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("float_vector")
+                .dataType(DataType.FloatVector)
+                .dimension(4)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("binary_vector")
+                .dataType(DataType.BinaryVector)
+                .dimension(8)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("sparse_vector")
+                .dataType(DataType.SparseFloatVector)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("float16_vector")
+                .dataType(DataType.Float16Vector)
+                .dimension(4)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("bfloat16_vector")
+                .dataType(DataType.BFloat16Vector)
+                .dimension(4)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int8_vector")
+                .dataType(DataType.Int8Vector)
+                .dimension(4)
+                .isNullable(true)
+                .build());
+        return schema;
+    }
+
+    private static JsonObject buildNullableVectorRow(long id, boolean allNull) {
+        JsonObject row = new JsonObject();
+        row.addProperty("id", id);
+        if (allNull) {
+            for (String field : NULLABLE_VECTOR_FIELDS) {
+                row.add(field, JsonNull.INSTANCE);
+            }
+            return row;
+        }
+
+        List<Float> vector = Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f);
+        SortedMap<Long, Float> sparse = new TreeMap<>();
+        sparse.put(1L, 0.5f);
+        row.add("float_vector", JsonUtils.toJsonTree(vector));
+        row.add("binary_vector", JsonUtils.toJsonTree(new byte[]{1}));
+        row.add("sparse_vector", JsonUtils.toJsonTree(sparse));
+        row.add("float16_vector", JsonUtils.toJsonTree(Float16Utils.f32VectorToFp16Buffer(vector).array()));
+        row.add("bfloat16_vector", JsonUtils.toJsonTree(Float16Utils.f32VectorToBf16Buffer(vector).array()));
+        row.add("int8_vector", JsonUtils.toJsonTree(new byte[]{1, 2, 3, 4}));
+        return row;
+    }
+
+    private static Map<String, String> readPipeDelimitedRow(String headerLine, String rowLine) {
+        String[] headers = headerLine.split("\\|", -1);
+        String[] values = rowLine.split("\\|", -1);
+        Assertions.assertEquals(headers.length, values.length);
+
+        Map<String, String> row = new HashMap<>();
+        for (int i = 0; i < headers.length; i++) {
+            row.put(headers[i], values[i]);
+        }
+        return row;
+    }
+
+    private static String stripCsvQuotes(String value) {
+        if (value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1).replace("\"\"", "\"");
+        }
+        return value;
     }
 
     private static void verifyJsonString(String s1, String s2) {

--- a/sdk-core/src/main/java/io/milvus/param/ParamUtils.java
+++ b/sdk-core/src/main/java/io/milvus/param/ParamUtils.java
@@ -1199,18 +1199,38 @@ public class ParamUtils {
 
     private static FieldData genFieldData(FieldType fieldType, List<?> objects, boolean isDynamic) {
         return genFieldData(fieldType.getName(), fieldType.getDataType(), fieldType.getElementType(),
-                fieldType.isNullable(), fieldType.getDefaultValue(), objects, isDynamic);
+                fieldType.isNullable(), fieldType.getDefaultValue(), objects, isDynamic, fieldType.getDimension());
     }
 
     public static FieldData genFieldData(String fieldName, DataType dataType, DataType elementType, boolean isNullable,
                                          Object defaultVal, List<?> objects, boolean isDynamic) {
+        return genFieldData(fieldName, dataType, elementType, isNullable, defaultVal, objects, isDynamic, 0);
+    }
+
+    public static FieldData genFieldData(String fieldName, DataType dataType, DataType elementType, boolean isNullable,
+                                         Object defaultVal, List<?> objects, boolean isDynamic, int dimension) {
         if (objects == null) {
             throw new ParamException("Cannot generate FieldData from null object");
         }
 
         FieldData.Builder builder = FieldData.newBuilder();
         if (isVectorDataType(dataType)) {
+            boolean allVectorValuesNull = false;
+            if (isNullable) {
+                List<Object> tempObjects = new ArrayList<>();
+                for (Object obj : objects) {
+                    builder.addValidData(obj != null);
+                    if (obj != null) {
+                        tempObjects.add(obj);
+                    }
+                }
+                objects = tempObjects;
+                allVectorValuesNull = objects.isEmpty();
+            }
             VectorField vectorField = genVectorField(dataType, objects);
+            if (allVectorValuesNull && dimension > 0 && vectorField.getDim() == 0) {
+                vectorField = vectorField.toBuilder().setDim(dimension).build();
+            }
             return builder.setFieldName(fieldName).setType(dataType).setVectors(vectorField).build();
         } else {
             if (isNullable || defaultVal != null) {
@@ -1234,6 +1254,22 @@ public class ParamUtils {
 
     @SuppressWarnings("unchecked")
     public static VectorField genVectorField(DataType dataType, List<?> objects) {
+        if (objects.isEmpty()) {
+            if (dataType == DataType.FloatVector) {
+                return VectorField.newBuilder().setDim(0).setFloatVector(FloatArray.newBuilder().build()).build();
+            } else if (dataType == DataType.BinaryVector) {
+                return VectorField.newBuilder().setDim(0).setBinaryVector(ByteString.EMPTY).build();
+            } else if (dataType == DataType.Float16Vector) {
+                return VectorField.newBuilder().setDim(0).setFloat16Vector(ByteString.EMPTY).build();
+            } else if (dataType == DataType.BFloat16Vector) {
+                return VectorField.newBuilder().setDim(0).setBfloat16Vector(ByteString.EMPTY).build();
+            } else if (dataType == DataType.Int8Vector) {
+                return VectorField.newBuilder().setDim(0).setInt8Vector(ByteString.EMPTY).build();
+            } else if (dataType == DataType.SparseFloatVector) {
+                return VectorField.newBuilder().setDim(0).setSparseFloatVector(SparseFloatArray.newBuilder().build()).build();
+            }
+        }
+
         if (dataType == DataType.FloatVector) {
             List<Float> floats = new ArrayList<>();
             // each object is List<Float>

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -280,6 +280,7 @@ public class CollectionService extends BaseService {
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
         String title = String.format("Add field to collection: '%s' in database: '%s'", collectionName, dbName);
+
         AddCollectionFieldRequest.Builder builder = AddCollectionFieldRequest.newBuilder()
                 .setCollectionName(collectionName);
         if (StringUtils.isNotEmpty(dbName)) {
@@ -287,7 +288,7 @@ public class CollectionService extends BaseService {
         }
 
         CreateCollectionReq.FieldSchema fieldSchema = SchemaUtils.convertFieldReqToFieldSchema(request);
-        FieldSchema grpcFieldSchema = SchemaUtils.convertToGrpcFieldSchema(fieldSchema);
+        FieldSchema grpcFieldSchema = SchemaUtils.convertToGrpcFieldSchema(fieldSchema, true);
         builder.setSchema(grpcFieldSchema.toByteString());
 
         Status response = blockingStub.addCollectionField(builder.build());
@@ -675,4 +676,5 @@ public class CollectionService extends BaseService {
             }
         }
     }
+
 }

--- a/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
@@ -505,7 +505,8 @@ public class DataUtils {
         DataType elementType = ConvertUtils.toProtoDataType(field.getElementType());
         boolean isNullable = field.getIsNullable();
         Object defaultVal = field.getDefaultValue();
-        return ParamUtils.genFieldData(fieldName, dataType, elementType, isNullable, defaultVal, objects, isDynamic);
+        int dimension = field.getDimension() == null ? 0 : field.getDimension();
+        return ParamUtils.genFieldData(fieldName, dataType, elementType, isNullable, defaultVal, objects, isDynamic, dimension);
     }
 
     public static Object checkFieldValue(CreateCollectionReq.FieldSchema field, JsonElement fieldData) {

--- a/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
@@ -50,9 +50,20 @@ public class SchemaUtils {
     }
 
     public static FieldSchema convertToGrpcFieldSchema(CreateCollectionReq.FieldSchema fieldSchema) {
+        return convertToGrpcFieldSchema(fieldSchema, false);
+    }
+
+    public static FieldSchema convertToGrpcFieldSchema(CreateCollectionReq.FieldSchema fieldSchema, boolean forAddField) {
         checkNullEmptyString(fieldSchema.getName(), "Field name");
 
         DataType dType = DataType.valueOf(fieldSchema.getDataType().name());
+        boolean isNullable = Boolean.TRUE.equals(fieldSchema.getIsNullable());
+
+        // Vector field must be nullable when adding to existing collection
+        if (forAddField && ParamUtils.isVectorDataType(dType) && !isNullable) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "Vector field must be nullable when adding to existing collection, field name: " + fieldSchema.getName());
+        }
         FieldSchema.Builder builder = FieldSchema.newBuilder()
                 .setName(fieldSchema.getName())
                 .setDescription(fieldSchema.getDescription())
@@ -61,7 +72,7 @@ public class SchemaUtils {
                 .setIsPartitionKey(fieldSchema.getIsPartitionKey())
                 .setIsClusteringKey(fieldSchema.getIsClusteringKey())
                 .setAutoID(fieldSchema.getAutoID())
-                .setNullable(fieldSchema.getIsNullable());
+                .setNullable(isNullable);
         if (!ParamUtils.isVectorDataType(dType) && !fieldSchema.getIsPrimaryKey()) {
             ValueField value = ParamUtils.objectToValueField(fieldSchema.getDefaultValue(), dType);
             if (value != null) {

--- a/sdk-core/src/test/java/io/milvus/TestUtils.java
+++ b/sdk-core/src/test/java/io/milvus/TestUtils.java
@@ -11,7 +11,7 @@ public class TestUtils {
     private int dimension = 256;
     private static final Random RANDOM = new Random();
 
-    public static final String MilvusDockerImageID = "milvusdb/milvus:v2.6.15";
+    public static final String MilvusDockerImageID = "milvusdb/milvus:2.6-20260519-ab427b8b";
 
     public TestUtils(int dimension) {
         this.dimension = dimension;

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/NullableVectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/NullableVectorTest.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.vector;
+
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import io.milvus.TestUtils;
+import io.milvus.common.utils.Float16Utils;
+import io.milvus.common.utils.JsonUtils;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.*;
+import io.milvus.v2.service.index.request.CreateIndexReq;
+import io.milvus.v2.service.vector.request.*;
+import io.milvus.v2.service.vector.request.data.*;
+import io.milvus.v2.service.vector.response.*;
+import org.junit.jupiter.api.*;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+
+@Testcontainers(disabledWithoutDocker = true)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class NullableVectorTest {
+
+    private static MilvusClientV2 client;
+    private static final int DIMENSION = 8;
+    private static final Random RANDOM = new Random(42L);
+    private static final String COLLECTION_PREFIX = "test_nullable_vec_";
+
+    @Container
+    private static final MilvusContainer milvus = new MilvusContainer(TestUtils.MilvusDockerImageID)
+            .withEnv("DEPLOY_MODE", "STANDALONE");
+
+    // Vector type configurations
+    private static final List<VectorTypeConfig> VECTOR_TYPES = Arrays.asList(
+            new VectorTypeConfig("float_vector", DataType.FloatVector, DIMENSION, "L2", "FLAT"),
+            new VectorTypeConfig("binary_vector", DataType.BinaryVector, DIMENSION * 8, "HAMMING", "BIN_FLAT"),
+            new VectorTypeConfig("float16_vector", DataType.Float16Vector, DIMENSION, "L2", "FLAT"),
+            new VectorTypeConfig("bfloat16_vector", DataType.BFloat16Vector, DIMENSION, "L2", "FLAT"),
+            new VectorTypeConfig("sparse_float_vector", DataType.SparseFloatVector, 0, "IP", "SPARSE_INVERTED_INDEX"),
+            new VectorTypeConfig("int8_vector", DataType.Int8Vector, DIMENSION, "L2", "HNSW")
+    );
+
+    static class VectorTypeConfig {
+        String name;
+        DataType dataType;
+        int dimension;
+        String metricType;
+        String indexType;
+
+        VectorTypeConfig(String name, DataType dataType, int dimension, String metricType, String indexType) {
+            this.name = name;
+            this.dataType = dataType;
+            this.dimension = dimension;
+            this.metricType = metricType;
+            this.indexType = indexType;
+        }
+    }
+
+    @BeforeAll
+    public static void setUp() {
+        try {
+            Thread.sleep(3000); // Sleep for few seconds since the master branch milvus healthz check is bug
+        } catch (InterruptedException ignored) {
+        }
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(milvus.getEndpoint())
+                .build();
+        client = new MilvusClientV2(config);
+    }
+
+    @AfterAll
+    public static void tearDown() throws InterruptedException {
+        if (client != null) {
+            // Cleanup collections
+            for (VectorTypeConfig vtc : VECTOR_TYPES) {
+                dropCollectionQuietly(COLLECTION_PREFIX + vtc.name);
+                dropCollectionQuietly(COLLECTION_PREFIX + "all_null_" + vtc.name);
+            }
+            dropCollectionQuietly(COLLECTION_PREFIX + "add_field_test");
+            client.close(5L);
+        }
+    }
+
+    private static void dropCollectionQuietly(String collectionName) {
+        try {
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+        } catch (Exception ignored) {
+        }
+    }
+
+    private Object generateVector(VectorTypeConfig config) {
+        switch (config.dataType) {
+            case FloatVector: {
+                List<Float> vector = new ArrayList<>();
+                for (int i = 0; i < config.dimension; i++) {
+                    vector.add(RANDOM.nextFloat());
+                }
+                return vector;
+            }
+            case BinaryVector: {
+                int byteCount = config.dimension / 8;
+                byte[] bytes = new byte[byteCount];
+                RANDOM.nextBytes(bytes);
+                ByteBuffer buf = ByteBuffer.wrap(bytes);
+                return buf;
+            }
+            case Float16Vector: {
+                // Generate float values first, then convert to fp16
+                List<Float> floatVec = new ArrayList<>();
+                for (int i = 0; i < config.dimension; i++) {
+                    floatVec.add(RANDOM.nextFloat());
+                }
+                ByteBuffer buf = Float16Utils.f32VectorToFp16Buffer(floatVec);
+                buf.rewind();
+                return buf;
+            }
+            case BFloat16Vector: {
+                // Generate float values first, then convert to bf16
+                List<Float> floatVec = new ArrayList<>();
+                for (int i = 0; i < config.dimension; i++) {
+                    floatVec.add(RANDOM.nextFloat());
+                }
+                ByteBuffer buf = Float16Utils.f32VectorToBf16Buffer(floatVec);
+                buf.rewind();
+                return buf;
+            }
+            case Int8Vector: {
+                ByteBuffer buf = ByteBuffer.allocate(config.dimension);
+                for (int i = 0; i < config.dimension; i++) {
+                    buf.put((byte) (RANDOM.nextInt(256) - 128));
+                }
+                buf.rewind();
+                return buf;
+            }
+            case SparseFloatVector: {
+                SortedMap<Long, Float> sparse = new TreeMap<>();
+                int nnz = RANDOM.nextInt(10) + 2;
+                for (int i = 0; i < nnz; i++) {
+                    sparse.put((long) i, RANDOM.nextFloat());
+                }
+                return sparse;
+            }
+            default:
+                throw new IllegalArgumentException("Unknown vector type: " + config.dataType);
+        }
+    }
+
+    private void addVectorToRow(JsonObject row, String fieldName, VectorTypeConfig config, Object vector) {
+        if (config.dataType == DataType.FloatVector || config.dataType == DataType.SparseFloatVector) {
+            row.add(fieldName, JsonUtils.toJsonTree(vector));
+            return;
+        }
+
+        // For binary/fp16/bf16/int8, encode as byte array.
+        ByteBuffer buf = (ByteBuffer) vector;
+        byte[] bytes = new byte[buf.remaining()];
+        buf.get(bytes);
+        buf.rewind();
+        row.add(fieldName, JsonUtils.toJsonTree(bytes));
+    }
+
+    private void createNullableVectorCollection(String collectionName, VectorTypeConfig config) {
+        // Drop if exists
+        dropCollectionQuietly(collectionName);
+
+        // Create schema with nullable vector field
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("name")
+                .dataType(DataType.VarChar)
+                .maxLength(100)
+                .build());
+
+        AddFieldReq.AddFieldReqBuilder fieldBuilder = AddFieldReq.builder()
+                .fieldName("embedding")
+                .dataType(config.dataType)
+                .isNullable(true);
+        if (config.dimension > 0) {
+            fieldBuilder.dimension(config.dimension);
+        }
+        schema.addField(fieldBuilder.build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .build());
+
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("embedding")
+                .metricType(IndexParam.MetricType.valueOf(config.metricType))
+                .indexType(IndexParam.IndexType.valueOf(config.indexType))
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(indexParam))
+                .build());
+
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+    }
+
+    @Test
+    @Order(1)
+    void testNullableFloatVector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(0));
+    }
+
+    @Test
+    @Order(2)
+    void testNullableBinaryVector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(1));
+    }
+
+    @Test
+    @Order(3)
+    void testNullableFloat16Vector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(2));
+    }
+
+    @Test
+    @Order(4)
+    void testNullableBFloat16Vector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(3));
+    }
+
+    @Test
+    @Order(5)
+    void testNullableSparseFloatVector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(4));
+    }
+
+    @Test
+    @Order(6)
+    void testNullableInt8Vector() throws Exception {
+        testNullableVector(VECTOR_TYPES.get(5));
+    }
+
+    @Test
+    @Order(7)
+    void testAllNullNullableVectors() throws Exception {
+        for (VectorTypeConfig config : VECTOR_TYPES) {
+            testAllNullNullableVector(config);
+        }
+    }
+
+    /**
+     * Test that adding a non-nullable vector field to existing collection should fail.
+     */
+    @Test
+    @Order(8)
+    void testAddVectorFieldMustBeNullable() throws Exception {
+        String collectionName = COLLECTION_PREFIX + "add_field_test";
+        System.out.println("\n[Test] add_vector_field_must_be_nullable");
+
+        // Drop if exists
+        try {
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+        } catch (Exception ignored) {
+        }
+
+        // Create collection with one vector field
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("embedding")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .build());
+
+        // Try to add a non-nullable vector field - should fail
+        Exception exception = Assertions.assertThrows(Exception.class, () -> {
+            client.addCollectionField(AddCollectionFieldReq.builder()
+                    .collectionName(collectionName)
+                    .fieldName("embedding_v2")
+                    .dataType(DataType.FloatVector)
+                    .dimension(DIMENSION)
+                    .isNullable(false)  // Non-nullable should fail
+                    .build());
+        });
+        System.out.println("  Expected error: " + exception.getMessage());
+        Assertions.assertTrue(exception.getMessage().toLowerCase().contains("nullable"),
+                "Error should mention nullable requirement");
+
+        // Cleanup
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        System.out.println("  PASSED");
+    }
+
+    private void testNullableVector(VectorTypeConfig config) throws Exception {
+        String collectionName = COLLECTION_PREFIX + config.name;
+        System.out.println("\n[Test] " + config.name);
+
+        createNullableVectorCollection(collectionName, config);
+
+        // Prepare test data: 100 rows, ~50% null vectors
+        int totalRows = 100;
+        int nullPercent = 50;
+        List<JsonObject> data = new ArrayList<>();
+        int expectedNullCount = 0;
+        int expectedValidCount = 0;
+
+        for (int i = 1; i <= totalRows; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", (long) i);
+            row.addProperty("name", "row_" + i);
+
+            boolean isNull = RANDOM.nextInt(100) < nullPercent;
+            if (isNull) {
+                row.add("embedding", JsonNull.INSTANCE);
+                expectedNullCount++;
+            } else {
+                Object vector = generateVector(config);
+                expectedValidCount++;
+                addVectorToRow(row, "embedding", config, vector);
+            }
+            data.add(row);
+        }
+
+        // Insert data
+        InsertResp insertResp = client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(data)
+                .build());
+        Assertions.assertEquals(totalRows, insertResp.getInsertCnt());
+
+        // Wait for data to be available
+        Thread.sleep(1000);
+
+        // Query all data
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id >= 0")
+                .outputFields(Arrays.asList("id", "name", "embedding"))
+                .limit(totalRows + 10)
+                .build());
+
+        List<QueryResp.QueryResult> results = queryResp.getQueryResults();
+        Assertions.assertEquals(totalRows, results.size());
+
+        int nullCount = 0;
+        int validCount = 0;
+        for (QueryResp.QueryResult result : results) {
+            Map<String, Object> entity = result.getEntity();
+            Object embedding = entity.get("embedding");
+            if (embedding == null) {
+                nullCount++;
+            } else {
+                validCount++;
+            }
+        }
+        Assertions.assertEquals(expectedNullCount, nullCount);
+        Assertions.assertEquals(expectedValidCount, validCount);
+
+        // Search - should only return non-null vectors
+        Object searchVector = generateVector(config);
+        BaseVector searchVec;
+        if (config.dataType == DataType.FloatVector) {
+            searchVec = new FloatVec((List<Float>) searchVector);
+        } else if (config.dataType == DataType.BinaryVector) {
+            searchVec = new BinaryVec((ByteBuffer) searchVector);
+        } else if (config.dataType == DataType.Float16Vector) {
+            searchVec = new Float16Vec((ByteBuffer) searchVector);
+        } else if (config.dataType == DataType.BFloat16Vector) {
+            searchVec = new BFloat16Vec((ByteBuffer) searchVector);
+        } else if (config.dataType == DataType.SparseFloatVector) {
+            searchVec = new SparseFloatVec((SortedMap<Long, Float>) searchVector);
+        } else {
+            // Int8Vector
+            searchVec = new Int8Vec((ByteBuffer) searchVector);
+        }
+
+        int searchLimit = Math.min(50, expectedValidCount);
+        SearchResp searchResp = client.search(SearchReq.builder()
+                .collectionName(collectionName)
+                .data(Collections.singletonList(searchVec))
+                .annsField("embedding")
+                .topK(searchLimit)
+                .outputFields(Arrays.asList("id", "name", "embedding"))
+                .build());
+
+        List<List<SearchResp.SearchResult>> searchResults = searchResp.getSearchResults();
+        Assertions.assertFalse(searchResults.isEmpty());
+        List<SearchResp.SearchResult> hits = searchResults.get(0);
+
+        // Search should only return non-null vectors
+        Assertions.assertTrue(hits.size() <= expectedValidCount, "Search should return at most expectedValidCount results");
+        for (SearchResp.SearchResult hit : hits) {
+            Map<String, Object> entity = hit.getEntity();
+            Object embedding = entity.get("embedding");
+            Assertions.assertNotNull(embedding, "Search should not return null vectors");
+        }
+
+        System.out.println("  PASSED");
+    }
+
+    private void testAllNullNullableVector(VectorTypeConfig config) throws Exception {
+        String collectionName = COLLECTION_PREFIX + "all_null_" + config.name;
+        System.out.println("\n[Test] all_null_" + config.name);
+
+        createNullableVectorCollection(collectionName, config);
+
+        int totalRows = 10;
+        List<JsonObject> data = new ArrayList<>();
+        for (int i = 1; i <= totalRows; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", (long) i);
+            row.addProperty("name", "row_" + i);
+            row.add("embedding", JsonNull.INSTANCE);
+            data.add(row);
+        }
+
+        InsertResp insertResp = client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(data)
+                .build());
+        Assertions.assertEquals(totalRows, insertResp.getInsertCnt());
+
+        // Wait for data to be available
+        Thread.sleep(1000);
+
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id >= 0")
+                .outputFields(Arrays.asList("id", "name", "embedding"))
+                .limit(totalRows + 10)
+                .build());
+
+        List<QueryResp.QueryResult> results = queryResp.getQueryResults();
+        Assertions.assertEquals(totalRows, results.size());
+        for (QueryResp.QueryResult result : results) {
+            Assertions.assertNull(result.getEntity().get("embedding"));
+        }
+
+        System.out.println("  PASSED");
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
@@ -21,6 +21,8 @@ package io.milvus.v2.utils;
 
 import io.milvus.grpc.*;
 import io.milvus.param.Constant;
+import io.milvus.v2.exception.ErrorCode;
+import io.milvus.v2.exception.MilvusClientException;
 import io.milvus.v2.service.collection.request.AddFieldReq;
 import io.milvus.v2.service.collection.request.CreateCollectionReq;
 import org.junit.jupiter.api.Assertions;
@@ -236,6 +238,21 @@ public class SchemaUtilsTest {
                 Assertions.assertTrue(keys.contains("multi_analyzer_params"));
             }
         }
+    }
+
+    @Test
+    void testConvertToGrpcFieldSchemaTreatsNullNullableAsFalseForAddVectorField() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("nullable_vector")
+                .dataType(io.milvus.v2.common.DataType.FloatVector)
+                .dimension(128)
+                .isNullable(null)
+                .build();
+
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> SchemaUtils.convertToGrpcFieldSchema(fieldSchema, true));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("Vector field must be nullable"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Cherrypick #1730 to the 2.6 branch to support nullable vector fields in Java SDK request/response handling and bulk writer paths.
- Keep 2.6 API compatibility by omitting the master-only externalField schema setter.
- Adapt NullableVectorTest to the existing 2.6 Testcontainers style instead of backporting the master compose test fixture.
- Update the 2.6 test Milvus image references to `milvusdb/milvus:2.6-20260519-ab427b8b`, which was verified to include the server-side nullable vector support.

pr: #1730

## Test plan
- [x] `git diff --check upstream/2.6..HEAD`
- [x] `mvn -pl sdk-core,sdk-bulkwriter -DskipTests test-compile`
- [x] `mvn -pl sdk-core -Dtest=SchemaUtilsTest test`
- [x] `mvn -pl sdk-bulkwriter -Dtest=BulkWriterTest test`
- [x] `MILVUS_DOCKER_IMAGE=milvusdb/milvus:2.6-20260519-ab427b8b mvn -pl sdk-core -Dtest=NullableVectorTest test`
- [x] `mvn -pl sdk-core -Dtest=NullableVectorTest test`