### PR TITLE
feat: add get replicate configuration API

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -33,6 +33,7 @@ import io.milvus.orm.iterator.SearchIterator;
 import io.milvus.orm.iterator.SearchIteratorV2;
 import io.milvus.v2.service.cdc.CDCService;
 import io.milvus.v2.service.cdc.request.UpdateReplicateConfigurationReq;
+import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
 import io.milvus.v2.service.cdc.response.UpdateReplicateConfigurationResp;
 import io.milvus.v2.service.collection.CollectionService;
 import io.milvus.v2.service.collection.request.*;
@@ -1588,6 +1589,10 @@ public class MilvusClientV2 {
      */
     public CheckHealthResp checkHealth() {
         return rpcUtils.retry(() -> utilityService.checkHealth(this.getRpcStub()));
+    }
+
+    public GetReplicateConfigurationResp getReplicateConfiguration() {
+        return rpcUtils.retry(() -> cdcService.getReplicateConfiguration(this.getRpcStub()));
     }
 
     public UpdateReplicateConfigurationResp updateReplicateConfiguration(UpdateReplicateConfigurationReq request) {

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
@@ -19,14 +19,30 @@
 
 package io.milvus.v2.service.cdc;
 
+import io.milvus.grpc.GetReplicateConfigurationRequest;
+import io.milvus.grpc.GetReplicateConfigurationResponse;
 import io.milvus.grpc.MilvusServiceGrpc;
 import io.milvus.grpc.Status;
 import io.milvus.grpc.UpdateReplicateConfigurationRequest;
 import io.milvus.v2.service.BaseService;
+import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
 import io.milvus.v2.service.cdc.request.UpdateReplicateConfigurationReq;
+import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
 import io.milvus.v2.service.cdc.response.UpdateReplicateConfigurationResp;
 
 public class CDCService extends BaseService {
+    public GetReplicateConfigurationResp getReplicateConfiguration(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub) {
+        GetReplicateConfigurationRequest request = GetReplicateConfigurationRequest.newBuilder().build();
+
+        String title = "GetReplicateConfiguration";
+
+        GetReplicateConfigurationResponse response = blockingStub.getReplicateConfiguration(request);
+        rpcUtils.handleResponse(title, response.getStatus());
+        return GetReplicateConfigurationResp.builder()
+                .replicateConfiguration(ReplicateConfiguration.fromGRPC(response.getConfiguration()))
+                .build();
+    }
+
     public UpdateReplicateConfigurationResp updateReplicateConfiguration(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, UpdateReplicateConfigurationReq requestParam) {
         UpdateReplicateConfigurationRequest request = UpdateReplicateConfigurationRequest.newBuilder()
                 .setReplicateConfiguration(requestParam.getReplicateConfiguration().toGRPC())

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/CrossClusterTopology.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/CrossClusterTopology.java
@@ -24,6 +24,13 @@ public class CrossClusterTopology {
     private String sourceClusterId;
     private String targetClusterId;
 
+    public static CrossClusterTopology fromGRPC(io.milvus.grpc.CrossClusterTopology topology) {
+        return CrossClusterTopology.builder()
+                .sourceClusterId(topology.getSourceClusterId())
+                .targetClusterId(topology.getTargetClusterId())
+                .build();
+    }
+
     public io.milvus.grpc.CrossClusterTopology toGRPC() {
         return io.milvus.grpc.CrossClusterTopology.newBuilder()
                 .setSourceClusterId(this.sourceClusterId)

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/MilvusCluster.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/MilvusCluster.java
@@ -19,6 +19,7 @@
 
 package io.milvus.v2.service.cdc.request;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MilvusCluster {
@@ -26,6 +27,16 @@ public class MilvusCluster {
     private String uri;
     private String token;
     private List<String> pchannels;
+
+    public static MilvusCluster fromGRPC(io.milvus.grpc.MilvusCluster cluster) {
+        io.milvus.grpc.ConnectionParam connectionParam = cluster.getConnectionParam();
+        return MilvusCluster.builder()
+                .clusterId(cluster.getClusterId())
+                .uri(connectionParam.getUri())
+                .token(connectionParam.getToken())
+                .pchannels(new ArrayList<>(cluster.getPchannelsList()))
+                .build();
+    }
 
     public io.milvus.grpc.MilvusCluster toGRPC() {
         io.milvus.grpc.ConnectionParam.Builder connectionParamBuilder = io.milvus.grpc.ConnectionParam.newBuilder()

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/ReplicateConfiguration.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/ReplicateConfiguration.java
@@ -19,11 +19,26 @@
 
 package io.milvus.v2.service.cdc.request;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ReplicateConfiguration {
     private List<MilvusCluster> clusters;
     private List<CrossClusterTopology> crossClusterTopologies;
+
+    public static ReplicateConfiguration fromGRPC(io.milvus.grpc.ReplicateConfiguration configuration) {
+        List<MilvusCluster> clusters = new ArrayList<>();
+        configuration.getClustersList().forEach(cluster -> clusters.add(MilvusCluster.fromGRPC(cluster)));
+
+        List<CrossClusterTopology> crossClusterTopologies = new ArrayList<>();
+        configuration.getCrossClusterTopologyList().forEach(topology ->
+                crossClusterTopologies.add(CrossClusterTopology.fromGRPC(topology)));
+
+        return ReplicateConfiguration.builder()
+                .clusters(clusters)
+                .crossClusterTopologies(crossClusterTopologies)
+                .build();
+    }
 
     public io.milvus.grpc.ReplicateConfiguration toGRPC() {
         io.milvus.grpc.ReplicateConfiguration.Builder builder = io.milvus.grpc.ReplicateConfiguration.newBuilder();

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/response/GetReplicateConfigurationResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/response/GetReplicateConfigurationResp.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.cdc.response;
+
+import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
+
+public class GetReplicateConfigurationResp {
+    private ReplicateConfiguration replicateConfiguration;
+
+    private GetReplicateConfigurationResp(GetReplicateConfigurationRespBuilder builder) {
+        this.replicateConfiguration = builder.replicateConfiguration;
+    }
+
+    public static GetReplicateConfigurationRespBuilder builder() {
+        return new GetReplicateConfigurationRespBuilder();
+    }
+
+    public ReplicateConfiguration getReplicateConfiguration() {
+        return replicateConfiguration;
+    }
+
+    public void setReplicateConfiguration(ReplicateConfiguration replicateConfiguration) {
+        this.replicateConfiguration = replicateConfiguration;
+    }
+
+    @Override
+    public String toString() {
+        return "GetReplicateConfigurationResp{" +
+                "replicateConfiguration=" + replicateConfiguration +
+                '}';
+    }
+
+    public static class GetReplicateConfigurationRespBuilder {
+        private ReplicateConfiguration replicateConfiguration;
+
+        public GetReplicateConfigurationRespBuilder replicateConfiguration(ReplicateConfiguration replicateConfiguration) {
+            this.replicateConfiguration = replicateConfiguration;
+            return this;
+        }
+
+        public GetReplicateConfigurationResp build() {
+            return new GetReplicateConfigurationResp(this);
+        }
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
@@ -228,6 +228,36 @@ public class BaseTest {
                                 .build())
                         .build());
 
+        // cdc api
+        ReplicateConfiguration replicateConfiguration = ReplicateConfiguration.newBuilder()
+                .addClusters(MilvusCluster.newBuilder()
+                        .setClusterId("source_cluster")
+                        .setConnectionParam(ConnectionParam.newBuilder()
+                                .setUri("http://source.example.com:19530")
+                                .setToken("source-token")
+                                .build())
+                        .addPchannels("by-dev-rootcoord-dml_0")
+                        .build())
+                .addClusters(MilvusCluster.newBuilder()
+                        .setClusterId("target_cluster")
+                        .setConnectionParam(ConnectionParam.newBuilder()
+                                .setUri("http://target.example.com:19530")
+                                .setToken("target-token")
+                                .build())
+                        .addPchannels("by-dev-rootcoord-dml_1")
+                        .build())
+                .addCrossClusterTopology(CrossClusterTopology.newBuilder()
+                        .setSourceClusterId("source_cluster")
+                        .setTargetClusterId("target_cluster")
+                        .build())
+                .build();
+        when(blockingStub.getReplicateConfiguration(any())).thenReturn(
+                GetReplicateConfigurationResponse.newBuilder()
+                        .setStatus(successStatus)
+                        .setConfiguration(replicateConfiguration)
+                        .build());
+        when(blockingStub.updateReplicateConfiguration(any())).thenReturn(successStatus);
+
         // snapshot api
         when(blockingStub.createSnapshot(any())).thenReturn(successStatus);
         when(blockingStub.dropSnapshot(any())).thenReturn(successStatus);

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -53,6 +53,7 @@ import io.milvus.v2.service.cdc.request.CrossClusterTopology;
 import io.milvus.v2.service.cdc.request.MilvusCluster;
 import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
 import io.milvus.v2.service.cdc.request.UpdateReplicateConfigurationReq;
+import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
 import io.milvus.v2.service.cdc.response.UpdateReplicateConfigurationResp;
 import io.milvus.v2.service.collection.request.*;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
@@ -520,6 +521,7 @@ public class MilvusClientV2Test extends BaseTest {
         VerifyClass(ReplicateConfiguration.class.getName(), config);
         VerifyClass(UpdateReplicateConfigurationReq.class.getName(), config);
 
+        VerifyClass(GetReplicateConfigurationResp.class.getName(), config);
         VerifyClass(UpdateReplicateConfigurationResp.class.getName(), config);
 
         // io.milvus/v2/service/collection

--- a/sdk-core/src/test/java/io/milvus/v2/service/cdc/CDCServiceTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/cdc/CDCServiceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.cdc;
+
+import io.milvus.v2.BaseTest;
+import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
+import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class CDCServiceTest extends BaseTest {
+    @Test
+    void testGetReplicateConfiguration() {
+        GetReplicateConfigurationResp resp = client_v2.getReplicateConfiguration();
+
+        ReplicateConfiguration replicateConfiguration = resp.getReplicateConfiguration();
+        assertNotNull(replicateConfiguration);
+        assertEquals(2, replicateConfiguration.getClusters().size());
+        assertEquals("source_cluster", replicateConfiguration.getClusters().get(0).getClusterId());
+        assertEquals("http://source.example.com:19530", replicateConfiguration.getClusters().get(0).getUri());
+        assertEquals("source-token", replicateConfiguration.getClusters().get(0).getToken());
+        assertEquals("by-dev-rootcoord-dml_0", replicateConfiguration.getClusters().get(0).getPchannels().get(0));
+        assertEquals(1, replicateConfiguration.getCrossClusterTopologies().size());
+        assertEquals("source_cluster", replicateConfiguration.getCrossClusterTopologies().get(0).getSourceClusterId());
+        assertEquals("target_cluster", replicateConfiguration.getCrossClusterTopologies().get(0).getTargetClusterId());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MilvusClientV2#getReplicateConfiguration()`.
- Add CDC service handling for `GetReplicateConfiguration`.
- Add SDK DTO conversion from gRPC replicate configuration response.
- Add unit coverage for the new getter.

## Tests

- `mvn -pl sdk-core -am package -Dmaven.test.skip=true`
- `mvn -pl sdk-core -am install -Dmaven.test.skip=true`
- `mvn -pl sdk-core test -Dtest=CDCServiceTest -Dsurefire.failIfNoSpecifiedTests=false -DargLine="-Dnet.bytebuddy.experimental=true"`

Note: the Byte Buddy argLine is needed locally with Java 21 and the current Mockito/Byte Buddy versions.
