### PR TITLE
Redact credentials from connection configuration logs

### DIFF
--- a/sdk-core/src/main/java/io/milvus/common/utils/RedactCredential.java
+++ b/sdk-core/src/main/java/io/milvus/common/utils/RedactCredential.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.common.utils;
+
+public final class RedactCredential {
+    private static final String REDACTED_CREDENTIAL = "<redacted>";
+
+    private RedactCredential() {
+    }
+
+    public static String redactCredential(String credential) {
+        return credential == null ? null : REDACTED_CREDENTIAL;
+    }
+
+    public static String redactUriUserInfo(String uri) {
+        return uri == null ? null : uri.replaceAll(
+                "^([^:/?#]+://)?[^/?#]*@", "$1" + REDACTED_CREDENTIAL + "@");
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
@@ -32,6 +32,8 @@ import java.util.regex.Pattern;
 
 import static io.milvus.common.constant.MilvusClientConstant.MilvusConsts.CLOUD_SERVERLESS_URI_REGEX;
 import static io.milvus.common.constant.MilvusClientConstant.MilvusConsts.HOST_HTTPS_PREFIX;
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
 
 /**
  * Parameters for client connection.
@@ -186,8 +188,8 @@ public class ConnectParam {
                 "host='" + host + '\'' +
                 ", port=" + port +
                 ", databaseName='" + databaseName + '\'' +
-                ", uri='" + uri + '\'' +
-                ", token='" + token + '\'' +
+                ", uri='" + redactUriUserInfo(uri) + '\'' +
+                ", token='" + redactCredential(token) + '\'' +
                 ", connectTimeoutMs=" + connectTimeoutMs +
                 ", keepAliveTimeMs=" + keepAliveTimeMs +
                 ", keepAliveTimeoutMs=" + keepAliveTimeoutMs +
@@ -195,7 +197,7 @@ public class ConnectParam {
                 ", rpcDeadlineMs=" + rpcDeadlineMs +
                 ", secure=" + secure +
                 ", idleTimeoutMs=" + idleTimeoutMs +
-                ", authorization='" + authorization + '\'' +
+                ", authorization='" + redactCredential(authorization) + '\'' +
                 ", clientKeyPath='" + clientKeyPath + '\'' +
                 ", clientPemPath='" + clientPemPath + '\'' +
                 ", caPemPath='" + caPemPath + '\'' +

--- a/sdk-core/src/main/java/io/milvus/param/credential/CreateCredentialParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/credential/CreateCredentialParam.java
@@ -22,6 +22,8 @@ package io.milvus.param.credential;
 import io.milvus.exception.ParamException;
 import io.milvus.param.ParamUtils;
 
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+
 public class CreateCredentialParam {
     private final String username;
     private final String password;
@@ -52,7 +54,7 @@ public class CreateCredentialParam {
     public String toString() {
         return "CreateCredentialParam{" +
                 "username='" + username + '\'' +
-                ", password='" + password + '\'' +
+                ", password='" + redactCredential(password) + '\'' +
                 '}';
     }
 

--- a/sdk-core/src/main/java/io/milvus/param/credential/UpdateCredentialParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/credential/UpdateCredentialParam.java
@@ -22,6 +22,8 @@ package io.milvus.param.credential;
 import io.milvus.exception.ParamException;
 import io.milvus.param.ParamUtils;
 
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+
 public class UpdateCredentialParam {
     private final String username;
     private final String oldPassword;
@@ -58,8 +60,8 @@ public class UpdateCredentialParam {
     public String toString() {
         return "UpdateCredentialParam{" +
                 "username='" + username + '\'' +
-                ", oldPassword='" + oldPassword + '\'' +
-                ", newPassword='" + newPassword + '\'' +
+                ", oldPassword='" + redactCredential(oldPassword) + '\'' +
+                ", newPassword='" + redactCredential(newPassword) + '\'' +
                 '}';
     }
 

--- a/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static io.milvus.common.constant.MilvusClientConstant.MilvusConsts.CLOUD_SERVERLESS_URI_REGEX;
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
 
 public class ConnectConfig {
     private String uri;
@@ -305,10 +307,10 @@ public class ConnectConfig {
     @Override
     public String toString() {
         return "ConnectConfig{" +
-                "uri='" + uri + '\'' +
-                ", token='" + token + '\'' +
+                "uri='" + redactUriUserInfo(uri) + '\'' +
+                ", token='" + redactCredential(token) + '\'' +
                 ", username='" + username + '\'' +
-                ", password='" + password + '\'' +
+                ", password='" + redactCredential(password) + '\'' +
                 ", dbName='" + dbName + '\'' +
                 ", connectTimeoutMs=" + connectTimeoutMs +
                 ", keepAliveTimeMs=" + keepAliveTimeMs +

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -92,6 +92,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
+
 /**
  * Client for interacting with Milvus through the V2 API.
  *
@@ -181,7 +183,7 @@ public class MilvusClientV2 {
 
         // Check if this is a global cluster endpoint
         if (GlobalClusterUtils.isGlobalEndpoint(connectConfig.getUri())) {
-            logger.info("Detected global cluster endpoint: {}", connectConfig.getUri());
+            logger.info("Detected global cluster endpoint: {}", redactUriUserInfo(connectConfig.getUri()));
             this.globalStub = new GlobalStub(connectConfig.getUri(), connectConfig, this::updatePrimaryConnection);
             updatePrimaryConnection(this.globalStub.getPrimaryClient());
             // Set up the global refresh trigger on RpcUtils for UNAVAILABLE errors

--- a/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/GlobalStub.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/GlobalStub.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
+
 public class GlobalStub {
     private static final Logger logger = LoggerFactory.getLogger(GlobalStub.class);
 
@@ -51,7 +53,7 @@ public class GlobalStub {
         this.topology = GlobalClusterUtils.fetchTopology(globalEndpoint, authorization);
         ClusterInfo primary = this.topology.getPrimary();
         this.primaryEndpoint = primary.getEndpoint();
-        logger.info("Global cluster: discovered primary endpoint: {}", primaryEndpoint);
+        logger.info("Global cluster: discovered primary endpoint: {}", redactUriUserInfo(primaryEndpoint));
 
         this.innerClient = createClientForEndpoint(primaryEndpoint);
 
@@ -102,12 +104,14 @@ public class GlobalStub {
             String newEndpoint = newPrimary.getEndpoint();
 
             if (newEndpoint.equals(this.primaryEndpoint)) {
-                logger.info("Global cluster: topology version changed but primary endpoint unchanged: {}", newEndpoint);
+                logger.info("Global cluster: topology version changed but primary endpoint unchanged: {}",
+                        redactUriUserInfo(newEndpoint));
                 this.topology = newTopology;
                 return;
             }
 
-            logger.info("Global cluster: primary endpoint changed from {} to {}", this.primaryEndpoint, newEndpoint);
+            logger.info("Global cluster: primary endpoint changed from {} to {}",
+                    redactUriUserInfo(this.primaryEndpoint), redactUriUserInfo(newEndpoint));
 
             MilvusClientV2 oldClient = this.innerClient;
             MilvusClientV2 newClient = createClientForEndpoint(newEndpoint);

--- a/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/TopologyRefresher.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/TopologyRefresher.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
+
 public class TopologyRefresher {
     private static final Logger logger = LoggerFactory.getLogger(TopologyRefresher.class);
     private static final long REFRESH_INTERVAL_MINUTES = 5;
@@ -57,7 +59,7 @@ public class TopologyRefresher {
         scheduler.scheduleWithFixedDelay(this::refresh, REFRESH_INTERVAL_MINUTES,
                 REFRESH_INTERVAL_MINUTES, TimeUnit.MINUTES);
         logger.info("Global topology refresher started with {}min interval for endpoint: {}",
-                REFRESH_INTERVAL_MINUTES, globalEndpoint);
+                REFRESH_INTERVAL_MINUTES, redactUriUserInfo(globalEndpoint));
     }
 
     public void triggerRefresh() {
@@ -75,7 +77,7 @@ public class TopologyRefresher {
 
     public void stop() {
         scheduler.shutdownNow();
-        logger.info("Global topology refresher stopped for endpoint: {}", globalEndpoint);
+        logger.info("Global topology refresher stopped for endpoint: {}", redactUriUserInfo(globalEndpoint));
     }
 
     private void refreshWithCleanup() {

--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/MilvusCluster.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/request/MilvusCluster.java
@@ -22,6 +22,9 @@ package io.milvus.v2.service.cdc.request;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
+
 public class MilvusCluster {
     private String clusterId;
     private String uri;
@@ -97,8 +100,8 @@ public class MilvusCluster {
     public String toString() {
         return "MilvusCluster{" +
                 "clusterId='" + clusterId + '\'' +
-                ", uri='" + uri + '\'' +
-                ", token='" + token + '\'' +
+                ", uri='" + redactUriUserInfo(uri) + '\'' +
+                ", token='" + redactCredential(token) + '\'' +
                 ", pchannels=" + pchannels +
                 '}';
     }

--- a/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/CreateUserReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/CreateUserReq.java
@@ -19,6 +19,8 @@
 
 package io.milvus.v2.service.rbac.request;
 
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+
 public class CreateUserReq {
     private String userName;
     private String password;
@@ -58,7 +60,7 @@ public class CreateUserReq {
     public String toString() {
         return "CreateUserReq{" +
                 "userName='" + userName + '\'' +
-                ", password='" + password + '\'' +
+                ", password='" + redactCredential(password) + '\'' +
                 ", description='" + description + '\'' +
                 '}';
     }

--- a/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/UpdatePasswordReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/rbac/request/UpdatePasswordReq.java
@@ -19,6 +19,8 @@
 
 package io.milvus.v2.service.rbac.request;
 
+import static io.milvus.common.utils.RedactCredential.redactCredential;
+
 public class UpdatePasswordReq {
     private String userName;
     private String password;
@@ -78,8 +80,8 @@ public class UpdatePasswordReq {
     public String toString() {
         return "UpdatePasswordReq{" +
                 "userName='" + userName + '\'' +
-                ", password='" + password + '\'' +
-                ", newPassword='" + newPassword + '\'' +
+                ", password='" + redactCredential(password) + '\'' +
+                ", newPassword='" + redactCredential(newPassword) + '\'' +
                 ", resetConnection=" + resetConnection +
                 ", description='" + description + '\'' +
                 '}';

--- a/sdk-core/src/test/java/io/milvus/param/CredentialRedactionTest.java
+++ b/sdk-core/src/test/java/io/milvus/param/CredentialRedactionTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.param;
+
+import io.milvus.param.credential.CreateCredentialParam;
+import io.milvus.param.credential.DeleteCredentialParam;
+import io.milvus.param.credential.UpdateCredentialParam;
+import io.milvus.v2.service.cdc.request.MilvusCluster;
+import io.milvus.v2.service.rbac.request.CreateUserReq;
+import io.milvus.v2.service.rbac.request.UpdatePasswordReq;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CredentialRedactionTest {
+    @Test
+    void globalClusterEndpointLoggingRedactsUriUserInfo() {
+        String loggedEndpoint = redactUriUserInfo(
+                "https://uri-user:uri-password@foo.global-cluster.example");
+
+        assertFalse(loggedEndpoint.contains("uri-user"));
+        assertFalse(loggedEndpoint.contains("uri-password"));
+        assertEquals("https://<redacted>@foo.global-cluster.example", loggedEndpoint);
+    }
+
+    @Test
+    void uriRedactionUsesLastAtSignWithinAuthority() {
+        assertEquals("https://<redacted>@host:19530/default",
+                redactUriUserInfo("https://user:p@ss@host:19530/default"));
+    }
+
+    @Test
+    void uriRedactionIgnoresQueryAndFragmentAtSigns() {
+        String queryUri = "https://host:19530/default?owner=a@b";
+        String fragmentUri = "https://host:19530/default#owner=a@b";
+
+        assertEquals(queryUri, redactUriUserInfo(queryUri));
+        assertEquals(fragmentUri, redactUriUserInfo(fragmentUri));
+    }
+
+    @Test
+    void connectParamToStringRedactsCredentials() {
+        ConnectParam connectParam = ConnectParam.newBuilder()
+                .withUri("http://uri-user:uri-password@localhost:19530/default")
+                .withToken("sensitive-token")
+                .withAuthorization("sensitive-user", "sensitive-password")
+                .build();
+
+        assertCredentialsRedacted(connectParam.toString(),
+                "sensitive-token", "sensitive-password",
+                "uri-user", "uri-password");
+        assertTrue(connectParam.toString().contains(
+                "uri='http://<redacted>@localhost:19530/default'"));
+        assertTrue(connectParam.toString().contains("token='<redacted>'"));
+        assertTrue(connectParam.toString().contains("authorization='<redacted>'"));
+        assertTrue(connectParam.toString().contains("userName='sensitive-user'"));
+    }
+
+    @Test
+    void multiConnectParamToStringRedactsInheritedCredentials() {
+        MultiConnectParam connectParam = MultiConnectParam.newBuilder()
+                .withHosts(Collections.singletonList(ServerAddress.newBuilder().build()))
+                .withToken("sensitive-token")
+                .withAuthorization("sensitive-user", "sensitive-password")
+                .build();
+
+        assertCredentialsRedacted(connectParam.toString(),
+                "sensitive-token", "sensitive-password");
+        assertTrue(connectParam.toString().contains("userName='sensitive-user'"));
+    }
+
+    @Test
+    void credentialParamsToStringRedactsCredentials() {
+        CreateCredentialParam createParam = CreateCredentialParam.newBuilder()
+                .withUsername("sensitive-user")
+                .withPassword("sensitive-password")
+                .build();
+        UpdateCredentialParam updateParam = UpdateCredentialParam.newBuilder()
+                .withUsername("sensitive-user")
+                .withOldPassword("sensitive-old-password")
+                .withNewPassword("sensitive-new-password")
+                .build();
+        DeleteCredentialParam deleteParam = DeleteCredentialParam.newBuilder()
+                .withUsername("sensitive-user")
+                .build();
+
+        assertCredentialsRedacted(createParam.toString(),
+                "sensitive-password");
+        assertCredentialsRedacted(updateParam.toString(),
+                "sensitive-old-password", "sensitive-new-password");
+        assertTrue(createParam.toString().contains("username='sensitive-user'"));
+        assertTrue(createParam.toString().contains("password='<redacted>'"));
+        assertTrue(updateParam.toString().contains("username='sensitive-user'"));
+        assertTrue(updateParam.toString().contains("oldPassword='<redacted>'"));
+        assertTrue(updateParam.toString().contains("newPassword='<redacted>'"));
+        assertTrue(deleteParam.toString().contains("username='sensitive-user'"));
+    }
+
+    @Test
+    void v2CredentialParamsToStringRedactsSecrets() {
+        CreateUserReq createUserReq = CreateUserReq.builder()
+                .userName("sensitive-user")
+                .password("sensitive-password")
+                .build();
+        UpdatePasswordReq updatePasswordReq = UpdatePasswordReq.builder()
+                .userName("sensitive-user")
+                .password("sensitive-old-password")
+                .newPassword("sensitive-new-password")
+                .build();
+        MilvusCluster milvusCluster = MilvusCluster.builder()
+                .clusterId("cluster")
+                .uri("http://uri-user:uri-password@localhost:19530")
+                .token("sensitive-token")
+                .build();
+
+        assertCredentialsRedacted(createUserReq.toString(), "sensitive-password");
+        assertCredentialsRedacted(updatePasswordReq.toString(),
+                "sensitive-old-password", "sensitive-new-password");
+        assertCredentialsRedacted(milvusCluster.toString(),
+                "sensitive-token", "uri-user", "uri-password");
+        assertTrue(createUserReq.toString().contains("userName='sensitive-user'"));
+        assertTrue(createUserReq.toString().contains("password='<redacted>'"));
+        assertTrue(updatePasswordReq.toString().contains("userName='sensitive-user'"));
+        assertTrue(updatePasswordReq.toString().contains("password='<redacted>'"));
+        assertTrue(updatePasswordReq.toString().contains("newPassword='<redacted>'"));
+        assertTrue(milvusCluster.toString().contains(
+                "uri='http://<redacted>@localhost:19530'"));
+        assertTrue(milvusCluster.toString().contains("token='<redacted>'"));
+    }
+
+    private static void assertCredentialsRedacted(String output, String... credentials) {
+        for (String credential : credentials) {
+            assertFalse(output.contains(credential));
+        }
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -505,6 +505,29 @@ public class MilvusClientV2Test extends BaseTest {
     }
 
     @Test
+    void connectConfigToStringRedactsCredentials() {
+        ConnectConfig config = ConnectConfig.builder()
+                .uri("http://uri-user:uri-password@dummyHost:19530/default")
+                .token("sensitive-token")
+                .username("sensitive-user")
+                .password("sensitive-password")
+                .dbName("default")
+                .build();
+
+        String loggedConfig = config.toString();
+        Assertions.assertFalse(loggedConfig.contains("sensitive-token"));
+        Assertions.assertFalse(loggedConfig.contains("sensitive-password"));
+        Assertions.assertFalse(loggedConfig.contains("uri-user"));
+        Assertions.assertFalse(loggedConfig.contains("uri-password"));
+        Assertions.assertTrue(loggedConfig.contains("token='<redacted>'"));
+        Assertions.assertTrue(loggedConfig.contains("username='sensitive-user'"));
+        Assertions.assertTrue(loggedConfig.contains("password='<redacted>'"));
+        Assertions.assertTrue(loggedConfig.contains(
+                "uri='http://<redacted>@dummyHost:19530/default'"));
+        Assertions.assertTrue(loggedConfig.contains("dbName='default'"));
+    }
+
+    @Test
     void testV2BuilderClasses() {
         CheckConfig config = new CheckConfig();
 


### PR DESCRIPTION
  - Redact passwords, tokens, authorization values, and URI user-info from V1 and V2 diagnostic output.
  - Keep standalone usernames visible for authentication and RBAC troubleshooting.
  - Sanitize global-cluster endpoint logs throughout connection and topology refresh paths.
  - Centralize redaction logic in a shared utility and add regression coverage.
