### PR TITLE
feat: add FMINDEX to IndexParam.IndexType

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
+++ b/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
@@ -214,6 +214,12 @@ public class IndexParam {
         // From Milvus 2.5.4 onward, SPARSE_WAND is being deprecated. Instead, it is recommended to
         // use "inverted_index_algo": "DAAT_WAND" for equivalency while maintaining compatibility.
         SPARSE_WAND(301),
+
+        // Appended at the tail rather than grouped with the other varchar-only
+        // types: new constants go on the end so no existing entry shifts.
+        // Only for varchar type field. Exact byte-level substring index that
+        // answers anchored LIKE (prefix/infix/suffix) with no candidate recheck.
+        FMINDEX(102),
         ;
 
         private final String name;


### PR DESCRIPTION
Closes #1980.

`FMINDEX` is a new scalar index type on the Milvus server (scalar index engine
version 5, merged in milvus-io/milvus#51375): an exact byte-level substring index
for VARCHAR that answers anchored `LIKE` — prefix, infix and suffix — with no
candidate recheck.

This is a hard block rather than a convenience gap. `IndexParam.indexType` is a
closed enum with no `String` overload, and `IndexService` sends
`indexParam.getIndexType().getName()`, so there is no way to produce that name
without an enum constant — a Java user simply cannot create an FMINDEX today. It
also affects the read path: `DescribeIndexResp.IndexDesc.getIndexType()` cannot
report a type the enum does not contain.

`102` follows `NGRAM(101)` in the varchar-only block. The code is SDK-internal —
only `getName()` reaches the server — and collides with nothing.

Build params are optional and travel through the usual `extraParams` map:
`fm_sa_sample_rate` (4..256, server default 8) and `fm_block_bytes` (a power of two
in 8..128, server default 64). VARCHAR only in this release.

For context, this came out of an audit across all six Milvus clients. This SDK is in
good shape otherwise — it already has `NGRAM`, `HNSW_SQ/PQ/PRQ` and `AISAQ`;
`FMINDEX` is the only index type it was missing.
