### PR TITLE
Support Text data type

### DIFF
--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/BulkWriter.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/BulkWriter.java
@@ -371,6 +371,7 @@ public abstract class BulkWriter implements AutoCloseable {
                 return verifyVector(obj, field);
             }
             case VarChar:
+            case Text:
             case Geometry:
             case Timestamptz: {
                 return verifyVarchar(obj, field);

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/common/utils/ParquetUtils.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/common/utils/ParquetUtils.java
@@ -113,6 +113,7 @@ public class ParquetUtils {
                     fillArrayType(messageTypeBuilder, field);
                     break;
                 case VarChar:
+                case Text:
                 case Geometry:
                 case Timestamptz:
                 case JSON:

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/writer/ParquetFileWriter.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/writer/ParquetFileWriter.java
@@ -144,6 +144,7 @@ public class ParquetFileWriter implements FormatFileWriter {
                 break;
             case VarChar:
             case String:
+            case Text:
             case Geometry:
             case Timestamptz:
             case JSON:

--- a/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/BulkWriterTest.java
+++ b/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/BulkWriterTest.java
@@ -544,6 +544,109 @@ public class BulkWriterTest {
         }
     }
 
+    @Test
+    void testWriteTextFields() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("body")
+                .dataType(DataType.Text)
+                .maxLength(1)
+                .build());
+        String longText = String.join("", Collections.nCopies(1024, "text"));
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 1L);
+        row.addProperty("body", longText);
+
+        for (BulkFileType fileType : Arrays.asList(BulkFileType.JSON, BulkFileType.CSV, BulkFileType.PARQUET)) {
+            LocalBulkWriterParam param = LocalBulkWriterParam.newBuilder()
+                    .withCollectionSchema(schema)
+                    .withLocalPath("/tmp/bulk_writer_text")
+                    .withFileType(fileType)
+                    .build();
+            try (LocalBulkWriter writer = new LocalBulkWriter(param)) {
+                writer.appendRow(row);
+                writer.commit(false);
+                List<List<String>> batchFiles = writer.getBatchFiles();
+                Assertions.assertFalse(batchFiles.isEmpty());
+                String filePath = batchFiles.get(0).get(0);
+                if (fileType == BulkFileType.JSON) {
+                    try (Reader reader = Files.newBufferedReader(Paths.get(filePath))) {
+                        List<JsonObject> rows = new Gson().fromJson(reader,
+                                new TypeToken<List<JsonObject>>() {
+                                }.getType());
+                        Assertions.assertEquals(1, rows.size());
+                        Assertions.assertEquals(longText, rows.get(0).get("body").getAsString());
+                    }
+                } else if (fileType == BulkFileType.CSV) {
+                    List<String> lines = Files.readAllLines(Paths.get(filePath), StandardCharsets.UTF_8);
+                    Assertions.assertEquals(2, lines.size());
+                    List<String> header = Arrays.asList(lines.get(0).split(",", -1));
+                    String[] values = lines.get(1).split(",", -1);
+                    String body = values[header.indexOf("body")];
+                    Assertions.assertEquals(longText, body.substring(1, body.length() - 1));
+                } else {
+                    final int[] rowsRead = {0};
+                    new ParquetReaderUtils() {
+                        @Override
+                        public void readRecord(GenericData.Record record) {
+                            rowsRead[0]++;
+                            Assertions.assertEquals(longText, record.get("body").toString());
+                        }
+                    }.readParquet(filePath);
+                    Assertions.assertEquals(1, rowsRead[0]);
+                }
+            } catch (Exception e) {
+                Assertions.fail(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void testWriteTextFieldsWithV1Schema() {
+        CollectionSchemaParam schema = CollectionSchemaParam.newBuilder()
+                .withFieldTypes(Arrays.asList(
+                        FieldType.newBuilder()
+                                .withName("id")
+                                .withDataType(io.milvus.grpc.DataType.Int64)
+                                .withPrimaryKey(true)
+                                .build(),
+                        FieldType.newBuilder()
+                                .withName("body")
+                                .withDataType(io.milvus.grpc.DataType.Text)
+                                .build()))
+                .build();
+        LocalBulkWriterParam param = LocalBulkWriterParam.newBuilder()
+                .withCollectionSchema(schema)
+                .withLocalPath("/tmp/bulk_writer_text_v1")
+                .withFileType(BulkFileType.JSON)
+                .build();
+
+        String longText = String.join("", Collections.nCopies(1024, "text"));
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 1L);
+        row.addProperty("body", longText);
+
+        try (LocalBulkWriter writer = new LocalBulkWriter(param)) {
+            writer.appendRow(row);
+            writer.commit(false);
+            String filePath = writer.getBatchFiles().get(0).get(0);
+            try (Reader reader = Files.newBufferedReader(Paths.get(filePath))) {
+                List<JsonObject> rows = new Gson().fromJson(reader,
+                        new TypeToken<List<JsonObject>>() {
+                        }.getType());
+                Assertions.assertEquals(1, rows.size());
+                Assertions.assertEquals(longText, rows.get(0).get("body").getAsString());
+            }
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+
     private static void compareJsonArray(JsonElement j1, JsonElement j2, DataType dt) {
         if (j1.isJsonNull()) {
             Assertions.assertTrue(j2.isJsonNull());
@@ -571,6 +674,7 @@ public class BulkWriterTest {
                     Assertions.assertEquals(a1.get(i).getAsDouble(), a2.get(i).getAsDouble());
                     break;
                 case VarChar:
+                case Text:
                     Assertions.assertEquals(a1.get(i).getAsString(), a2.get(i).getAsString());
                 default:
                     Assertions.assertEquals(a1.get(i), a2.get(i));

--- a/sdk-core/src/main/java/io/milvus/param/ParamUtils.java
+++ b/sdk-core/src/main/java/io/milvus/param/ParamUtils.java
@@ -61,6 +61,7 @@ public class ParamUtils {
         typeErrMsg.put(DataType.String, "Type mismatch for field '%s': String field value type must be String."); // actually String type is useless
         typeErrMsg.put(DataType.JSON, "Type mismatch for field '%s': JSON field value type must be JSON, current type: %s.");
         typeErrMsg.put(DataType.VarChar, "Type mismatch for field '%s': VarChar field value type must be String, and the string length must shorter than max_length.");
+        typeErrMsg.put(DataType.Text, "Type mismatch for field '%s': Text field value type must be String.");
         typeErrMsg.put(DataType.Array, "Type mismatch for field '%s': Array field value type must be List<Object>, each object type must be element_type, and the array length must be shorter than max_capacity.");
         typeErrMsg.put(DataType.FloatVector, "Type mismatch for field '%s': Float vector field's value type must be List<Float>.");
         typeErrMsg.put(DataType.BinaryVector, "Type mismatch for field '%s': Binary vector field's value type must be ByteBuffer.");
@@ -82,6 +83,7 @@ public class ParamUtils {
         typeErrMsg.put(DataType.Double, "Type mismatch for field '%s': Double field value type must be JsonPrimitive of number.");
         typeErrMsg.put(DataType.String, "Type mismatch for field '%s': String field value type must be JsonPrimitive of string."); // actually String type is useless
         typeErrMsg.put(DataType.VarChar, "Type mismatch for field '%s': VarChar field value type must be JsonPrimitive of string, and the string length must shorter than max_length.");
+        typeErrMsg.put(DataType.Text, "Type mismatch for field '%s': Text field value type must be JsonPrimitive of string.");
         typeErrMsg.put(DataType.Array, "Type mismatch for field '%s': Array field value type must be JsonArray, each object type must be element_type, and the array length must be shorter than max_capacity.");
         typeErrMsg.put(DataType.FloatVector, "Type mismatch for field '%s': Float vector field's value type must be JsonArray of List<Float>.");
         typeErrMsg.put(DataType.BinaryVector, "Type mismatch for field '%s': Binary vector field's value type must be JsonArray of byte[].");
@@ -282,6 +284,16 @@ public class ParamUtils {
                     }
                 }
                 break;
+            case Text:
+                for (Object value : values) {
+                    if (checkNullableFieldData(fieldSchema, value, verifyElementType)) {
+                        continue;
+                    }
+                    if (!(value instanceof String)) {
+                        throw new ParamException(String.format(errMsgs.get(dataType), fieldSchema.getName()));
+                    }
+                }
+                break;
             case JSON:
                 for (Object value : values) {
                     if (checkNullableFieldData(fieldSchema, value, verifyElementType)) {
@@ -436,6 +448,11 @@ public class ParamUtils {
                     throw new ParamException(String.format(errMsgs.get(dataType), fieldName));
                 }
                 return str; // return String for genFieldData()
+            case Text:
+                if (!(value.isJsonPrimitive()) || !value.getAsJsonPrimitive().isString()) {
+                    throw new ParamException(String.format(errMsgs.get(dataType), fieldName));
+                }
+                return value.getAsString();
             case JSON:
                 return value; // return JsonElement for genFieldData()
             case Array:
@@ -476,6 +493,18 @@ public class ParamUtils {
                 case VarChar:
                     return JsonUtils.fromJson(jsonArray, new TypeToken<List<String>>() {
                     }.getType());
+                case Text:
+                    List<Object> texts = new ArrayList<>(jsonArray.size());
+                    for (JsonElement element : jsonArray) {
+                        if (element.isJsonNull() || !element.isJsonPrimitive()
+                                || !element.getAsJsonPrimitive().isString()) {
+                            throw new ParamException(String.format(
+                                    "Type mismatch for field '%s': Text array elements must be non-null strings.",
+                                    fieldName));
+                        }
+                        texts.add(element.getAsString());
+                    }
+                    return texts;
                 default:
                     throw new ParamException(String.format("Unsupported element type of Array field '%s'", fieldName));
             }
@@ -1441,6 +1470,7 @@ public class ParamUtils {
             }
             case String:
             case VarChar:
+            case Text:
             case Timestamptz: {
                 List<String> strings = objects.stream().map(p -> (p == null) ? null : (String) p).collect(Collectors.toList());
                 StringArray stringArray = StringArray.newBuilder().addAllData(strings).build();
@@ -1590,6 +1620,7 @@ public class ParamUtils {
                 break;
             case VarChar:
             case String:
+            case Text:
             case Geometry:
             case Timestamptz:
                 if (obj instanceof String) {
@@ -1628,6 +1659,7 @@ public class ParamUtils {
                 return value.getBoolData();
             case VarChar:
             case String:
+            case Text:
             case Geometry:
             case Timestamptz:
                 return value.getStringData();

--- a/sdk-core/src/main/java/io/milvus/response/FieldDataWrapper.java
+++ b/sdk-core/src/main/java/io/milvus/response/FieldDataWrapper.java
@@ -188,6 +188,7 @@ public class FieldDataWrapper {
                 return fieldData.getScalars().getDoubleData().getDataCount();
             case VarChar:
             case String:
+            case Text:
             case Timestamptz:
                 return fieldData.getScalars().getStringData().getDataCount();
             case Geometry:
@@ -226,6 +227,7 @@ public class FieldDataWrapper {
      * Float field returns List of Float
      * Double field returns List of Double
      * Varchar field returns List of String
+     * Text field returns List of String
      * Array field returns List of List
      * JSON field returns List of String;
      * Struct field returns List of List<Map<String, Object>>
@@ -264,6 +266,7 @@ public class FieldDataWrapper {
             case Double:
             case VarChar:
             case String:
+            case Text:
             case Geometry:
             case Timestamptz:
             case JSON:
@@ -384,6 +387,7 @@ public class FieldDataWrapper {
                 return setNoneData(scalar.getDoubleData().getDataList(), validData);
             case VarChar:
             case String:
+            case Text:
             case Timestamptz: {
                 ProtocolStringList protoStrList = scalar.getStringData().getDataList();
                 return setNoneData(protoStrList.subList(0, protoStrList.size()), validData);

--- a/sdk-core/src/main/java/io/milvus/v2/common/DataType.java
+++ b/sdk-core/src/main/java/io/milvus/v2/common/DataType.java
@@ -37,6 +37,7 @@ public enum DataType {
     Array(22),
     JSON(23),
     Geometry(24),
+    Text(25),
     Timestamptz(26),
 
     BinaryVector(100),

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/InsertReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/InsertReq.java
@@ -30,7 +30,7 @@ public class InsertReq {
      * Sets the row data to insert. The rows list cannot be empty.
      * <p>
      * Internal class for insert data.
-     * If dataType is Bool/Int8/Int16/Int32/Int64/Float/Double/Varchar/Geometry/Timestamptz, use JsonObject.addProperty(key, value) to input;
+     * If dataType is Bool/Int8/Int16/Int32/Int64/Float/Double/Varchar/Text/Geometry/Timestamptz, use JsonObject.addProperty(key, value) to input;
      * If dataType is FloatVector, use JsonObject.add(key, gson.toJsonTree(List[Float]) to input;
      * If dataType is BinaryVector/Float16Vector/BFloat16Vector/Int8Vector, use JsonObject.add(key, gson.toJsonTree(byte[])) to input;
      * If dataType is SparseFloatVector, use JsonObject.add(key, gson.toJsonTree(SortedMap[Long, Float])) to input;

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/UpsertReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/UpsertReq.java
@@ -28,7 +28,7 @@ public class UpsertReq {
      * Sets the row data to insert. The rows list cannot be empty.
      * <p>
      * Internal class for insert data.
-     * If dataType is Bool/Int8/Int16/Int32/Int64/Float/Double/Varchar/Geometry/Timestamptz, use JsonObject.addProperty(key, value) to input;
+     * If dataType is Bool/Int8/Int16/Int32/Int64/Float/Double/Varchar/Text/Geometry/Timestamptz, use JsonObject.addProperty(key, value) to input;
      * If dataType is FloatVector, use JsonObject.add(key, gson.toJsonTree(List[Float]) to input;
      * If dataType is BinaryVector/Float16Vector/BFloat16Vector, use JsonObject.add(key, gson.toJsonTree(byte[])) to input;
      * If dataType is SparseFloatVector, use JsonObject.add(key, gson.toJsonTree(SortedMap[Long, Float])) to input;

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
@@ -2021,6 +2021,106 @@ class MilvusClientV2DockerTest {
     }
 
     @Test
+    void testText() {
+        String collectionName = generator.generate(10);
+        String longText = String.join("", Collections.nCopies(70000, "x"));
+        List<Float> vector = utils.generateFloatVector();
+
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("vector")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("body")
+                .dataType(DataType.Text)
+                .enableAnalyzer(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("sparse")
+                .dataType(DataType.SparseFloatVector)
+                .build());
+        schema.addFunction(CreateCollectionReq.Function.builder()
+                .name("body_bm25")
+                .functionType(FunctionType.BM25)
+                .inputFieldNames(Collections.singletonList("body"))
+                .outputFieldNames(Collections.singletonList("sparse"))
+                .build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .build());
+        client.addCollectionField(AddCollectionFieldReq.builder()
+                .collectionName(collectionName)
+                .fieldName("added_text")
+                .dataType(DataType.Text)
+                .isNullable(true)
+                .build());
+
+        DescribeCollectionResp describeResp = client.describeCollection(DescribeCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        Assertions.assertEquals(DataType.Text, describeResp.getCollectionSchema().getField("body").getDataType());
+        Assertions.assertEquals(DataType.Text, describeResp.getCollectionSchema().getField("added_text").getDataType());
+        Assertions.assertEquals("body_bm25",
+                describeResp.getCollectionSchema().getFunctionList().get(0).getName());
+
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Arrays.asList(
+                        IndexParam.builder()
+                                .fieldName("vector")
+                                .indexType(IndexParam.IndexType.HNSW)
+                                .metricType(IndexParam.MetricType.COSINE)
+                                .build(),
+                        IndexParam.builder()
+                                .fieldName("sparse")
+                                .indexType(IndexParam.IndexType.SPARSE_INVERTED_INDEX)
+                                .metricType(IndexParam.MetricType.BM25)
+                                .build()))
+                .build());
+        client.loadCollection(LoadCollectionReq.builder().collectionName(collectionName).build());
+
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 1L);
+        row.add("vector", JsonUtils.toJsonTree(vector));
+        row.addProperty("body", longText);
+        client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(Collections.singletonList(row))
+                .build());
+
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id == 1")
+                .outputFields(Collections.singletonList("body"))
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        Map<String, Object> queryEntity = queryResp.getQueryResults().get(0).getEntity();
+        Assertions.assertEquals(longText, queryEntity.get("body"));
+
+        SearchResp searchResp = client.search(SearchReq.builder()
+                .collectionName(collectionName)
+                .annsField("vector")
+                .data(Collections.singletonList(new FloatVec(vector)))
+                .limit(1)
+                .outputFields(Collections.singletonList("body"))
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        Map<String, Object> searchEntity = searchResp.getSearchResults().get(0).get(0).getEntity();
+        Assertions.assertEquals(longText, searchEntity.get("body"));
+
+        client.dropCollection(DropCollectionReq.builder().collectionName(collectionName).build());
+    }
+
+    @Test
     void testDeleteUpsert() {
         String randomCollectionName = generator.generate(10);
 

--- a/sdk-core/src/test/java/io/milvus/v2/utils/TextDataTypeTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/TextDataTypeTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.utils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
+import io.milvus.exception.ParamException;
+import io.milvus.grpc.ArrayArray;
+import io.milvus.grpc.FieldData;
+import io.milvus.grpc.FieldSchema;
+import io.milvus.grpc.IDs;
+import io.milvus.grpc.LongArray;
+import io.milvus.grpc.QueryResults;
+import io.milvus.grpc.ScalarField;
+import io.milvus.grpc.SearchResultData;
+import io.milvus.grpc.StringArray;
+import io.milvus.grpc.StructArrayField;
+import io.milvus.grpc.StructArrayFieldSchema;
+import io.milvus.param.ParamUtils;
+import io.milvus.param.collection.FieldType;
+import io.milvus.response.FieldDataWrapper;
+import io.milvus.response.QueryResultsWrapper;
+import io.milvus.response.SearchResultsWrapper;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.AddCollectionStructFieldReq;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+class TextDataTypeTest {
+
+    @Test
+    void convertsTextSchemaWithoutVarcharLengthConstraint() {
+        CreateCollectionReq.FieldSchema textField = CreateCollectionReq.FieldSchema.builder()
+                .name("body")
+                .dataType(DataType.Text)
+                .maxLength(1)
+                .defaultValue("long default text")
+                .enableAnalyzer(true)
+                .build();
+
+        FieldSchema grpcField = SchemaUtils.convertToGrpcFieldSchema(textField);
+
+        Assertions.assertEquals(io.milvus.grpc.DataType.Text, grpcField.getDataType());
+        Assertions.assertEquals("long default text", grpcField.getDefaultValue().getStringData());
+        Assertions.assertTrue(grpcField.getTypeParamsList().stream()
+                .noneMatch(pair -> pair.getKey().equals("max_length")));
+        Assertions.assertEquals(DataType.Text, SchemaUtils.convertFromGrpcFieldSchema(grpcField).getDataType());
+    }
+
+    @Test
+    void convertsTextArrayAndStructSubField() {
+        CreateCollectionReq.FieldSchema textArray = CreateCollectionReq.FieldSchema.builder()
+                .name("paragraphs")
+                .dataType(DataType.Array)
+                .elementType(DataType.Text)
+                .maxCapacity(10)
+                .maxLength(1)
+                .build();
+
+        FieldSchema grpcArray = SchemaUtils.convertToGrpcFieldSchema(textArray);
+        Assertions.assertEquals(io.milvus.grpc.DataType.Array, grpcArray.getDataType());
+        Assertions.assertEquals(io.milvus.grpc.DataType.Text, grpcArray.getElementType());
+        Assertions.assertTrue(grpcArray.getTypeParamsList().stream()
+                .noneMatch(pair -> pair.getKey().equals("max_length")));
+
+        CreateCollectionReq.StructFieldSchema structField = CreateCollectionReq.StructFieldSchema.builder()
+                .name("chunks")
+                .maxCapacity(20)
+                .fields(Collections.singletonList(CreateCollectionReq.FieldSchema.builder()
+                        .name("content")
+                        .dataType(DataType.Text)
+                        .build()))
+                .build();
+
+        StructArrayFieldSchema grpcStruct = SchemaUtils.convertToGrpcStructFieldSchema(structField);
+        Assertions.assertEquals(io.milvus.grpc.DataType.Array, grpcStruct.getFields(0).getDataType());
+        Assertions.assertEquals(io.milvus.grpc.DataType.Text, grpcStruct.getFields(0).getElementType());
+
+        AddCollectionStructFieldReq addStructFieldReq = AddCollectionStructFieldReq.builder()
+                .collectionName("collection")
+                .fieldName("chunks")
+                .maxCapacity(20)
+                .addStructField(AddFieldReq.builder()
+                        .fieldName("content")
+                        .dataType(DataType.Text)
+                        .build())
+                .build();
+        StructArrayFieldSchema grpcAddStruct = SchemaUtils.convertToGrpcStructFieldSchema(
+                addStructFieldReq.toStructFieldSchema());
+        Assertions.assertEquals(io.milvus.grpc.DataType.Text, grpcAddStruct.getFields(0).getElementType());
+    }
+
+    @Test
+    void acceptsAndDecodesTextWithoutMaxLengthValidation() {
+        String longText = String.join("", Collections.nCopies(1024, "text"));
+        CreateCollectionReq.FieldSchema textField = CreateCollectionReq.FieldSchema.builder()
+                .name("body")
+                .dataType(DataType.Text)
+                .maxLength(1)
+                .build();
+
+        Assertions.assertEquals(longText, DataUtils.checkFieldValue(textField, new JsonPrimitive(longText)));
+        Assertions.assertThrows(ParamException.class,
+                () -> DataUtils.checkFieldValue(textField, new JsonPrimitive(10)));
+
+        ScalarField scalarField = ParamUtils.genScalarField(
+                io.milvus.grpc.DataType.Text,
+                io.milvus.grpc.DataType.None,
+                Arrays.asList("first", "second"));
+        FieldData fieldData = FieldData.newBuilder()
+                .setType(io.milvus.grpc.DataType.Text)
+                .setFieldName("body")
+                .setScalars(scalarField)
+                .build();
+
+        FieldDataWrapper wrapper = new FieldDataWrapper(fieldData);
+        Assertions.assertEquals(2, wrapper.getRowCount());
+        Assertions.assertEquals(Arrays.asList("first", "second"), wrapper.getFieldData());
+    }
+
+    @Test
+    void decodesArrayOfText() {
+        ScalarField row = ScalarField.newBuilder()
+                .setStringData(StringArray.newBuilder().addData("first").addData("second"))
+                .build();
+        FieldData fieldData = FieldData.newBuilder()
+                .setType(io.milvus.grpc.DataType.Array)
+                .setFieldName("paragraphs")
+                .setScalars(ScalarField.newBuilder().setArrayData(ArrayArray.newBuilder()
+                        .setElementType(io.milvus.grpc.DataType.Text)
+                        .addData(row)))
+                .build();
+
+        Assertions.assertEquals(Collections.singletonList(Arrays.asList("first", "second")),
+                new FieldDataWrapper(fieldData).getFieldData());
+    }
+
+    @Test
+    void supportsTextInV1FieldAndArrayValidation() {
+        String longText = String.join("", Collections.nCopies(1024, "text"));
+        FieldType textField = FieldType.newBuilder()
+                .withName("body")
+                .withDataType(io.milvus.grpc.DataType.Text)
+                .build();
+        ParamUtils.checkFieldData(textField, Collections.singletonList(longText), false);
+
+        FieldType textArray = FieldType.newBuilder()
+                .withName("paragraphs")
+                .withDataType(io.milvus.grpc.DataType.Array)
+                .withElementType(io.milvus.grpc.DataType.Text)
+                .withMaxCapacity(10)
+                .build();
+        ParamUtils.checkFieldData(textArray,
+                Collections.singletonList(Arrays.asList(longText, "second")), false);
+    }
+
+    @Test
+    void validatesEveryJsonTextArrayElement() {
+        JsonArray valid = new JsonArray();
+        valid.add("first");
+        valid.add("second");
+        Assertions.assertEquals(Arrays.asList("first", "second"),
+                ParamUtils.convertJsonArray(valid, io.milvus.grpc.DataType.Text, "paragraphs"));
+
+        JsonArray number = new JsonArray();
+        number.add("first");
+        number.add(10);
+        Assertions.assertThrows(ParamException.class,
+                () -> ParamUtils.convertJsonArray(number, io.milvus.grpc.DataType.Text, "paragraphs"));
+
+        JsonArray bool = new JsonArray();
+        bool.add("first");
+        bool.add(true);
+        Assertions.assertThrows(ParamException.class,
+                () -> ParamUtils.convertJsonArray(bool, io.milvus.grpc.DataType.Text, "paragraphs"));
+
+        JsonArray nullable = new JsonArray();
+        nullable.add("first");
+        nullable.add((String) null);
+        Assertions.assertThrows(ParamException.class,
+                () -> ParamUtils.convertJsonArray(nullable, io.milvus.grpc.DataType.Text, "paragraphs"));
+    }
+
+    @Test
+    void decodesTextFromQueryAndSearchResults() {
+        FieldData textData = FieldData.newBuilder()
+                .setType(io.milvus.grpc.DataType.Text)
+                .setFieldName("body")
+                .setScalars(ScalarField.newBuilder().setStringData(
+                        StringArray.newBuilder().addData("first").addData("second")))
+                .build();
+
+        QueryResults queryResults = QueryResults.newBuilder()
+                .addOutputFields("body")
+                .addFieldsData(textData)
+                .build();
+        List<QueryResultsWrapper.RowRecord> queryRows = new QueryResultsWrapper(queryResults).getRowRecords();
+        Assertions.assertEquals("first", queryRows.get(0).get("body"));
+        Assertions.assertEquals("second", queryRows.get(1).get("body"));
+
+        SearchResultData searchResultData = SearchResultData.newBuilder()
+                .setNumQueries(1)
+                .setTopK(2)
+                .addTopks(2)
+                .addScores(1.0f)
+                .addScores(0.5f)
+                .setIds(IDs.newBuilder().setIntId(LongArray.newBuilder().addData(1L).addData(2L)))
+                .setPrimaryFieldName("id")
+                .addOutputFields("body")
+                .addFieldsData(textData)
+                .build();
+        List<QueryResultsWrapper.RowRecord> searchRows = new SearchResultsWrapper(searchResultData).getRowRecords(0);
+        Assertions.assertEquals("first", searchRows.get(0).get("body"));
+        Assertions.assertEquals("second", searchRows.get(1).get("body"));
+    }
+
+    @Test
+    void decodesTextStructSubField() {
+        ScalarField contentRow = ScalarField.newBuilder()
+                .setStringData(StringArray.newBuilder().addData("first").addData("second"))
+                .build();
+        FieldData contentField = FieldData.newBuilder()
+                .setType(io.milvus.grpc.DataType.Array)
+                .setFieldName("content")
+                .setScalars(ScalarField.newBuilder().setArrayData(ArrayArray.newBuilder()
+                        .setElementType(io.milvus.grpc.DataType.Text)
+                        .addData(contentRow)))
+                .build();
+        FieldData chunksField = FieldData.newBuilder()
+                .setType(io.milvus.grpc.DataType.ArrayOfStruct)
+                .setFieldName("chunks")
+                .setStructArrays(StructArrayField.newBuilder().addFields(contentField))
+                .build();
+
+        List<Map<String, Object>> expectedStructs = Arrays.asList(
+                Collections.singletonMap("content", "first"),
+                Collections.singletonMap("content", "second"));
+        Assertions.assertEquals(Collections.singletonList(expectedStructs),
+                new FieldDataWrapper(chunksField).getFieldData());
+    }
+}


### PR DESCRIPTION
## What
- expose `DataType.Text` in the V2 Java SDK
- align scalar Text value handling with PyMilvus: use `string_data` without VARCHAR `max_length` validation
- preserve PyMilvus-compatible protocol encoding/decoding for Text array and struct sub-fields while leaving schema capability validation to Milvus
- strictly validate every JSON `Array<Text>` element as a non-null string
- support scalar Text defaults, query/search decoding, and BulkWriter JSON/CSV/Parquet flows

## Tests
- `mvn -pl sdk-core -Dtest=TextDataTypeTest test`
- `mvn -pl sdk-bulkwriter -am -Dtest=BulkWriterTest -Dsurefire.failIfNoSpecifiedTests=false test`