### PR TITLE
Fix RpcUtils.retry() silently swallowing timeout and max-retry exceptions, returning null

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
@@ -205,7 +205,11 @@ public class RpcUtils {
                 }
                 try {
                     TimeUnit.MILLISECONDS.sleep(retryIntervalMs);
-                } catch (InterruptedException ignored) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    String msg = String.format("Retry sleep interrupted, aborting retry after %d attempts", k);
+                    logger.warn(msg);
+                    throw new MilvusClientException(ErrorCode.CLIENT_ERROR, msg);
                 }
             }
 

--- a/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 public class RpcUtils {
 
@@ -123,9 +124,8 @@ public class RpcUtils {
         // method to check timeout
         long begin = System.currentTimeMillis();
         long maxRetryTimeoutMs = retryConfig.getMaxRetryTimeoutMs();
-        Callable<Boolean> timeoutChecker = () -> {
-            long current = System.currentTimeMillis();
-            long cost = (current - begin);
+        Function<Long, Boolean> timeoutChecker = (timePoint) -> {
+            long cost = (timePoint - begin);
             if (maxRetryTimeoutMs > 0 && cost >= maxRetryTimeoutMs) {
                 return Boolean.TRUE;
             }
@@ -154,24 +154,18 @@ public class RpcUtils {
                 // trigger topology refresh if connection is unavailable, and continue to retry
                 handleGlobalConnectionError(e);
 
-                try {
-                    if (timeoutChecker.call() == Boolean.TRUE) {
-                        String msg = String.format("Retry timeout: %dms, maxRetry:%d, retries: %d, reason: %s",
-                                maxRetryTimeoutMs, maxRetryTimes, k, e.getMessage());
-                        logger.warn(msg);
-                        throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exit retry for timeout
-                    }
-                } catch (Exception ignored) {
+                if (timeoutChecker.apply(System.currentTimeMillis()) == Boolean.TRUE) {
+                    String msg = String.format("Retry timeout: %dms, maxRetry:%d, retries: %d, reason: %s",
+                            maxRetryTimeoutMs, maxRetryTimes, k, e.getMessage());
+                    logger.warn(msg);
+                    throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exit retry for timeout
                 }
             } catch (MilvusClientException e) {
-                try {
-                    if (timeoutChecker.call() == Boolean.TRUE) {
-                        String msg = String.format("Retry timeout: %dms, maxRetry:%d, retries: %d, reason: %s",
-                                maxRetryTimeoutMs, maxRetryTimes, k, e.getMessage());
-                        logger.warn(msg);
-                        throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exit retry for timeout
-                    }
-                } catch (Exception ignored) {
+                if (timeoutChecker.apply(System.currentTimeMillis()) == Boolean.TRUE) {
+                    String msg = String.format("Retry timeout: %dms, maxRetry:%d, retries: %d, reason: %s",
+                            maxRetryTimeoutMs, maxRetryTimes, k, e.getMessage());
+                    logger.warn(msg);
+                    throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exit retry for timeout
                 }
 
                 if (retryConfig.isRetryOnRateLimit() &&
@@ -188,27 +182,37 @@ public class RpcUtils {
                 throw new MilvusClientException(ErrorCode.CLIENT_ERROR, e); // others error treated as client error
             }
 
-            try {
-                if (k >= maxRetryTimes) {
-                    // finish retry loop, return the response of the last retry
-                    String msg = String.format("Finish %d retry times, stop retry", maxRetryTimes);
+            if (k >= maxRetryTimes) {
+                // finish retry loop, return the response of the last retry
+                String msg = String.format("Finish %d retry times, stop retry", maxRetryTimes);
+                logger.warn(msg);
+                throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exceed max time, exit retry
+            } else {
+                // check if sleep would exceed maxRetryTimeoutMs, if so, directly throw timeout
+                long futureTimePoint = System.currentTimeMillis() + retryIntervalMs;
+                if (timeoutChecker.apply(futureTimePoint) == Boolean.TRUE) {
+                    String msg = String.format("Retry timeout: %dms, maxRetry:%d, retries: %d, "
+                                    + "elapsed time + next interval %dms would exceed timeout",
+                            maxRetryTimeoutMs, maxRetryTimes, k, retryIntervalMs);
                     logger.warn(msg);
-                    throw new MilvusClientException(ErrorCode.TIMEOUT, msg); // exceed max time, exit retry
-                } else {
-                    // sleep for interval
-                    // print log, follow the pymilvus logic
-                    if (k > 3) {
-                        logger.warn(String.format("Retry(%d) with interval %dms", k, retryIntervalMs));
-                    }
-                    TimeUnit.MILLISECONDS.sleep(retryIntervalMs);
+                    throw new MilvusClientException(ErrorCode.TIMEOUT, msg);
                 }
 
-                // reset the next interval value
-                retryIntervalMs = retryIntervalMs * retryConfig.getBackOffMultiplier();
-                if (retryIntervalMs > retryConfig.getMaxBackOffMs()) {
-                    retryIntervalMs = retryConfig.getMaxBackOffMs();
+                // sleep for interval
+                // print log, follow the pymilvus logic
+                if (k > 3) {
+                    logger.warn(String.format("Retry(%d) with interval %dms", k, retryIntervalMs));
                 }
-            } catch (Exception ignored) {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(retryIntervalMs);
+                } catch (InterruptedException ignored) {
+                }
+            }
+
+            // reset the next interval value
+            retryIntervalMs = retryIntervalMs * retryConfig.getBackOffMultiplier();
+            if (retryIntervalMs > retryConfig.getMaxBackOffMs()) {
+                retryIntervalMs = retryConfig.getMaxBackOffMs();
             }
         }
 

--- a/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.utils;
+
+import io.grpc.StatusRuntimeException;
+import io.milvus.v2.client.RetryConfig;
+import io.milvus.v2.exception.ErrorCode;
+import io.milvus.v2.exception.MilvusClientException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RpcUtilsTest {
+
+    @Test
+    void testEarlyExitWhenPredictedBackoffExceedsMaxRetryTimeoutMs() {
+        RpcUtils rpcUtils = new RpcUtils();
+        long maxRetryTimeoutMs = 5000;
+        rpcUtils.retryConfig(RetryConfig.builder()
+                .maxRetryTimes(10)
+                .maxRetryTimeoutMs(maxRetryTimeoutMs)
+                .initialBackOffMs(10)
+                .maxBackOffMs(3000)
+                .backOffMultiplier(3)
+                .build());
+
+        long start = System.currentTimeMillis();
+
+        MilvusClientException thrown = Assertions.assertThrows(MilvusClientException.class, () -> {
+            rpcUtils.retry(() -> {
+                throw new StatusRuntimeException(
+                        io.grpc.Status.UNAVAILABLE.withDescription("server unavailable"));
+            });
+        });
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        Assertions.assertEquals(ErrorCode.TIMEOUT, thrown.getErrorCode(),
+                "Should fail with TIMEOUT error code");
+        // Backoff sequence (initial=10ms, multiplier=3, max=3000ms):
+        //   k=1 @~0ms    → sleep 10ms
+        //   k=2 @~10ms   → sleep 30ms
+        //   k=3 @~40ms   → sleep 90ms
+        //   k=4 @~130ms  → sleep 270ms
+        //   k=5 @~400ms  → sleep 810ms
+        //   k=6 @~1210ms → sleep 2430ms
+        //   k=7 @~3640ms → next backoff 3000ms, 3640+3000=6640 > 5000ms → TIMEOUT
+        Assertions.assertTrue(elapsed <= 4000,
+                "Retry should respect maxRetryTimeoutMs(5000ms), but took " + elapsed + "ms");
+    }
+
+    @Test
+    void testMaxRetryTimes() {
+        RpcUtils rpcUtils = new RpcUtils();
+        int maxRetryTimes = 3;
+        rpcUtils.retryConfig(RetryConfig.builder()
+                .maxRetryTimes(maxRetryTimes)
+                .maxRetryTimeoutMs(60000) // large timeout so retry times is the limiting factor
+                .initialBackOffMs(10)
+                .maxBackOffMs(100)
+                .backOffMultiplier(2)
+                .build());
+
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        MilvusClientException thrown = Assertions.assertThrows(MilvusClientException.class, () -> {
+            rpcUtils.retry(() -> {
+                callCount.incrementAndGet();
+                throw new StatusRuntimeException(
+                        io.grpc.Status.UNAVAILABLE.withDescription("server unavailable"));
+            });
+        });
+
+        Assertions.assertEquals(ErrorCode.TIMEOUT, thrown.getErrorCode(),
+                "Should fail with TIMEOUT error code");
+        Assertions.assertEquals(maxRetryTimes, callCount.get(),
+                "Should have retried exactly maxRetryTimes(" + maxRetryTimes + ") times, but got " + callCount.get());
+    }
+
+    @Test
+    void testTimeoutAfterSlowCallExceedsMaxRetryTimeoutMs() {
+        RpcUtils rpcUtils = new RpcUtils();
+        long maxRetryTimeoutMs = 2000;
+        rpcUtils.retryConfig(RetryConfig.builder()
+                .maxRetryTimes(10)
+                .maxRetryTimeoutMs(maxRetryTimeoutMs)
+                .initialBackOffMs(50)
+                .maxBackOffMs(500)
+                .backOffMultiplier(2)
+                .build());
+
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        long start = System.currentTimeMillis();
+
+        MilvusClientException thrown = Assertions.assertThrows(MilvusClientException.class, () -> {
+            rpcUtils.retry(() -> {
+                callCount.incrementAndGet();
+                // Simulate a slow RPC call that takes 400ms each time
+                Thread.sleep(500);
+                throw new StatusRuntimeException(
+                        io.grpc.Status.UNAVAILABLE.withDescription("server unavailable"));
+            });
+        });
+
+        long elapsed = System.currentTimeMillis() - start;
+
+        Assertions.assertEquals(ErrorCode.TIMEOUT, thrown.getErrorCode(),
+                "Should fail with TIMEOUT error code when slow calls accumulate beyond maxRetryTimeoutMs");
+        // Timeline (slow call sleep=500ms, backoff: initial=50ms, multiplier=2, max=500ms):
+        //   k=1 @~0ms     → sleep 500ms, call ends @500ms
+        //                    backoff 50ms, total ~550ms < 2000ms → continue
+        //   k=2 @~550ms   → sleep 500ms, call ends @~1050ms
+        //                    backoff 100ms, total ~1150ms < 2000ms → continue
+        //   k=3 @~1150ms   → sleep 500ms, call ends @~1650ms
+        //                    backoff 200ms, total ~1850ms < 2000ms → continue
+        //   k=4 @~1850ms  → sleep 500ms, call ends @~2350ms
+        //                    elapsed(2350ms) >= maxRetryTimeoutMs(2000ms)
+        Assertions.assertEquals(4, callCount.get(), "Should have 4 times, but got " + callCount.get());
+        Assertions.assertTrue(elapsed > maxRetryTimeoutMs,
+                "Elapsed time should greater than maxRetryTimeoutMs, but was " + elapsed + "ms");
+        Assertions.assertTrue(elapsed < maxRetryTimeoutMs + 1000,
+                "Should not exceed maxRetryTimeoutMs by too much, elapsed was " + elapsed + "ms");
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
@@ -114,7 +114,7 @@ public class RpcUtilsTest {
         MilvusClientException thrown = Assertions.assertThrows(MilvusClientException.class, () -> {
             rpcUtils.retry(() -> {
                 callCount.incrementAndGet();
-                // Simulate a slow RPC call that takes 400ms each time
+                // Simulate a slow RPC call that takes 500ms each time
                 Thread.sleep(500);
                 throw new StatusRuntimeException(
                         io.grpc.Status.UNAVAILABLE.withDescription("server unavailable"));


### PR DESCRIPTION
close #1877

1. timeoutChecker 类型从 Callable<Boolean> 改为 Function<Long, Boolean>
原来的代码：timeoutChecker 是 Callable<Boolean>，call() 声明了受检异常，调用方被迫 try-catch 包裹，catch 块 ignored 无差别吞掉了所有异常——包括超时时抛出的 MilvusClientException.

修改为 Function<Long, Boolean>，通过 timeoutChecker.apply(System.currentTimeMillis()) 调用，无需捕获受检异常，超时异常能正确向上传播

2. 移除包裹 k >= maxRetryTimes 退出逻辑的外层 try-catch
原来的代码：达到最大重试次数后抛出的 MilvusClientException 被外层 try { ... throw ... } catch (Exception ignored) {} 吞掉，导致循环正常结束并 return null。

修改为只对sleep进行catch

3. 退避 sleep 前预判是否会超时，提前退出
原来的代码：退避间隔直接 sleep，没有做任何预判。当指数退避乘数较大时，最后一次 sleep 可能使累计耗时远超 maxRetryTimeoutMs.减少无意义的等待