### PR TITLE
[cherry-pick] feat: add FMINDEX to IndexParam.IndexType (#1983)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
+++ b/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
@@ -214,6 +214,12 @@ public class IndexParam {
         // From Milvus 2.5.4 onward, SPARSE_WAND is being deprecated. Instead, it is recommended to
         // use "inverted_index_algo": "DAAT_WAND" for equivalency while maintaining compatibility.
         SPARSE_WAND(301),
+
+        // Appended at the tail rather than grouped with the other varchar-only
+        // types: new constants go on the end so no existing entry shifts.
+        // Only for varchar type field. Exact byte-level substring index that
+        // answers anchored LIKE (prefix/infix/suffix) with no candidate recheck.
+        FMINDEX(102),
         ;
 
         private final String name;


### PR DESCRIPTION
FMINDEX is a new scalar index type on the Milvus server (scalar index engine version 5): an exact byte-level substring index for VARCHAR that answers anchored LIKE — prefix, infix and suffix — with no candidate recheck.

Because IndexParam.indexType is a closed enum with no String overload, a Java user currently cannot create one at all: IndexService sends indexParam.getIndexType().getName(), and there is no way to produce that name without an enum constant. Adding it also lets DescribeIndexResp.IndexDesc.getIndexType() report the type back correctly.

102 follows NGRAM(101) in the varchar-only block. The code is SDK-internal (only getName() reaches the server) and does not collide with any existing value.

Build params are optional and go through the usual extraParams map: fm_sa_sample_rate (4..256, server default 8) and fm_block_bytes (a power of two in 8..128, server default 64).