### PR TITLE
Support async DQL interfaces

### DIFF
--- a/examples/src/main/java/io/milvus/v2/AsyncDQLExample.java
+++ b/examples/src/main/java/io/milvus/v2/AsyncDQLExample.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.vector.request.AnnSearchReq;
+import io.milvus.v2.service.vector.request.FunctionScore;
+import io.milvus.v2.service.vector.request.HybridSearchReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.request.ranker.RRFRanker;
+import io.milvus.v2.service.vector.response.QueryResp;
+import io.milvus.v2.service.vector.response.SearchResp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public class AsyncDQLExample {
+    private static final String COLLECTION_NAME = "java_sdk_example_async_dql_v2";
+    private static final int DEFAULT_REQUEST_ROUNDS = 1000;
+    private static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 20;
+
+    public static void main(String[] args) {
+        int requestRounds = args.length > 0 ? Integer.parseInt(args[0]) : DEFAULT_REQUEST_ROUNDS;
+        int maxConcurrentRequests = args.length > 1
+                ? Integer.parseInt(args[1]) : DEFAULT_MAX_CONCURRENT_REQUESTS;
+        MilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
+                .uri("http://localhost:19530")
+                .build());
+
+        try {
+            prepareCollection(client);
+            runAsyncDql(client, requestRounds, maxConcurrentRequests);
+        } finally {
+            try {
+                client.dropCollection(DropCollectionReq.builder()
+                        .collectionName(COLLECTION_NAME)
+                        .build());
+            } finally {
+                client.close();
+            }
+        }
+    }
+
+    private static void prepareCollection(MilvusClientV2 client) {
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .build());
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .dimension(4)
+                .build());
+
+        Gson gson = new Gson();
+        List<JsonObject> rows = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", i);
+            row.addProperty("name", "item-" + i);
+            row.add("vector", gson.toJsonTree(
+                    new float[]{i, (float) i / 2, (float) i / 3, (float) i / 4}));
+            rows.add(row);
+        }
+        client.insert(InsertReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .data(rows)
+                .build());
+        System.out.println("Collection prepared with 100 rows\n");
+    }
+
+    private static void runAsyncDql(MilvusClientV2 client, int requestRounds,
+                                    int maxConcurrentRequests) {
+        if (requestRounds <= 0 || maxConcurrentRequests <= 0) {
+            throw new IllegalArgumentException("Request rounds and concurrency must be greater than zero");
+        }
+
+        Semaphore concurrencyLimit = new Semaphore(maxConcurrentRequests);
+        List<CompletableFuture<?>> futures = new ArrayList<>(requestRounds * 3);
+        AtomicInteger queryResultCount = new AtomicInteger();
+        AtomicInteger searchResultCount = new AtomicInteger();
+        AtomicInteger hybridSearchResultCount = new AtomicInteger();
+        long startNanos = System.nanoTime();
+        System.out.printf("Submitting %d rounds (%d total requests), max concurrency=%d%n",
+                requestRounds, requestRounds * 3, maxConcurrentRequests);
+
+        for (int i = 0; i < requestRounds; i++) {
+            int requestId = i;
+            futures.add(submitWithLimit(concurrencyLimit, () -> client.queryAsync(QueryReq.builder()
+                    .collectionName(COLLECTION_NAME)
+                    .filter(String.format("id >= %d and id < %d", requestId % 95, requestId % 95 + 5))
+                    .outputFields(Arrays.asList("id", "name"))
+                    .consistencyLevel(ConsistencyLevel.STRONG)
+                    .build())).thenAccept(response ->
+                    queryResultCount.addAndGet(response.getQueryResults().size())));
+
+            float value = requestId % 100 + 1;
+            futures.add(submitWithLimit(concurrencyLimit, () -> client.searchAsync(SearchReq.builder()
+                    .collectionName(COLLECTION_NAME)
+                    .data(Collections.singletonList(new FloatVec(
+                            new float[]{value, value / 2, value / 3, value / 4})))
+                    .limit(5)
+                    .outputFields(Arrays.asList("id", "name"))
+                    .consistencyLevel(ConsistencyLevel.STRONG)
+                    .build())).thenAccept(response ->
+                    searchResultCount.addAndGet(countSearchResults(response))));
+
+            futures.add(submitWithLimit(concurrencyLimit, () -> client.hybridSearchAsync(
+                    buildHybridSearchRequest(value))).thenAccept(response ->
+                    hybridSearchResultCount.addAndGet(countSearchResults(response))));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).join();
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        System.out.printf("Completed %d async requests with max concurrency %d in %d ms%n",
+                futures.size(), maxConcurrentRequests, elapsedMs);
+        System.out.printf("Returned entities: query=%d, search=%d, hybridSearch=%d%n",
+                queryResultCount.get(), searchResultCount.get(), hybridSearchResultCount.get());
+    }
+
+    private static HybridSearchReq buildHybridSearchRequest(float value) {
+        List<AnnSearchReq> annSearchRequests = Arrays.asList(
+                AnnSearchReq.builder()
+                        .vectorFieldName("vector")
+                        .vectors(Collections.singletonList(
+                                new FloatVec(new float[]{value, value / 2, value / 3, value / 4})))
+                        .filter("id < 50")
+                        .limit(10)
+                        .build(),
+                AnnSearchReq.builder()
+                        .vectorFieldName("vector")
+                        .vectors(Collections.singletonList(
+                                new FloatVec(new float[]{value + 1, value, value / 2, value / 3})))
+                        .filter("id >= 50")
+                        .limit(10)
+                        .build());
+        return HybridSearchReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .searchRequests(annSearchRequests)
+                .functionScore(FunctionScore.builder()
+                        .addFunction(RRFRanker.builder().k(60).build())
+                        .build())
+                .limit(5)
+                .outFields(Arrays.asList("id", "name"))
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build();
+    }
+
+    private static int countSearchResults(SearchResp response) {
+        return response.getSearchResults().stream().mapToInt(List::size).sum();
+    }
+
+    private static <T> CompletableFuture<T> submitWithLimit(
+            Semaphore concurrencyLimit, Supplier<CompletableFuture<T>> request) {
+        concurrencyLimit.acquireUninterruptibly();
+        try {
+            CompletableFuture<T> future = request.get();
+            future.whenComplete((response, throwable) -> concurrencyLimit.release());
+            return future;
+        } catch (RuntimeException | Error throwable) {
+            concurrencyLimit.release();
+            throw throwable;
+        }
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/common/utils/cache/SchemaCache.java
+++ b/sdk-core/src/main/java/io/milvus/common/utils/cache/SchemaCache.java
@@ -25,6 +25,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -35,6 +38,11 @@ public class SchemaCache {
     @FunctionalInterface
     public interface Loader {
         DescribeCollectionResponse load();
+    }
+
+    @FunctionalInterface
+    public interface AsyncLoader {
+        CompletableFuture<DescribeCollectionResponse> load();
     }
 
     private static final SchemaCache INSTANCE = new SchemaCache();
@@ -54,6 +62,7 @@ public class SchemaCache {
         private boolean completed;
         private DescribeCollectionResponse response;
         private Throwable failure;
+        private final CompletableFuture<DescribeCollectionResponse> future = new CompletableFuture<>();
     }
 
     private static final class LoadKey {
@@ -136,24 +145,80 @@ public class SchemaCache {
         try {
             DescribeCollectionResponse current = getCached(key);
             if (current != null && (!forceUpdate || current != initial)) {
-                complete(state, current, null);
+                publishLoadResult(loadKey, state, current, null);
                 return current;
             }
 
             DescribeCollectionResponse loaded = loader.load();
             setCachedIfValid(key, loaded, state);
-            complete(state, loaded, null);
+            publishLoadResult(loadKey, state, loaded, null);
             return loaded;
         } catch (Throwable throwable) {
-            complete(state, null, throwable);
+            publishLoadResult(loadKey, state, null, throwable);
             throw propagate(throwable);
         } finally {
-            synchronized (loadingLock) {
-                if (loading.get(loadKey) == state) {
-                    loading.remove(loadKey);
-                }
+            removeLoad(loadKey, state);
+        }
+    }
+
+    /**
+     * Asynchronously loads a schema with the same cache, scope, coalescing, and invalidation
+     * semantics as {@link #getOrLoad(String, String, String, boolean, Object, Loader)}.
+     * Cancelling one returned future does not cancel a load shared by other callers.
+     */
+    public CompletableFuture<DescribeCollectionResponse> getOrLoadAsync(
+            String endpoint, String databaseName, String collectionName,
+            boolean forceUpdate, Object loadScope, AsyncLoader loader) {
+        CollectionCacheKey key = CollectionCacheKey.create(endpoint, databaseName, collectionName);
+        DescribeCollectionResponse initial = getCached(key);
+        if (initial != null && !forceUpdate) {
+            return CompletableFuture.completedFuture(initial);
+        }
+
+        LoadKey loadKey = new LoadKey(key, Objects.requireNonNull(loadScope, "loadScope cannot be null"));
+        LoadState newState = new LoadState();
+        LoadState state;
+        synchronized (loadingLock) {
+            state = loading.get(loadKey);
+            if (state == null) {
+                loading.put(loadKey, newState);
             }
         }
+        if (state != null) {
+            return dependentFuture(state);
+        }
+        state = newState;
+
+        DescribeCollectionResponse current = getCached(key);
+        if (current != null && (!forceUpdate || current != initial)) {
+            publishLoadResult(loadKey, state, current, null);
+            return dependentFuture(state);
+        }
+
+        CompletableFuture<DescribeCollectionResponse> loadFuture;
+        try {
+            loadFuture = Objects.requireNonNull(loader, "loader cannot be null").load();
+            if (loadFuture == null) {
+                throw new NullPointerException("Async schema loader returned null future");
+            }
+        } catch (Throwable throwable) {
+            publishLoadResult(loadKey, state, null, throwable);
+            return dependentFuture(state);
+        }
+
+        LoadState finalState = state;
+        loadFuture.whenComplete((loaded, throwable) -> {
+            Throwable failure = throwable == null ? null : unwrapCompletionThrowable(throwable);
+            if (failure == null) {
+                try {
+                    setCachedIfValid(key, loaded, finalState);
+                } catch (Throwable completionFailure) {
+                    failure = completionFailure;
+                }
+            }
+            publishLoadResult(loadKey, finalState, failure == null ? loaded : null, failure);
+        });
+        return dependentFuture(state);
     }
 
     public DescribeCollectionResponse get(String endpoint, String databaseName, String collectionName) {
@@ -295,11 +360,48 @@ public class SchemaCache {
 
     private void complete(LoadState state, DescribeCollectionResponse response, Throwable failure) {
         synchronized (state) {
+            if (state.completed) {
+                return;
+            }
             state.response = response;
             state.failure = failure;
             state.completed = true;
             state.notifyAll();
         }
+        if (failure == null) {
+            state.future.complete(response);
+        } else {
+            state.future.completeExceptionally(failure);
+        }
+    }
+
+    private CompletableFuture<DescribeCollectionResponse> dependentFuture(LoadState state) {
+        return state.future.thenApply(response -> response);
+    }
+
+    private void publishLoadResult(LoadKey loadKey, LoadState state,
+                                   DescribeCollectionResponse response, Throwable failure) {
+        // CompletableFuture continuations can execute inline in complete(). Remove this generation
+        // first so a reentrant retry starts a new load instead of joining an already-completed one.
+        removeLoad(loadKey, state);
+        complete(state, response, failure);
+    }
+
+    private void removeLoad(LoadKey loadKey, LoadState state) {
+        synchronized (loadingLock) {
+            if (loading.get(loadKey) == state) {
+                loading.remove(loadKey);
+            }
+        }
+    }
+
+    private Throwable unwrapCompletionThrowable(Throwable throwable) {
+        Throwable current = throwable;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
     }
 
     private RuntimeException propagate(Throwable throwable) {

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -90,6 +90,7 @@ import io.milvus.v2.exception.MilvusClientException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
@@ -114,6 +115,7 @@ public class MilvusClientV2 {
     private static final Logger logger = LoggerFactory.getLogger(MilvusClientV2.class);
     private ManagedChannel channel;
     private MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub;
+    private MilvusServiceGrpc.MilvusServiceFutureStub futureStub;
     private final ClientUtils clientUtils = new ClientUtils();
     private final DatabaseService databaseService = new DatabaseService();
     private final CollectionService collectionService = new CollectionService();
@@ -146,6 +148,11 @@ public class MilvusClientV2 {
     // Setter for blockingStub (replacing @Setter)
     public void setBlockingStub(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub) {
         this.blockingStub = blockingStub;
+    }
+
+    // Setter for futureStub, primarily used by tests and internal client wiring.
+    public void setFutureStub(MilvusServiceGrpc.MilvusServiceFutureStub futureStub) {
+        this.futureStub = futureStub;
     }
 
     private void initServices(String dbName) {
@@ -220,6 +227,7 @@ public class MilvusClientV2 {
             Channel interceptedChannel = ClientInterceptors.intercept(channel,
                     new IdentifierInterceptor(identifier));
             blockingStub = MilvusServiceGrpc.newBlockingStub(interceptedChannel).withWaitForReady();
+            futureStub = MilvusServiceGrpc.newFutureStub(interceptedChannel).withWaitForReady();
 
             if (connectConfig.getDbName() != null) {
                 // check if database exists
@@ -239,6 +247,7 @@ public class MilvusClientV2 {
     private synchronized void updatePrimaryConnection(MilvusClientV2 primaryClient) {
         this.channel = primaryClient.channel;
         this.blockingStub = primaryClient.blockingStub;
+        this.futureStub = primaryClient.futureStub;
         // Keep cacheEndpoint scoped to the logical global-cluster endpoint. Replacing it with the
         // physical primary endpoint would make session timestamps and schemas recorded before a
         // failover unreachable after the primary changes.
@@ -256,6 +265,14 @@ public class MilvusClientV2 {
             return blockingStub.withDeadlineAfter(connectConfig.getRpcDeadlineMs(), TimeUnit.MILLISECONDS);
         } else {
             return blockingStub;
+        }
+    }
+
+    private MilvusServiceGrpc.MilvusServiceFutureStub getFutureRpcStub() {
+        if (connectConfig != null && connectConfig.getRpcDeadlineMs() > 0) {
+            return futureStub.withDeadlineAfter(connectConfig.getRpcDeadlineMs(), TimeUnit.MILLISECONDS);
+        } else {
+            return futureStub;
         }
     }
 
@@ -865,6 +882,18 @@ public class MilvusClientV2 {
     }
 
     /**
+     * Queries vectors asynchronously in a collection in Milvus.
+     *
+     * @param request query request
+     * @return a future completed with QueryResp, or exceptionally when the operation fails
+     */
+    public CompletableFuture<QueryResp> queryAsync(QueryReq request) {
+        QueryReq requestSnapshot = VectorRequestCopier.copy(request);
+        return rpcUtils.retryAsync(() ->
+                vectorService.queryAsync(this.getFutureRpcStub(), VectorRequestCopier.copy(requestSnapshot)));
+    }
+
+    /**
      * Searches vectors in a collection in Milvus.
      *
      * @param request search request
@@ -875,6 +904,18 @@ public class MilvusClientV2 {
     }
 
     /**
+     * Searches vectors asynchronously in a collection in Milvus.
+     *
+     * @param request search request
+     * @return a future completed with SearchResp, or exceptionally when the operation fails
+     */
+    public CompletableFuture<SearchResp> searchAsync(SearchReq request) {
+        SearchReq requestSnapshot = VectorRequestCopier.copy(request);
+        return rpcUtils.retryAsync(() ->
+                vectorService.searchAsync(this.getFutureRpcStub(), VectorRequestCopier.copy(requestSnapshot)));
+    }
+
+    /**
      * Conducts multi vector similarity search with a ranker for rearrangement.
      *
      * @param request search request
@@ -882,6 +923,18 @@ public class MilvusClientV2 {
      */
     public SearchResp hybridSearch(HybridSearchReq request) {
         return rpcUtils.retry(() -> vectorService.hybridSearch(this.getRpcStub(), request));
+    }
+
+    /**
+     * Conducts multi vector similarity search asynchronously with a ranker for rearrangement.
+     *
+     * @param request hybrid search request
+     * @return a future completed with SearchResp, or exceptionally when the operation fails
+     */
+    public CompletableFuture<SearchResp> hybridSearchAsync(HybridSearchReq request) {
+        HybridSearchReq requestSnapshot = VectorRequestCopier.copy(request);
+        return rpcUtils.retryAsync(() ->
+                vectorService.hybridSearchAsync(this.getFutureRpcStub(), VectorRequestCopier.copy(requestSnapshot)));
     }
 
     /**

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2Session.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2Session.java
@@ -29,6 +29,8 @@ import io.milvus.v2.service.vector.response.GetResp;
 import io.milvus.v2.service.vector.response.QueryResp;
 import io.milvus.v2.service.vector.response.SearchResp;
 
+import java.util.concurrent.CompletableFuture;
+
 public class MilvusClientV2Session {
     private final MilvusClientV2 parent;
     private final String clusterId;
@@ -49,16 +51,34 @@ public class MilvusClientV2Session {
         return parent.search(request);
     }
 
+    public CompletableFuture<SearchResp> searchAsync(SearchReq request) {
+        ensureOpen();
+        request.setClusterId(clusterId);
+        return parent.searchAsync(request);
+    }
+
     public SearchResp hybridSearch(HybridSearchReq request) {
         ensureOpen();
         request.setClusterId(clusterId);
         return parent.hybridSearch(request);
     }
 
+    public CompletableFuture<SearchResp> hybridSearchAsync(HybridSearchReq request) {
+        ensureOpen();
+        request.setClusterId(clusterId);
+        return parent.hybridSearchAsync(request);
+    }
+
     public QueryResp query(QueryReq request) {
         ensureOpen();
         request.setClusterId(clusterId);
         return parent.query(request);
+    }
+
+    public CompletableFuture<QueryResp> queryAsync(QueryReq request) {
+        ensureOpen();
+        request.setClusterId(clusterId);
+        return parent.queryAsync(request);
     }
 
     public QueryIterator queryIterator(QueryIteratorReq request) {

--- a/sdk-core/src/main/java/io/milvus/v2/client/VectorRequestCopier.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/VectorRequestCopier.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.client;
+
+import io.milvus.v2.service.vector.request.AnnSearchReq;
+import io.milvus.v2.service.vector.request.FunctionScore;
+import io.milvus.v2.service.vector.request.HybridSearchReq;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class VectorRequestCopier {
+    private VectorRequestCopier() {
+    }
+
+    static QueryReq copy(QueryReq request) {
+        return QueryReq.builder()
+                .databaseName(request.getDatabaseName())
+                .collectionName(request.getCollectionName())
+                .clusterId(request.getClusterId())
+                .partitionNames(copyList(request.getPartitionNames()))
+                .outputFields(copyList(request.getOutputFields()))
+                .ids(copyList(request.getIds()))
+                .filter(request.getFilter())
+                .consistencyLevel(request.getConsistencyLevel())
+                .offset(request.getOffset())
+                .limit(request.getLimit())
+                .ignoreGrowing(request.isIgnoreGrowing())
+                .timezone(request.getTimezone())
+                .orderByFields(copyList(request.getOrderByFields()))
+                .queryParams(copyMap(request.getQueryParams()))
+                .filterTemplateValues(copyMap(request.getFilterTemplateValues()))
+                .build();
+    }
+
+    static SearchReq copy(SearchReq request) {
+        return SearchReq.builder()
+                .databaseName(request.getDatabaseName())
+                .collectionName(request.getCollectionName())
+                .clusterId(request.getClusterId())
+                .partitionNames(copyList(request.getPartitionNames()))
+                .annsField(request.getAnnsField())
+                .metricType(request.getMetricType())
+                .filter(request.getFilter())
+                .outputFields(copyList(request.getOutputFields()))
+                .data(copyList(request.getData()))
+                .ids(copyList(request.getIds()))
+                .offset(request.getOffset())
+                .limit(request.getLimit())
+                .roundDecimal(request.getRoundDecimal())
+                .searchParams(copyMap(request.getSearchParams()))
+                .guaranteeTimestamp(request.getGuaranteeTimestamp())
+                .gracefulTime(request.getGracefulTime())
+                .consistencyLevel(request.getConsistencyLevel())
+                .ignoreGrowing(request.isIgnoreGrowing())
+                .timezone(request.getTimezone())
+                .orderByFields(copyList(request.getOrderByFields()))
+                .groupByFieldName(request.getGroupByFieldName())
+                .groupSize(request.getGroupSize())
+                .strictGroupSize(request.getStrictGroupSize())
+                .ranker(request.getRanker())
+                .functionScore(copyFunctionScore(request.getFunctionScore()))
+                .filterTemplateValues(copyMap(request.getFilterTemplateValues()))
+                .highlighter(request.getHighlighter())
+                .searchAggregation(request.getSearchAggregation())
+                .build();
+    }
+
+    static HybridSearchReq copy(HybridSearchReq request) {
+        List<AnnSearchReq> searchRequests = null;
+        if (request.getSearchRequests() != null) {
+            searchRequests = new ArrayList<>();
+            for (AnnSearchReq searchRequest : request.getSearchRequests()) {
+                searchRequests.add(copy(searchRequest));
+            }
+        }
+        return HybridSearchReq.builder()
+                .databaseName(request.getDatabaseName())
+                .collectionName(request.getCollectionName())
+                .clusterId(request.getClusterId())
+                .partitionNames(copyList(request.getPartitionNames()))
+                .searchRequests(searchRequests)
+                .ranker(request.getRanker())
+                .functionScore(copyFunctionScore(request.getFunctionScore()))
+                .limit(request.getLimit())
+                .outFields(copyList(request.getOutFields()))
+                .offset(request.getOffset())
+                .roundDecimal(request.getRoundDecimal())
+                .consistencyLevel(request.getConsistencyLevel())
+                .groupByFieldName(request.getGroupByFieldName())
+                .groupSize(request.getGroupSize())
+                .strictGroupSize(request.getStrictGroupSize())
+                .build();
+    }
+
+    private static AnnSearchReq copy(AnnSearchReq request) {
+        return AnnSearchReq.builder()
+                .vectorFieldName(request.getVectorFieldName())
+                .limit(request.getLimit())
+                .filter(request.getFilter())
+                .vectors(copyList(request.getVectors()))
+                .params(request.getParams())
+                .metricType(request.getMetricType())
+                .timezone(request.getTimezone())
+                .filterTemplateValues(copyMap(request.getFilterTemplateValues()))
+                .build();
+    }
+
+    private static FunctionScore copyFunctionScore(FunctionScore functionScore) {
+        if (functionScore == null) {
+            return null;
+        }
+        return FunctionScore.builder()
+                .functions(copyList(functionScore.getFunctions()))
+                .params(copyMap(functionScore.getParams()))
+                .build();
+    }
+
+    private static <T> List<T> copyList(List<T> source) {
+        return source == null ? null : new ArrayList<>(source);
+    }
+
+    private static <K, V> Map<K, V> copyMap(Map<K, V> source) {
+        return source == null ? null : new HashMap<>(source);
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -19,6 +19,10 @@
 
 package io.milvus.v2.service.vector;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import io.milvus.common.utils.JsonUtils;
 import io.milvus.common.utils.cache.SchemaCache;
@@ -43,7 +47,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 public class VectorService extends BaseService {
     Logger logger = LoggerFactory.getLogger(VectorService.class);
@@ -60,6 +68,21 @@ public class VectorService extends BaseService {
         return response;
     }
 
+    private CompletableFuture<DescribeCollectionResponse> describeCollection(
+            MilvusServiceGrpc.MilvusServiceFutureStub futureStub,
+            String dbName, String collectionName) {
+        String title = String.format("Describe collection '%s' in database: '%s'", collectionName, dbName);
+        DescribeCollectionRequest.Builder builder = DescribeCollectionRequest.newBuilder()
+                .setCollectionName(collectionName);
+        if (StringUtils.isNotEmpty(dbName)) {
+            builder.setDbName(dbName);
+        }
+        return transformFuture(futureStub.describeCollection(builder.build()), response -> {
+            rpcUtils.handleResponse(title, response.getStatus());
+            return response;
+        });
+    }
+
     /**
      * Returns the cached collection schema when available, loading and caching it otherwise.
      * Insert/upsert callers may force a refresh when request construction indicates that the
@@ -71,6 +94,15 @@ public class VectorService extends BaseService {
         String dbName = actualDbName(databaseName);
         return SchemaCache.getInstance().getOrLoad(getEndpoint(), dbName, collectionName, forceUpdate, this,
                 () -> describeCollection(blockingStub, dbName, collectionName));
+    }
+
+    private CompletableFuture<DescribeCollectionResponse> getCollectionInfoAsync(
+            MilvusServiceGrpc.MilvusServiceFutureStub futureStub,
+            String databaseName, String collectionName, boolean forceUpdate) {
+        String dbName = actualDbName(databaseName);
+        return SchemaCache.getInstance().getOrLoadAsync(
+                getEndpoint(), dbName, collectionName, forceUpdate, this,
+                () -> describeCollection(futureStub, dbName, collectionName));
     }
 
     private InsertRequest buildInsertRequest(InsertReq request, DescribeCollectionResponse descResp) {
@@ -196,39 +228,105 @@ public class VectorService extends BaseService {
     }
 
     public QueryResp query(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, QueryReq request) {
-        String dbName = request.getDatabaseName();
-        String collectionName = request.getCollectionName();
-        String title = String.format("Query collection: '%s' in database: '%s'", collectionName, dbName);
-        if (StringUtils.isNotEmpty(request.getFilter()) && CollectionUtils.isNotEmpty(request.getIds())) {
-            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "filter and ids can't be set at the same time");
-        }
+        QueryRequest queryRequest = buildQueryRequest(blockingStub, request);
+        String title = String.format("Query collection: '%s' in database: '%s'",
+                request.getCollectionName(), queryRequest.getDbName());
+        QueryResults response = blockingStub.query(queryRequest);
+        return convertQueryResponse(title, response);
+    }
 
+    public CompletableFuture<QueryResp> queryAsync(MilvusServiceGrpc.MilvusServiceFutureStub futureStub,
+                                                   QueryReq request) {
+        return composeFuture(buildQueryRequestAsync(futureStub, request), queryRequest -> {
+            String title = String.format("Query collection: '%s' in database: '%s'",
+                    queryRequest.getCollectionName(), queryRequest.getDbName());
+            return transformFuture(futureStub.query(queryRequest),
+                    response -> convertQueryResponse(title, response));
+        });
+    }
+
+    private QueryRequest buildQueryRequest(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub,
+                                           QueryReq request) {
+        validateQueryRequest(request);
+        DescribeCollectionResponse descResp = null;
         if (CollectionUtils.isNotEmpty(request.getIds())) {
-            DescribeCollectionResponse descResp = getCollectionInfo(blockingStub, dbName, collectionName, false);
-            String primaryKeyName = "";
-            List<FieldSchema> fields = descResp.getSchema().getFieldsList();
-            for (FieldSchema field : fields) {
-                if (field.getIsPrimaryKey()) {
-                    primaryKeyName = field.getName();
-                    break;
-                }
-            }
-            if (StringUtils.isEmpty(primaryKeyName)) {
-                throw new MilvusClientException(ErrorCode.SERVER_ERROR, "cannot find the primary key field in collection schema");
-            }
-            request.setFilter(vectorUtils.getExprById(primaryKeyName, request.getIds()));
+            descResp = getCollectionInfo(blockingStub, request.getDatabaseName(),
+                    request.getCollectionName(), false);
+        }
+        return buildQueryRequest(request, descResp);
+    }
+
+    private CompletableFuture<QueryRequest> buildQueryRequestAsync(
+            MilvusServiceGrpc.MilvusServiceFutureStub futureStub, QueryReq request) {
+        validateQueryRequest(request);
+        if (CollectionUtils.isEmpty(request.getIds())) {
+            return CompletableFuture.completedFuture(buildQueryRequest(request, null));
+        }
+        return getCollectionInfoAsync(futureStub, request.getDatabaseName(),
+                request.getCollectionName(), false).thenApply(descResp -> buildQueryRequest(request, descResp));
+    }
+
+    private QueryRequest buildQueryRequest(QueryReq request, DescribeCollectionResponse descResp) {
+        String dbName = request.getDatabaseName();
+        QueryReq effectiveRequest = request;
+        if (CollectionUtils.isNotEmpty(request.getIds())) {
+            effectiveRequest = copyQueryReq(request);
+            effectiveRequest.setFilter(vectorUtils.getExprById(getPrimaryKeyName(descResp), request.getIds()));
         }
 
         // reset the db name so that the timestamp cache can set correct key for this collection
-        request.setDatabaseName(actualDbName(request.getDatabaseName()));
-        QueryResults response = blockingStub.query(vectorUtils.ConvertToGrpcQueryRequest(request));
+        effectiveRequest.setDatabaseName(actualDbName(dbName));
+        return vectorUtils.ConvertToGrpcQueryRequest(effectiveRequest);
+    }
+
+    private String getPrimaryKeyName(DescribeCollectionResponse descResp) {
+        for (FieldSchema field : descResp.getSchema().getFieldsList()) {
+            if (field.getIsPrimaryKey()) {
+                return field.getName();
+            }
+        }
+        throw new MilvusClientException(ErrorCode.SERVER_ERROR,
+                "cannot find the primary key field in collection schema");
+    }
+
+    private void validateQueryRequest(QueryReq request) {
+        if (StringUtils.isNotEmpty(request.getFilter()) && CollectionUtils.isNotEmpty(request.getIds())) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "filter and ids can't be set at the same time");
+        }
+    }
+
+    private QueryReq copyQueryReq(QueryReq request) {
+        return QueryReq.builder()
+                .databaseName(request.getDatabaseName())
+                .collectionName(request.getCollectionName())
+                .clusterId(request.getClusterId())
+                .partitionNames(copyList(request.getPartitionNames()))
+                .outputFields(copyList(request.getOutputFields()))
+                .ids(copyList(request.getIds()))
+                .filter(request.getFilter())
+                .consistencyLevel(request.getConsistencyLevel())
+                .offset(request.getOffset())
+                .limit(request.getLimit())
+                .ignoreGrowing(request.isIgnoreGrowing())
+                .timezone(request.getTimezone())
+                .orderByFields(copyList(request.getOrderByFields()))
+                .queryParams(request.getQueryParams() == null ? null : new HashMap<>(request.getQueryParams()))
+                .filterTemplateValues(request.getFilterTemplateValues() == null ? null
+                        : new HashMap<>(request.getFilterTemplateValues()))
+                .build();
+    }
+
+    private <T> List<T> copyList(List<T> source) {
+        return source == null ? null : new ArrayList<>(source);
+    }
+
+    private QueryResp convertQueryResponse(String title, QueryResults response) {
         rpcUtils.handleResponse(title, response.getStatus());
 
         return QueryResp.builder()
                 .queryResults(convertUtils.getEntities(response))
                 .sessionTs(response.getSessionTs())
                 .build();
-
     }
 
     public SearchResp search(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, SearchReq request) {
@@ -242,14 +340,30 @@ public class VectorService extends BaseService {
         request.setDatabaseName(actualDbName(dbName));
         SearchRequest searchRequest = vectorUtils.ConvertToGrpcSearchRequest(request);
 
-        SearchResults response = blockingStub.search(searchRequest);
+        return convertSearchResponse(title, blockingStub.search(searchRequest), true);
+    }
+
+    public CompletableFuture<SearchResp> searchAsync(MilvusServiceGrpc.MilvusServiceFutureStub futureStub,
+                                                     SearchReq request) {
+        String dbName = request.getDatabaseName();
+
+        request.setDatabaseName(actualDbName(dbName));
+        SearchRequest searchRequest = vectorUtils.ConvertToGrpcSearchRequest(request);
+        String title = String.format("Search collection: '%s' in database: '%s'",
+                searchRequest.getCollectionName(), searchRequest.getDbName());
+        return transformFuture(futureStub.search(searchRequest), response -> convertSearchResponse(title, response, true));
+    }
+
+    private SearchResp convertSearchResponse(String title, SearchResults response, boolean includeAggregations) {
         rpcUtils.handleResponse(title, response.getStatus());
 
         SearchResp.SearchRespBuilder respBuilder = SearchResp.builder()
                 .searchResults(convertUtils.getEntities(response))
-                .aggregationBuckets(convertUtils.getAggregationBuckets(response))
                 .sessionTs(response.getSessionTs())
                 .recalls(response.getResults().getRecallsList());
+        if (includeAggregations) {
+            respBuilder.aggregationBuckets(convertUtils.getAggregationBuckets(response));
+        }
         fillSearchRespFromExtraInfo(respBuilder, response.getStatus().getExtraInfoMap());
         return respBuilder.build();
     }
@@ -265,15 +379,104 @@ public class VectorService extends BaseService {
         request.setDatabaseName(actualDbName(dbName));
         HybridSearchRequest searchRequest = vectorUtils.ConvertToGrpcHybridSearchRequest(request);
 
-        SearchResults response = blockingStub.hybridSearch(searchRequest);
-        rpcUtils.handleResponse(title, response.getStatus());
+        return convertSearchResponse(title, blockingStub.hybridSearch(searchRequest), false);
+    }
 
-        SearchResp.SearchRespBuilder respBuilder = SearchResp.builder()
-                .searchResults(convertUtils.getEntities(response))
-                .sessionTs(response.getSessionTs())
-                .recalls(response.getResults().getRecallsList());
-        fillSearchRespFromExtraInfo(respBuilder, response.getStatus().getExtraInfoMap());
-        return respBuilder.build();
+    public CompletableFuture<SearchResp> hybridSearchAsync(MilvusServiceGrpc.MilvusServiceFutureStub futureStub,
+                                                           HybridSearchReq request) {
+        String dbName = request.getDatabaseName();
+
+        request.setDatabaseName(actualDbName(dbName));
+        HybridSearchRequest searchRequest = vectorUtils.ConvertToGrpcHybridSearchRequest(request);
+        String title = String.format("Hybrid search collection: '%s' in database: '%s'",
+                searchRequest.getCollectionName(), searchRequest.getDbName());
+        return transformFuture(futureStub.hybridSearch(searchRequest),
+                response -> convertSearchResponse(title, response, false));
+    }
+
+    private <T, R> CompletableFuture<R> transformFuture(ListenableFuture<T> source,
+                                                        Function<T, R> converter) {
+        CompletableFuture<R> target = new CompletableFuture<R>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                boolean cancelled = super.cancel(mayInterruptIfRunning);
+                if (cancelled) {
+                    source.cancel(mayInterruptIfRunning);
+                }
+                return cancelled;
+            }
+        };
+        Futures.addCallback(source, new FutureCallback<T>() {
+            @Override
+            public void onSuccess(T result) {
+                if (target.isDone()) {
+                    return;
+                }
+                try {
+                    target.complete(converter.apply(result));
+                } catch (Throwable throwable) {
+                    target.completeExceptionally(throwable);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                target.completeExceptionally(throwable);
+            }
+        }, MoreExecutors.directExecutor());
+        return target;
+    }
+
+    private <T, R> CompletableFuture<R> composeFuture(
+            CompletableFuture<T> source, Function<T, CompletableFuture<R>> composer) {
+        AtomicReference<CompletableFuture<?>> nextFuture = new AtomicReference<>();
+        CompletableFuture<R> target = new CompletableFuture<R>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                boolean cancelled = super.cancel(mayInterruptIfRunning);
+                if (cancelled) {
+                    source.cancel(mayInterruptIfRunning);
+                    CompletableFuture<?> next = nextFuture.get();
+                    if (next != null) {
+                        next.cancel(mayInterruptIfRunning);
+                    }
+                }
+                return cancelled;
+            }
+        };
+        source.whenComplete((value, throwable) -> {
+            if (target.isDone()) {
+                return;
+            }
+            if (throwable != null) {
+                target.completeExceptionally(throwable);
+                return;
+            }
+
+            CompletableFuture<R> next;
+            try {
+                next = composer.apply(value);
+                if (next == null) {
+                    throw new NullPointerException("Future composer returned null future");
+                }
+            } catch (Throwable compositionFailure) {
+                target.completeExceptionally(compositionFailure);
+                return;
+            }
+            nextFuture.set(next);
+            if (target.isCancelled()) {
+                next.cancel(true);
+                return;
+            }
+            next.whenComplete((result, nextFailure) -> {
+                if (nextFailure == null) {
+                    target.complete(result);
+                } else {
+                    target.completeExceptionally(nextFailure);
+                }
+            });
+        });
+        return target;
     }
 
     private void fillSearchRespFromExtraInfo(SearchResp.SearchRespBuilder respBuilder, java.util.Map<String, String> extraInfo) {

--- a/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/RpcUtils.java
@@ -28,13 +28,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class RpcUtils {
 
     protected static final Logger logger = LoggerFactory.getLogger(RpcUtils.class);
     private static final String GLOBAL_ROUTING_ERROR = "STREAMING_CODE_REPLICATE_VIOLATION";
+    private static final ScheduledExecutorService ASYNC_RETRY_EXECUTOR =
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "milvus-async-retry");
+                thread.setDaemon(true);
+                return thread;
+            });
     private RetryConfig retryConfig = RetryConfig.builder().build();
     private Runnable globalRefreshTrigger;
 
@@ -148,7 +163,7 @@ public class RpcUtils {
                         || code == io.grpc.Status.UNIMPLEMENTED.getCode()) {
                     String msg = String.format("Encounter rpc error that cannot be retried, reason: %s", e);
                     logger.error(msg);
-                    throw new MilvusClientException(ErrorCode.RPC_ERROR, msg); // throw rpc error
+                    throw new MilvusClientException(ErrorCode.RPC_ERROR, e); // throw rpc error
                 }
 
                 // trigger topology refresh if connection is unavailable, and continue to retry
@@ -221,5 +236,269 @@ public class RpcUtils {
         }
 
         return null;
+    }
+
+    /**
+     * Executes an asynchronous RPC with the same retry policy used by {@link #retry(Callable)}.
+     * Validation failures are returned as exceptionally completed futures, retry backoff never
+     * blocks a caller thread, and cancellation is propagated to the active RPC or scheduled retry.
+     */
+    public <T> CompletableFuture<T> retryAsync(Supplier<CompletableFuture<T>> supplier) {
+        RetryFuture<T> result = new RetryFuture<>();
+        int maxRetryTimes = retryConfig.getMaxRetryTimes();
+        int effectiveMaxRetryTimes = Math.max(1, maxRetryTimes);
+        attemptAsync(supplier, result, System.currentTimeMillis(), effectiveMaxRetryTimes,
+                1, retryConfig.getInitialBackOffMs());
+        return result;
+    }
+
+    private <T> void attemptAsync(Supplier<CompletableFuture<T>> supplier,
+                                  RetryFuture<T> result,
+                                  long begin,
+                                  int maxRetryTimes,
+                                  int attemptNumber,
+                                  long retryIntervalMs) {
+        if (result.isDone()) {
+            return;
+        }
+
+        CompletableFuture<T> attempt;
+        try {
+            attempt = supplier.get();
+            if (attempt == null) {
+                throw new NullPointerException("Async RPC supplier returned null future");
+            }
+        } catch (Throwable throwable) {
+            handleAsyncFailure(supplier, result, begin, maxRetryTimes, attemptNumber,
+                    retryIntervalMs, throwable);
+            return;
+        }
+
+        result.setInFlight(attempt);
+        attempt.whenComplete((value, throwable) -> {
+            result.clearInFlight(attempt);
+            if (result.isDone()) {
+                return;
+            }
+            if (throwable == null) {
+                result.complete(value);
+            } else {
+                handleAsyncFailure(supplier, result, begin, maxRetryTimes, attemptNumber,
+                        retryIntervalMs, unwrapCompletionThrowable(throwable));
+            }
+        });
+    }
+
+    private <T> void handleAsyncFailure(Supplier<CompletableFuture<T>> supplier,
+                                        RetryFuture<T> result,
+                                        long begin,
+                                        int maxRetryTimes,
+                                        int attemptNumber,
+                                        long retryIntervalMs,
+                                        Throwable throwable) {
+        if (result.isDone()) {
+            return;
+        }
+
+        Throwable cause = unwrapCompletionThrowable(throwable);
+        if (maxRetryTimes <= 1) {
+            result.completeExceptionally(normalizeAsyncFailure(cause));
+            return;
+        }
+        boolean retryable;
+        if (cause instanceof StatusRuntimeException) {
+            StatusRuntimeException statusException = (StatusRuntimeException) cause;
+            if (isNonRetryableRpcError(statusException)) {
+                String msg = String.format("Encounter rpc error that cannot be retried, reason: %s",
+                        statusException);
+                logger.error(msg);
+                result.completeExceptionally(new MilvusClientException(ErrorCode.RPC_ERROR, statusException));
+                return;
+            }
+            handleGlobalConnectionError(statusException);
+            retryable = true;
+        } else if (cause instanceof MilvusClientException) {
+            MilvusClientException clientException = (MilvusClientException) cause;
+            retryable = retryConfig.isRetryOnRateLimit()
+                    && (clientException.getLegacyServerCode() == io.milvus.grpc.ErrorCode.RateLimit.getNumber()
+                    || clientException.getServerErrCode() == 8);
+            if (!retryable) {
+                retryable = handleGlobalRoutingError(clientException);
+            }
+            if (!retryable) {
+                result.completeExceptionally(clientException);
+                return;
+            }
+        } else if (cause instanceof Error) {
+            result.completeExceptionally(cause);
+            return;
+        } else {
+            result.completeExceptionally(new MilvusClientException(ErrorCode.CLIENT_ERROR, cause));
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        if (retryTimedOut(begin, now)) {
+            completeAsyncTimeout(result, String.format(
+                    "Retry timeout: %dms, maxRetry:%d, retries: %d, reason: %s",
+                    retryConfig.getMaxRetryTimeoutMs(), maxRetryTimes, attemptNumber, cause.getMessage()));
+            return;
+        }
+        if (attemptNumber >= maxRetryTimes) {
+            completeAsyncTimeout(result,
+                    String.format("Finish %d retry times, stop retry", maxRetryTimes));
+            return;
+        }
+
+        long futureTimePoint = now + retryIntervalMs;
+        if (retryTimedOut(begin, futureTimePoint)) {
+            completeAsyncTimeout(result, String.format(
+                    "Retry timeout: %dms, maxRetry:%d, retries: %d, "
+                            + "elapsed time + next interval %dms would exceed timeout",
+                    retryConfig.getMaxRetryTimeoutMs(), maxRetryTimes, attemptNumber, retryIntervalMs));
+            return;
+        }
+
+        if (attemptNumber > 3) {
+            logger.warn(String.format("Retry(%d) with interval %dms", attemptNumber, retryIntervalMs));
+        }
+        long nextRetryIntervalMs = retryIntervalMs * retryConfig.getBackOffMultiplier();
+        if (nextRetryIntervalMs > retryConfig.getMaxBackOffMs()) {
+            nextRetryIntervalMs = retryConfig.getMaxBackOffMs();
+        }
+        long nextInterval = nextRetryIntervalMs;
+        ScheduledRetry scheduledRetry = result.registerScheduled();
+        try {
+            ScheduledFuture<?> scheduled = ASYNC_RETRY_EXECUTOR.schedule(() -> {
+                        if (result.startScheduled(scheduledRetry)) {
+                            attemptAsync(supplier, result, begin, maxRetryTimes,
+                                    attemptNumber + 1, nextInterval);
+                        }
+                    },
+                    retryIntervalMs,
+                    TimeUnit.MILLISECONDS);
+            scheduledRetry.setFuture(scheduled);
+        } catch (RuntimeException schedulingFailure) {
+            result.clearScheduled(scheduledRetry);
+            result.completeExceptionally(
+                    new MilvusClientException(ErrorCode.CLIENT_ERROR, schedulingFailure));
+        }
+    }
+
+    private boolean retryTimedOut(long begin, long timePoint) {
+        long maxRetryTimeoutMs = retryConfig.getMaxRetryTimeoutMs();
+        return maxRetryTimeoutMs > 0 && timePoint - begin >= maxRetryTimeoutMs;
+    }
+
+    private Throwable normalizeAsyncFailure(Throwable cause) {
+        if (cause instanceof StatusRuntimeException) {
+            return new MilvusClientException(ErrorCode.RPC_ERROR, cause);
+        }
+        if (cause instanceof MilvusClientException) {
+            return cause;
+        }
+        if (cause instanceof Error) {
+            return cause;
+        }
+        return new MilvusClientException(ErrorCode.CLIENT_ERROR, cause);
+    }
+
+    private boolean isNonRetryableRpcError(StatusRuntimeException exception) {
+        io.grpc.Status.Code code = exception.getStatus().getCode();
+        return code == io.grpc.Status.Code.DEADLINE_EXCEEDED
+                || code == io.grpc.Status.Code.PERMISSION_DENIED
+                || code == io.grpc.Status.Code.UNAUTHENTICATED
+                || code == io.grpc.Status.Code.INVALID_ARGUMENT
+                || code == io.grpc.Status.Code.ALREADY_EXISTS
+                || code == io.grpc.Status.Code.RESOURCE_EXHAUSTED
+                || code == io.grpc.Status.Code.UNIMPLEMENTED;
+    }
+
+    private void completeAsyncTimeout(CompletableFuture<?> result, String message) {
+        logger.warn(message);
+        result.completeExceptionally(new MilvusClientException(ErrorCode.TIMEOUT, message));
+    }
+
+    private Throwable unwrapCompletionThrowable(Throwable throwable) {
+        Throwable current = throwable;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static final class RetryFuture<T> extends CompletableFuture<T> {
+        private final AtomicReference<CompletableFuture<?>> inFlight = new AtomicReference<>();
+        private final AtomicReference<ScheduledRetry> scheduled = new AtomicReference<>();
+
+        private void setInFlight(CompletableFuture<?> future) {
+            inFlight.set(future);
+            if (isCancelled()) {
+                future.cancel(true);
+            }
+        }
+
+        private void clearInFlight(CompletableFuture<?> future) {
+            inFlight.compareAndSet(future, null);
+        }
+
+        private ScheduledRetry registerScheduled() {
+            ScheduledRetry retry = new ScheduledRetry();
+            ScheduledRetry previous = scheduled.getAndSet(retry);
+            if (previous != null) {
+                previous.cancel();
+            }
+            if (isDone() && scheduled.compareAndSet(retry, null)) {
+                retry.cancel();
+            }
+            return retry;
+        }
+
+        private boolean startScheduled(ScheduledRetry retry) {
+            return scheduled.compareAndSet(retry, null) && !isDone();
+        }
+
+        private void clearScheduled(ScheduledRetry retry) {
+            if (scheduled.compareAndSet(retry, null)) {
+                retry.cancel();
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            boolean cancelled = super.cancel(mayInterruptIfRunning);
+            if (cancelled) {
+                CompletableFuture<?> active = inFlight.getAndSet(null);
+                if (active != null) {
+                    active.cancel(mayInterruptIfRunning);
+                }
+                ScheduledRetry pending = scheduled.getAndSet(null);
+                if (pending != null) {
+                    pending.cancel();
+                }
+            }
+            return cancelled;
+        }
+    }
+
+    private static final class ScheduledRetry {
+        private final AtomicReference<ScheduledFuture<?>> future = new AtomicReference<>();
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        private void setFuture(ScheduledFuture<?> scheduledFuture) {
+            future.set(scheduledFuture);
+            if (cancelled.get()) {
+                scheduledFuture.cancel(false);
+            }
+        }
+
+        private void cancel() {
+            cancelled.set(true);
+            ScheduledFuture<?> scheduledFuture = future.get();
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(false);
+            }
+        }
     }
 }

--- a/sdk-core/src/test/java/io/milvus/common/utils/cache/SchemaCacheTest.java
+++ b/sdk-core/src/test/java/io/milvus/common/utils/cache/SchemaCacheTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -66,6 +67,180 @@ class SchemaCacheTest {
         assertEquals(2, loads.get());
         assertSame(refreshed, cache.get("host:19530", "default", "coll"));
         assertEquals(3L, cache.get("host:19531", "default", "coll").getCollectionID());
+    }
+
+    @Test
+    void sharesOneInflightAsyncLoadWithoutBlockingCallers() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CompletableFuture<DescribeCollectionResponse> loaderFuture = new CompletableFuture<>();
+        AtomicInteger loads = new AtomicInteger();
+
+        CompletableFuture<DescribeCollectionResponse> first = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    return loaderFuture;
+                });
+        CompletableFuture<DescribeCollectionResponse> second = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    return CompletableFuture.completedFuture(response(99L));
+                });
+
+        assertEquals(1, loads.get());
+        assertFalse(first.isDone());
+        assertFalse(second.isDone());
+
+        loaderFuture.complete(response(10L));
+        assertEquals(10L, first.get(5, TimeUnit.SECONDS).getCollectionID());
+        assertEquals(10L, second.get(5, TimeUnit.SECONDS).getCollectionID());
+        assertEquals(10L, cache.get("host:19530", "db", "coll").getCollectionID());
+    }
+
+    @Test
+    void asyncInvalidationPreventsOldLoadFromRepopulatingCache() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CompletableFuture<DescribeCollectionResponse> oldLoader = new CompletableFuture<>();
+
+        CompletableFuture<DescribeCollectionResponse> oldResult = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> oldLoader);
+        cache.invalidate("host:19530", "db", "coll");
+        CompletableFuture<DescribeCollectionResponse> newResult = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope,
+                () -> CompletableFuture.completedFuture(response(22L)));
+
+        assertEquals(22L, newResult.get(5, TimeUnit.SECONDS).getCollectionID());
+        oldLoader.complete(response(11L));
+        assertEquals(11L, oldResult.get(5, TimeUnit.SECONDS).getCollectionID());
+        assertEquals(22L, cache.get("host:19530", "db", "coll").getCollectionID());
+    }
+
+    @Test
+    void cancellingAsyncWaiterDoesNotCancelSharedLoad() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CompletableFuture<DescribeCollectionResponse> loaderFuture = new CompletableFuture<>();
+
+        CompletableFuture<DescribeCollectionResponse> cancelled = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> loaderFuture);
+        CompletableFuture<DescribeCollectionResponse> remaining = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope,
+                () -> CompletableFuture.completedFuture(response(99L)));
+
+        assertTrue(cancelled.cancel(true));
+        assertFalse(loaderFuture.isCancelled());
+        loaderFuture.complete(response(12L));
+        assertEquals(12L, remaining.get(5, TimeUnit.SECONDS).getCollectionID());
+    }
+
+    @Test
+    void synchronousAndAsyncCallersShareInflightLoad() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CompletableFuture<DescribeCollectionResponse> loaderFuture = new CompletableFuture<>();
+        AtomicInteger loads = new AtomicInteger();
+        AtomicReference<DescribeCollectionResponse> syncResponse = new AtomicReference<>();
+
+        CompletableFuture<DescribeCollectionResponse> asyncResult = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    return loaderFuture;
+                });
+        Thread syncCaller = new Thread(() -> syncResponse.set(cache.getOrLoad(
+                "host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    return response(99L);
+                })));
+        syncCaller.start();
+        awaitWaiting(syncCaller);
+
+        try {
+            loaderFuture.complete(response(14L));
+            assertEquals(14L, asyncResult.get(5, TimeUnit.SECONDS).getCollectionID());
+            syncCaller.join(TimeUnit.SECONDS.toMillis(5));
+            assertFalse(syncCaller.isAlive());
+            assertEquals(14L, syncResponse.get().getCollectionID());
+            assertEquals(1, loads.get());
+        } finally {
+            loaderFuture.complete(response(14L));
+            syncCaller.join(TimeUnit.SECONDS.toMillis(5));
+        }
+    }
+
+    @Test
+    void inlineRetryAfterAsyncFailureStartsNewLoadGeneration() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CompletableFuture<DescribeCollectionResponse> loaderFuture = new CompletableFuture<>();
+        AtomicInteger loads = new AtomicInteger();
+        AtomicReference<CompletableFuture<DescribeCollectionResponse>> retryFuture = new AtomicReference<>();
+
+        CompletableFuture<DescribeCollectionResponse> first = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    return loaderFuture;
+                });
+        CompletableFuture<Void> continuation = first.handle((ignoredResponse, failure) -> {
+            retryFuture.set(cache.getOrLoadAsync(
+                    "host:19530", "db", "coll", false, loadScope, () -> {
+                        loads.incrementAndGet();
+                        return CompletableFuture.completedFuture(response(20L));
+                    }));
+            return null;
+        });
+
+        loaderFuture.completeExceptionally(new IllegalStateException("load failed"));
+        continuation.get(5, TimeUnit.SECONDS);
+
+        assertEquals(2, loads.get());
+        assertEquals(20L, retryFuture.get().get(5, TimeUnit.SECONDS).getCollectionID());
+    }
+
+    @Test
+    void inlineRetryAfterSynchronousFailureStartsNewLoadGeneration() throws Exception {
+        SchemaCache cache = new SchemaCache();
+        CountDownLatch loaderStarted = new CountDownLatch(1);
+        CountDownLatch releaseLoader = new CountDownLatch(1);
+        AtomicInteger loads = new AtomicInteger();
+        AtomicReference<Throwable> synchronousFailure = new AtomicReference<>();
+        AtomicReference<CompletableFuture<DescribeCollectionResponse>> retryFuture = new AtomicReference<>();
+
+        Thread synchronousLoader = new Thread(() -> {
+            try {
+                cache.getOrLoad("host:19530", "db", "coll", false, loadScope, () -> {
+                    loads.incrementAndGet();
+                    loaderStarted.countDown();
+                    await(releaseLoader);
+                    throw new IllegalStateException("load failed");
+                });
+            } catch (Throwable throwable) {
+                synchronousFailure.set(throwable);
+            }
+        });
+        synchronousLoader.start();
+        assertTrue(loaderStarted.await(5, TimeUnit.SECONDS));
+
+        CompletableFuture<DescribeCollectionResponse> waiter = cache.getOrLoadAsync(
+                "host:19530", "db", "coll", false, loadScope,
+                () -> CompletableFuture.completedFuture(response(99L)));
+        CompletableFuture<Void> continuation = waiter.handle((ignoredResponse, failure) -> {
+            retryFuture.set(cache.getOrLoadAsync(
+                    "host:19530", "db", "coll", false, loadScope, () -> {
+                        loads.incrementAndGet();
+                        return CompletableFuture.completedFuture(response(21L));
+                    }));
+            return null;
+        });
+
+        try {
+            releaseLoader.countDown();
+            continuation.get(5, TimeUnit.SECONDS);
+            synchronousLoader.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertFalse(synchronousLoader.isAlive());
+            assertTrue(synchronousFailure.get() instanceof IllegalStateException);
+            assertEquals(2, loads.get());
+            assertEquals(21L, retryFuture.get().get(5, TimeUnit.SECONDS).getCollectionID());
+        } finally {
+            releaseLoader.countDown();
+            synchronousLoader.join(TimeUnit.SECONDS.toMillis(5));
+        }
     }
 
     @Test
