### PR TITLE
Dump gRPC and protobuf versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,11 @@ target/
 volumes/
 *.iml
 .flattened-pom.xml
+dependency-reduced-pom.xml
+META-INF/
 
 # Example files
 examples/bulk_writer
 examples/src/main/resources/tls/*
 !examples/src/main/resources/tls/gen.sh
 !examples/src/main/resources/tls/openssl.cnf
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ version: '3.5'
 services:
   standalone:
     container_name: milvus-javasdk-standalone-1
-    image: milvusdb/milvus:v2.5.18
+    image: milvusdb/milvus:v2.5.27
     command: [ "milvus", "run", "standalone" ]
     environment:
       - COMMON_STORAGETYPE=local
       - DEPLOY_MODE=STANDALONE
       - ETCD_USE_EMBED=true
       - ETCD_DATA_DIR=/var/lib/milvus/etcd
-    volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus-1:/var/lib/milvus
+#    volumes:
+#      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus-1:/var/lib/milvus
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9091/healthz" ]
       interval: 30s
@@ -24,15 +24,15 @@ services:
 
   standaloneslave:
     container_name: milvus-javasdk-standalone-2
-    image: milvusdb/milvus:v2.5.18
+    image: milvusdb/milvus:v2.5.27
     command: [ "milvus", "run", "standalone" ]
     environment:
       - COMMON_STORAGETYPE=local
       - DEPLOY_MODE=STANDALONE
       - ETCD_USE_EMBED=true
       - ETCD_DATA_DIR=/var/lib/milvus/etcd
-    volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus-2:/var/lib/milvus
+#    volumes:
+#      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus-2:/var/lib/milvus
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9091/healthz" ]
       interval: 30s

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,60 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${errorprone.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <properties>
         <revision>2.5.15</revision>
         <maven.compiler.source>8</maven.compiler.source>
@@ -89,9 +143,9 @@
         <skip.maven.deploy>false</skip.maven.deploy>
 
         <!--for Core-->
-        <grpc.version>1.59.1</grpc.version>
-        <protobuf.version>3.25.5</protobuf.version>
-        <protoc.version>3.25.5</protoc.version>
+        <grpc.version>1.75.0</grpc.version>
+        <protobuf.version>3.25.8</protobuf.version>
+        <protoc.version>3.25.8</protoc.version>
         <commons-collections4.version>4.3</commons-collections4.version>
         <versio.maven.deploy.plugin>2.8.2</versio.maven.deploy.plugin>
         <versio.maven.source.plugin>3.2.1</versio.maven.source.plugin>
@@ -118,7 +172,7 @@
         <mockito.version>4.11.0</mockito.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <apache.commons.pool2.version>2.12.0</apache.commons.pool2.version>
-        <guava.version>32.1.3-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
         <errorprone.version>2.38.0</errorprone.version>
 
         <!--for BulkWriter-->
@@ -207,7 +261,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/sdk-bulkwriter/pom.xml
+++ b/sdk-bulkwriter/pom.xml
@@ -19,60 +19,6 @@
         <skip.maven.deploy>false</skip.maven.deploy>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>${grpc.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>${errorprone.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.milvus</groupId>

--- a/sdk-core/pom.xml
+++ b/sdk-core/pom.xml
@@ -19,55 +19,6 @@
         <skip.maven.deploy>false</skip.maven.deploy>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>${grpc.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>${errorprone.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -177,4 +128,75 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${project.basedir}/.flattened-pom.xml</dependencyReducedPomLocation>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.grpc:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.grpc</pattern>
+                                    <shadedPattern>io.milvus.shaded.io.grpc</shadedPattern>
+                                    <excludes>
+                                        <exclude>io.grpc.netty.shaded.io.grpc.netty.*</exclude>
+                                    </excludes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.grpc.netty.shaded.io.grpc.netty</pattern>
+                                    <shadedPattern>io.milvus.shaded.io.grpc.netty.shaded.io.grpc.netty</shadedPattern>
+                                    <includes>
+                                        <include>io.grpc.netty.shaded.io.grpc.netty.*</include>
+                                    </includes>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sdk-core/src/test/java/io/milvus/TestUtils.java
+++ b/sdk-core/src/test/java/io/milvus/TestUtils.java
@@ -10,7 +10,7 @@ import java.util.*;
 public class TestUtils {
     private int dimension = 256;
     private static final Random RANDOM = new Random();
-    public static final String MilvusDockerImageID = "milvusdb/milvus:v2.5.18";
+    public static final String MilvusDockerImageID = "milvusdb/milvus:v2.5.27";
 
     public TestUtils(int dimension) {
         this.dimension = dimension;


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus-sdk-java/issues/1926
Upgrades gRPC to 1.75.0 with aligned Protobuf and Guava versions, adopts centralized dependency management and
  gRPC shading for safer publishing, and updates Docker tests to Milvus v2.5.27.