### PR TITLE
[3.0] fix: allow AUTOINDEX for bound function fields

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -801,8 +801,7 @@ public class CollectionService extends BaseService {
                     "Bound index field must match the function output field.");
         }
         if (indexParam.getIndexType() == null
-                || indexParam.getIndexType() == IndexParam.IndexType.None
-                || indexParam.getIndexType() == IndexParam.IndexType.AUTOINDEX) {
+                || indexParam.getIndexType() == IndexParam.IndexType.None) {
             throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
                     "Bound index must specify an explicit index type.");
         }

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
@@ -650,12 +650,17 @@ class CollectionTest extends BaseTest {
     }
 
     @Test
-    void testAddFunctionFieldRejectsAutoIndex() {
-        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
-                () -> client_v2.addFunctionField(addFunctionFieldBuilder()
-                        .indexParam(IndexParam.builder().fieldName("sparse").build())
-                        .build()));
-        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+    void testAddFunctionFieldAllowsAutoIndex() {
+        client_v2.addFunctionField(addFunctionFieldBuilder()
+                .indexParam(IndexParam.builder().fieldName("sparse").build())
+                .build());
+
+        ArgumentCaptor<io.milvus.grpc.AlterCollectionSchemaRequest> captor =
+                ArgumentCaptor.forClass(io.milvus.grpc.AlterCollectionSchemaRequest.class);
+        verify(blockingStub).alterCollectionSchema(captor.capture());
+        Assertions.assertEquals("AUTOINDEX",
+                getParam(captor.getValue().getAction().getAddRequest().getFieldInfos(0).getExtraParamsList(),
+                        Constant.INDEX_TYPE));
     }
 
     @Test


### PR DESCRIPTION
## What this PR does

- Allow bound indexes in `addFunctionField` to use `AUTOINDEX`.
- Update the unit test to verify that `AUTOINDEX` is forwarded in the schema alteration request.

## Testing

- `mvn -pl sdk-core -Dtest=io.milvus.v2.service.collection.CollectionTest test` (Java 17)
- 39 tests passed.