@@ -371,6 +546,16 @@ class SchemaCacheTest {
         while (!lock.hasQueuedThread(thread)) {
             if (System.nanoTime() >= deadline) {
                 throw new AssertionError("Loader did not reach the schema publication boundary");
+            }
+            Thread.yield();
+        }
+    }
+
+    private static void awaitWaiting(Thread thread) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (thread.getState() != Thread.State.WAITING) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Synchronous caller did not wait for the async schema load");
             }
             Thread.yield();
         }

--- a/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
@@ -19,6 +19,7 @@
 
 package io.milvus.v2;
 
+import com.google.common.util.concurrent.Futures;
 import io.milvus.grpc.*;
 import io.milvus.v2.client.MilvusClientV2;
 import org.junit.jupiter.api.AfterEach;
@@ -46,11 +47,15 @@ public class BaseTest {
     public MilvusClientV2 client_v2 = new MilvusClientV2(null);
     @Mock
     protected MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub;
+    @Mock
+    protected MilvusServiceGrpc.MilvusServiceFutureStub futureStub;
 
     @BeforeEach
     public void setUp() {
         client_v2.setBlockingStub(blockingStub);
+        client_v2.setFutureStub(futureStub);
         when(blockingStub.withDeadlineAfter(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(blockingStub);
+        when(futureStub.withDeadlineAfter(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(futureStub);
 
         Status successStatus = Status.newBuilder().setCode(0).build();
         BoolResponse trueResponse = BoolResponse.newBuilder().setStatus(successStatus).setValue(Boolean.TRUE).build();
@@ -122,6 +127,7 @@ public class BaseTest {
         when(blockingStub.truncateCollection(any())).thenReturn(TruncateCollectionResponse.newBuilder().setStatus(successStatus).build());
         when(blockingStub.hasCollection(any())).thenReturn(trueResponse);
         when(blockingStub.describeCollection(any())).thenReturn(describeCollectionResponse);
+        when(futureStub.describeCollection(any())).thenReturn(Futures.immediateFuture(describeCollectionResponse));
         when(blockingStub.batchDescribeCollection(any())).thenReturn(BatchDescribeCollectionResponse.newBuilder()
                 .setStatus(successStatus)
                 .addResponses(describeCollectionResponse)
@@ -139,6 +145,7 @@ public class BaseTest {
         when(blockingStub.insert(any())).thenReturn(MutationResult.newBuilder().setInsertCnt(2L).build());
         when(blockingStub.upsert(any())).thenReturn(MutationResult.newBuilder().setUpsertCnt(2L).build());
         when(blockingStub.query(any())).thenReturn(QueryResults.newBuilder().build());
+        when(futureStub.query(any())).thenReturn(Futures.immediateFuture(QueryResults.newBuilder().build()));
         when(blockingStub.delete(any())).thenReturn(MutationResult.newBuilder().setDeleteCnt(2L).build());
         SearchResults searchResults = SearchResults.newBuilder()
                 .setStatus(Status.newBuilder().setCode(0)
@@ -151,6 +158,8 @@ public class BaseTest {
                 .build();
         when(blockingStub.search(any())).thenReturn(searchResults);
         when(blockingStub.hybridSearch(any())).thenReturn(searchResults);
+        when(futureStub.search(any())).thenReturn(Futures.immediateFuture(searchResults));
+        when(futureStub.hybridSearch(any())).thenReturn(Futures.immediateFuture(searchResults));
 
         // partition api
         when(blockingStub.createPartition(any())).thenReturn(successStatus);

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -19,8 +19,11 @@
 
 package io.milvus.v2.service.vector;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.JsonObject;
 import io.milvus.common.utils.JsonUtils;
+import io.milvus.common.utils.cache.SchemaCache;
 import io.milvus.grpc.*;
 import io.milvus.param.Constant;
 import io.milvus.v2.BaseTest;
@@ -50,8 +53,14 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -141,6 +150,129 @@ class VectorTest extends BaseTest {
     }
 
     @Test
+    void testQueryAsync() throws Exception {
+        QueryReq request = QueryReq.builder()
+                .collectionName("book")
+                .filter("id > 0")
+                .limit(10)
+                .build();
+
+        QueryResp response = client_v2.queryAsync(request).get(1, TimeUnit.SECONDS);
+
+        Assertions.assertNotNull(response);
+        verify(futureStub).query(any(QueryRequest.class));
+        verify(blockingStub, never()).query(any(QueryRequest.class));
+    }
+
+    @Test
+    void testQueryAsyncWithIdsLoadsSchemaAsynchronously() throws Exception {
+        SchemaCache.getInstance().clear();
+        SettableFuture<DescribeCollectionResponse> schemaFuture = SettableFuture.create();
+        when(futureStub.describeCollection(any())).thenReturn(schemaFuture);
+        QueryReq request = QueryReq.builder()
+                .collectionName("book")
+                .ids(Collections.singletonList(1L))
+                .limit(10)
+                .build();
+
+        try {
+            CompletableFuture<QueryResp> resultFuture = client_v2.queryAsync(request);
+
+            Assertions.assertFalse(resultFuture.isDone());
+            verify(futureStub).describeCollection(any(DescribeCollectionRequest.class));
+            verify(blockingStub, never()).describeCollection(any(DescribeCollectionRequest.class));
+            verify(futureStub, never()).query(any(QueryRequest.class));
+
+            schemaFuture.set(describeCollectionResponse());
+            Assertions.assertNotNull(resultFuture.get(1, TimeUnit.SECONDS));
+            ArgumentCaptor<QueryRequest> queryCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+            verify(futureStub).query(queryCaptor.capture());
+            Assertions.assertEquals("id in [1]", queryCaptor.getValue().getExpr());
+        } finally {
+            SchemaCache.getInstance().clear();
+        }
+    }
+
+    @Test
+    void testQueryAsyncSnapshotsRequestBeforeSchemaLoad() throws Exception {
+        SchemaCache.getInstance().clear();
+        SettableFuture<DescribeCollectionResponse> schemaFuture = SettableFuture.create();
+        when(futureStub.describeCollection(any())).thenReturn(schemaFuture);
+        List<String> outputFields = new ArrayList<>(Collections.singletonList("original_field"));
+        QueryReq request = QueryReq.builder()
+                .databaseName("original_db")
+                .collectionName("original_collection")
+                .ids(Collections.singletonList(1L))
+                .outputFields(outputFields)
+                .limit(10)
+                .build();
+
+        try {
+            CompletableFuture<QueryResp> first = client_v2.session("cluster-a").queryAsync(request);
+            CompletableFuture<QueryResp> second = client_v2.session("cluster-b").queryAsync(request);
+
+            request.setDatabaseName("mutated_db");
+            request.setCollectionName("mutated_collection");
+            request.setClusterId("cluster-c");
+            request.setLimit(20);
+            outputFields.add("mutated_field");
+
+            schemaFuture.set(describeCollectionResponse());
+            first.get(1, TimeUnit.SECONDS);
+            second.get(1, TimeUnit.SECONDS);
+
+            ArgumentCaptor<QueryRequest> queryCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+            verify(futureStub, times(2)).query(queryCaptor.capture());
+            Set<String> clusterIds = new HashSet<>();
+            for (QueryRequest rpcRequest : queryCaptor.getAllValues()) {
+                Assertions.assertEquals("original_db", rpcRequest.getDbName());
+                Assertions.assertEquals("original_collection", rpcRequest.getCollectionName());
+                Assertions.assertEquals(Collections.singletonList("original_field"),
+                        rpcRequest.getOutputFieldsList());
+                Assertions.assertEquals("10", getParam(rpcRequest.getQueryParamsList(), Constant.LIMIT));
+                clusterIds.add(getParam(rpcRequest.getQueryParamsList(), Constant.CLUSTER_ID));
+            }
+            Assertions.assertEquals(new HashSet<>(Arrays.asList("cluster-a", "cluster-b")), clusterIds);
+        } finally {
+            SchemaCache.getInstance().clear();
+        }
+    }
+
+    @Test
+    void testQueryAsyncCancellationPropagatesToQueryRpc() {
+        SettableFuture<QueryResults> grpcFuture = SettableFuture.create();
+        when(futureStub.query(any())).thenReturn(grpcFuture);
+        QueryReq request = QueryReq.builder()
+                .collectionName("book")
+                .filter("id > 0")
+                .build();
+
+        CompletableFuture<QueryResp> resultFuture = client_v2.queryAsync(request);
+        Assertions.assertTrue(resultFuture.cancel(true));
+
+        Assertions.assertTrue(grpcFuture.isCancelled());
+    }
+
+    @Test
+    void testQueryAsyncValidationFailureCompletesExceptionally() {
+        QueryReq request = QueryReq.builder()
+                .collectionName("book")
+                .filter("id > 0")
+                .ids(Collections.singletonList(1L))
+                .build();
+
+        CompletableFuture<QueryResp> future = Assertions.assertDoesNotThrow(
+                () -> client_v2.queryAsync(request));
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                () -> future.get(1, TimeUnit.SECONDS));
+
+        Assertions.assertTrue(exception.getCause() instanceof MilvusClientException);
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS,
+                ((MilvusClientException) exception.getCause()).getErrorCode());
+        verify(futureStub, never()).query(any(QueryRequest.class));
+    }
+
+    @Test
     void testSearch() {
         List<Float> vectorList = new ArrayList<>();
         vectorList.add(1.0f);
@@ -157,6 +289,151 @@ class VectorTest extends BaseTest {
         Assertions.assertEquals(456L, statusR.getScannedRemoteBytes());
         Assertions.assertEquals(789L, statusR.getScannedTotalBytes());
         Assertions.assertEquals(0.5f, statusR.getCacheHitRatio());
+    }
+
+    @Test
+    void testSearchAsync() throws Exception {
+        SearchReq request = SearchReq.builder()
+                .collectionName("test2")
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+
+        SearchResp response = client_v2.searchAsync(request).get(1, TimeUnit.SECONDS);
+
+        Assertions.assertEquals(123L, response.getCost());
+        Assertions.assertEquals(456L, response.getScannedRemoteBytes());
+        Assertions.assertEquals(789L, response.getScannedTotalBytes());
+        Assertions.assertEquals(0.5f, response.getCacheHitRatio());
+        verify(futureStub).search(any(SearchRequest.class));
+        verify(blockingStub, never()).search(any(SearchRequest.class));
+    }
+
+    @Test
+    void testSearchAsyncServerFailureCompletesExceptionally() {
+        SearchResults failedResponse = SearchResults.newBuilder()
+                .setStatus(Status.newBuilder().setCode(1).setReason("search failed").build())
+                .build();
+        when(futureStub.search(any())).thenReturn(Futures.immediateFuture(failedResponse));
+        SearchReq request = SearchReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                () -> client_v2.searchAsync(request).get(1, TimeUnit.SECONDS));
+
+        Assertions.assertTrue(exception.getCause() instanceof MilvusClientException);
+        Assertions.assertEquals(ErrorCode.SERVER_ERROR,
+                ((MilvusClientException) exception.getCause()).getErrorCode());
+    }
+
+    @Test
+    void testSearchAsyncCancellationPropagatesToGrpcFuture() {
+        SettableFuture<SearchResults> grpcFuture = SettableFuture.create();
+        when(futureStub.search(any())).thenReturn(grpcFuture);
+        SearchReq request = SearchReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+
+        CompletableFuture<SearchResp> future = client_v2.searchAsync(request);
+        Assertions.assertTrue(future.cancel(true));
+
+        Assertions.assertTrue(grpcFuture.isCancelled());
+    }
+
+    @Test
+    void testHybridSearchAsync() throws Exception {
+        AnnSearchReq annSearchReq = AnnSearchReq.builder()
+                .vectorFieldName("vector")
+                .vectors(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+        HybridSearchReq request = HybridSearchReq.builder()
+                .collectionName("test")
+                .searchRequests(Collections.singletonList(annSearchReq))
+                .limit(10)
+                .build();
+
+        SearchResp response = client_v2.hybridSearchAsync(request).get(1, TimeUnit.SECONDS);
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(123L, response.getCost());
+        verify(futureStub).hybridSearch(any(HybridSearchRequest.class));
+        verify(blockingStub, never()).hybridSearch(any(HybridSearchRequest.class));
+    }
+
+    @Test
+    void testAsyncDqlRetriesUseSubmissionSnapshots() throws Exception {
+        client_v2.retryConfig(io.milvus.v2.client.RetryConfig.builder()
+                .maxRetryTimes(2)
+                .initialBackOffMs(0)
+                .maxBackOffMs(0)
+                .build());
+
+        SettableFuture<QueryResults> firstQuery = SettableFuture.create();
+        when(futureStub.query(any())).thenReturn(firstQuery,
+                Futures.immediateFuture(QueryResults.newBuilder().build()));
+        QueryReq queryReq = QueryReq.builder()
+                .collectionName("query_original")
+                .filter("id > 0")
+                .build();
+        CompletableFuture<QueryResp> queryFuture = client_v2.queryAsync(queryReq);
+        queryReq.setCollectionName("query_mutated");
+        firstQuery.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
+        queryFuture.get(1, TimeUnit.SECONDS);
+        ArgumentCaptor<QueryRequest> queryCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(futureStub, times(2)).query(queryCaptor.capture());
+        queryCaptor.getAllValues().forEach(rpcRequest ->
+                Assertions.assertEquals("query_original", rpcRequest.getCollectionName()));
+
+        clearInvocations(futureStub);
+        SettableFuture<SearchResults> firstSearch = SettableFuture.create();
+        when(futureStub.search(any())).thenReturn(firstSearch,
+                Futures.immediateFuture(SearchResults.newBuilder().build()));
+        SearchReq searchReq = SearchReq.builder()
+                .collectionName("search_original")
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+        CompletableFuture<SearchResp> searchFuture = client_v2.searchAsync(searchReq);
+        searchReq.setCollectionName("search_mutated");
+        firstSearch.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
+        searchFuture.get(1, TimeUnit.SECONDS);
+        ArgumentCaptor<SearchRequest> searchCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(futureStub, times(2)).search(searchCaptor.capture());
+        searchCaptor.getAllValues().forEach(rpcRequest ->
+                Assertions.assertEquals("search_original", rpcRequest.getCollectionName()));
+
+        clearInvocations(futureStub);
+        SettableFuture<SearchResults> firstHybridSearch = SettableFuture.create();
+        when(futureStub.hybridSearch(any())).thenReturn(firstHybridSearch,
+                Futures.immediateFuture(SearchResults.newBuilder().build()));
+        AnnSearchReq annSearchReq = AnnSearchReq.builder()
+                .vectorFieldName("vector")
+                .vectors(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+        HybridSearchReq hybridSearchReq = HybridSearchReq.builder()
+                .collectionName("hybrid_original")
+                .searchRequests(Collections.singletonList(annSearchReq))
+                .limit(10)
+                .build();
+        CompletableFuture<SearchResp> hybridFuture = client_v2.hybridSearchAsync(hybridSearchReq);
+        hybridSearchReq.setCollectionName("hybrid_mutated");
+        annSearchReq.setVectorFieldName("mutated_vector");
+        firstHybridSearch.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
+        hybridFuture.get(1, TimeUnit.SECONDS);
+        ArgumentCaptor<HybridSearchRequest> hybridCaptor = ArgumentCaptor.forClass(HybridSearchRequest.class);
+        verify(futureStub, times(2)).hybridSearch(hybridCaptor.capture());
+        hybridCaptor.getAllValues().forEach(rpcRequest -> {
+            Assertions.assertEquals("hybrid_original", rpcRequest.getCollectionName());
+            Assertions.assertEquals("vector",
+                    getParam(rpcRequest.getRequests(0).getSearchParamsList(), Constant.VECTOR_FIELD));
+        });
     }
 
     @Test
@@ -327,6 +604,48 @@ class VectorTest extends BaseTest {
         verify(blockingStub).hybridSearch(captor.capture());
         Assertions.assertEquals("cluster-a", getParam(captor.getValue().getRankParamsList(), Constant.CLUSTER_ID));
         Assertions.assertEquals("cluster-a", request.getClusterId());
+    }
+
+    @Test
+    void testSessionAsyncOperationsPassClusterId() throws Exception {
+        SearchReq searchRequest = SearchReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+        QueryReq queryRequest = QueryReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .build();
+        AnnSearchReq annSearchReq = AnnSearchReq.builder()
+                .vectorFieldName("vector")
+                .vectors(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(10)
+                .build();
+        HybridSearchReq hybridSearchRequest = HybridSearchReq.builder()
+                .collectionName("test")
+                .searchRequests(Collections.singletonList(annSearchReq))
+                .limit(10)
+                .build();
+
+        client_v2.session("cluster-a").searchAsync(searchRequest).get(1, TimeUnit.SECONDS);
+        client_v2.session("cluster-a").queryAsync(queryRequest).get(1, TimeUnit.SECONDS);
+        client_v2.session("cluster-a").hybridSearchAsync(hybridSearchRequest).get(1, TimeUnit.SECONDS);
+
+        ArgumentCaptor<SearchRequest> searchCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(futureStub).search(searchCaptor.capture());
+        Assertions.assertEquals("cluster-a",
+                getParam(searchCaptor.getValue().getSearchParamsList(), Constant.CLUSTER_ID));
+
+        ArgumentCaptor<QueryRequest> queryCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(futureStub).query(queryCaptor.capture());
+        Assertions.assertEquals("cluster-a",
+                getParam(queryCaptor.getValue().getQueryParamsList(), Constant.CLUSTER_ID));
+
+        ArgumentCaptor<HybridSearchRequest> hybridCaptor = ArgumentCaptor.forClass(HybridSearchRequest.class);
+        verify(futureStub).hybridSearch(hybridCaptor.capture());
+        Assertions.assertEquals("cluster-a",
+                getParam(hybridCaptor.getValue().getRankParamsList(), Constant.CLUSTER_ID));
     }
 
     @Test
@@ -657,6 +976,28 @@ class VectorTest extends BaseTest {
                 .subAggregation(SearchAggregation.builder()
                         .addField("brand")
                         .size(3)
+                        .build())
+                .build();
+    }
+
+    private DescribeCollectionResponse describeCollectionResponse() {
+        return DescribeCollectionResponse.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0).build())
+                .setCollectionName("book")
+                .setSchema(CollectionSchema.newBuilder()
+                        .addFields(FieldSchema.newBuilder()
+                                .setName("id")
+                                .setDataType(DataType.Int64)
+                                .setIsPrimaryKey(true)
+                                .build())
+                        .addFields(FieldSchema.newBuilder()
+                                .setName("vector")
+                                .setDataType(DataType.FloatVector)
+                                .addTypeParams(KeyValuePair.newBuilder()
+                                        .setKey("dim")
+                                        .setValue("2")
+                                        .build())
+                                .build())
                         .build())
                 .build();
     }

--- a/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/RpcUtilsTest.java
@@ -26,9 +26,162 @@ import io.milvus.v2.exception.MilvusClientException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RpcUtilsTest {
+
+    @Test
+    void testRetryAsyncSuccess() throws Exception {
+        RpcUtils rpcUtils = new RpcUtils();
+
+        String result = rpcUtils.retryAsync(() -> CompletableFuture.completedFuture("ok"))
+                .get(1, TimeUnit.SECONDS);
+
+        Assertions.assertEquals("ok", result);
+    }
+
+    @Test
+    void testRetryAsyncRetriesUnavailable() throws Exception {
+        RpcUtils rpcUtils = new RpcUtils();
+        rpcUtils.retryConfig(RetryConfig.builder()
+                .maxRetryTimes(3)
+                .initialBackOffMs(1)
+                .maxBackOffMs(1)
+                .backOffMultiplier(1)
+                .build());
+        AtomicInteger callCount = new AtomicInteger();
+
+        String result = rpcUtils.retryAsync(() -> {
+            if (callCount.incrementAndGet() < 3) {
+                CompletableFuture<String> failed = new CompletableFuture<>();
+                failed.completeExceptionally(new StatusRuntimeException(
+                        io.grpc.Status.UNAVAILABLE.withDescription("server unavailable")));
+                return failed;
+            }
+            return CompletableFuture.completedFuture("ok");
+        }).get(1, TimeUnit.SECONDS);
+
+        Assertions.assertEquals("ok", result);
+        Assertions.assertEquals(3, callCount.get());
+    }
+
+    @Test
+    void testRetryAsyncZeroBackoffDoesNotLoseRetryGeneration() {
+        RpcUtils rpcUtils = new RpcUtils();
+        int maxRetryTimes = 20;
+        rpcUtils.retryConfig(RetryConfig.builder()
+                .maxRetryTimes(maxRetryTimes)
+                .initialBackOffMs(0)
+                .maxBackOffMs(0)
+                .backOffMultiplier(1)
+                .build());
+
+        for (int round = 0; round < 100; round++) {
+            AtomicInteger callCount = new AtomicInteger();
+            ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                    () -> rpcUtils.retryAsync(() -> {
+                        callCount.incrementAndGet();
+                        CompletableFuture<String> failed = new CompletableFuture<>();
+                        failed.completeExceptionally(new StatusRuntimeException(
+                                io.grpc.Status.UNAVAILABLE.withDescription("server unavailable")));
+                        return failed;
+                    }).get(2, TimeUnit.SECONDS));
+
+            Assertions.assertTrue(exception.getCause() instanceof MilvusClientException);
+            Assertions.assertEquals(ErrorCode.TIMEOUT,
+                    ((MilvusClientException) exception.getCause()).getErrorCode());
+            Assertions.assertEquals(maxRetryTimes, callCount.get());
+        }
+    }
+
+    @Test
+    void testRetryAsyncDoesNotRetryInvalidArgument() {
+        RpcUtils rpcUtils = new RpcUtils();
+        AtomicInteger callCount = new AtomicInteger();
+        StatusRuntimeException original = new StatusRuntimeException(
+                io.grpc.Status.INVALID_ARGUMENT.withDescription("invalid"));
+
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                () -> rpcUtils.retryAsync(() -> {
+                    callCount.incrementAndGet();
+                    CompletableFuture<String> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(original);
+                    return failed;
+                }).get(1, TimeUnit.SECONDS));
+
+        Assertions.assertEquals(1, callCount.get());
+        Assertions.assertTrue(exception.getCause() instanceof MilvusClientException);
+        MilvusClientException clientException = (MilvusClientException) exception.getCause();
+        Assertions.assertEquals(ErrorCode.RPC_ERROR, clientException.getErrorCode());
+        Assertions.assertSame(original, clientException.getCause());
+    }
+
+    @Test
+    void testRetryDoesNotRetryInvalidArgumentPreservesCause() {
+        RpcUtils rpcUtils = new RpcUtils();
+        AtomicInteger callCount = new AtomicInteger();
+        StatusRuntimeException original = new StatusRuntimeException(
+                io.grpc.Status.INVALID_ARGUMENT.withDescription("invalid"));
+
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> rpcUtils.retry(() -> {
+                    callCount.incrementAndGet();
+                    throw original;
+                }));
+
+        Assertions.assertEquals(1, callCount.get());
+        Assertions.assertEquals(ErrorCode.RPC_ERROR, exception.getErrorCode());
+        Assertions.assertSame(original, exception.getCause());
+    }
+
+    @Test
+    void testRetryAsyncPreservesClientException() {
+        RpcUtils rpcUtils = new RpcUtils();
+        MilvusClientException original = new MilvusClientException(ErrorCode.INVALID_PARAMS, "invalid");
+
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                () -> rpcUtils.retryAsync(() -> {
+                    CompletableFuture<String> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(original);
+                    return failed;
+                }).get(1, TimeUnit.SECONDS));
+
+        Assertions.assertSame(original, exception.getCause());
+    }
+
+    @Test
+    void testRetryAsyncCancellationCancelsActiveAttempt() {
+        RpcUtils rpcUtils = new RpcUtils();
+        CompletableFuture<String> activeAttempt = new CompletableFuture<>();
+
+        CompletableFuture<String> result = rpcUtils.retryAsync(() -> activeAttempt);
+        Assertions.assertTrue(result.cancel(true));
+
+        Assertions.assertTrue(activeAttempt.isCancelled());
+    }
+
+    @Test
+    void testRetryAsyncNoRetryMapsRpcFailure() {
+        RpcUtils rpcUtils = new RpcUtils();
+        rpcUtils.retryConfig(RetryConfig.builder().maxRetryTimes(1).build());
+        AtomicInteger callCount = new AtomicInteger();
+
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class,
+                () -> rpcUtils.retryAsync(() -> {
+                    callCount.incrementAndGet();
+                    CompletableFuture<String> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(new StatusRuntimeException(io.grpc.Status.UNAVAILABLE));
+                    return failed;
+                }).get(1, TimeUnit.SECONDS));
+
+        Assertions.assertEquals(1, callCount.get());
+        Assertions.assertTrue(exception.getCause() instanceof MilvusClientException);
+        Assertions.assertEquals(ErrorCode.RPC_ERROR,
+                ((MilvusClientException) exception.getCause()).getErrorCode());
+    }
 
     @Test
     void testEarlyExitWhenPredictedBackoffExceedsMaxRetryTimeoutMs() {


### PR DESCRIPTION
  - Add CompletableFuture-based async APIs for query, search, and hybrid search.
  - Use gRPC future stubs with retry, deadline, global-cluster refresh, and cancellation support.
  - Add async APIs to client sessions and regression tests for success, errors, retries, and cancellation.