### PR TITLE
fix: avoid sending empty analyzer params in runAnalyzer

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -377,14 +377,16 @@ public class VectorService extends BaseService {
 
         String params = JsonUtils.toJson(request.getAnalyzerParams());
         logger.debug(params);
-        RunAnalyzerRequest runRequest = builder.addAllPlaceholder(byteStrings)
-                .setAnalyzerParams(params)
+        RunAnalyzerRequest.Builder runRequestBuilder = builder.addAllPlaceholder(byteStrings)
                 .setWithDetail(request.getWithDetail())
                 .setWithHash(request.getWithHash())
                 .setDbName(request.getDatabaseName())
                 .setCollectionName(request.getCollectionName())
-                .setFieldName(request.getFieldName())
-                .build();
+                .setFieldName(request.getFieldName());
+        if (request.getAnalyzerParams() != null && !request.getAnalyzerParams().isEmpty()) {
+            runRequestBuilder.setAnalyzerParams(params);
+        }
+        RunAnalyzerRequest runRequest = runRequestBuilder.build();
         RunAnalyzerResponse response = blockingStub.runAnalyzer(runRequest);
         rpcUtils.handleResponse(title, response.getStatus());
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -380,7 +380,7 @@ public class VectorService extends BaseService {
         RunAnalyzerRequest.Builder runRequestBuilder = builder.addAllPlaceholder(byteStrings)
                 .setWithDetail(request.getWithDetail())
                 .setWithHash(request.getWithHash())
-                .setDbName(request.getDatabaseName())
+                .setDbName(actualDbName(request.getDatabaseName()))
                 .setCollectionName(request.getCollectionName())
                 .setFieldName(request.getFieldName());
         if (request.getAnalyzerParams() != null && !request.getAnalyzerParams().isEmpty()) {

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
@@ -4239,6 +4239,50 @@ class MilvusClientV2DockerTest {
     }
 
     @Test
+    void testRunAnalyzerCollectionMode() {
+        String collectionName = generator.generate(10);
+        CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(Boolean.TRUE)
+                .autoID(Boolean.FALSE)
+                .build());
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("vector")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+        Map<String, Object> analyzerParams = new HashMap<>();
+        analyzerParams.put("tokenizer", "standard");
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("text")
+                .dataType(DataType.VarChar)
+                .maxLength(100)
+                .enableAnalyzer(true)
+                .analyzerParams(analyzerParams)
+                .build());
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(collectionSchema)
+                .build());
+
+        try {
+            RunAnalyzerResp resp = client.runAnalyzer(RunAnalyzerReq.builder()
+                    .collectionName(collectionName)
+                    .fieldName("text")
+                    .texts(Arrays.asList("Analyzers tokenizers for multi languages"))
+                    .build());
+            List<RunAnalyzerResp.AnalyzerResult> results = resp.getResults();
+            Assertions.assertEquals(1, results.size());
+            Assertions.assertFalse(results.get(0).getTokens().isEmpty());
+        } finally {
+            client.dropCollection(DropCollectionReq.builder().collectionName(collectionName).build());
+        }
+    }
+
+    @Test
     void testConsistencyLevel() throws InterruptedException {
         String randomCollectionName = generator.generate(10);
         String pkName = "pk";

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
@@ -4268,6 +4268,20 @@ class MilvusClientV2DockerTest {
                 .collectionSchema(collectionSchema)
                 .build());
 
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("vector")
+                .indexType(IndexParam.IndexType.AUTOINDEX)
+                .metricType(IndexParam.MetricType.COSINE)
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(indexParam))
+                .build());
+
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
         try {
             RunAnalyzerResp resp = client.runAnalyzer(RunAnalyzerReq.builder()
                     .collectionName(collectionName)


### PR DESCRIPTION
# fix: avoid sending empty analyzer params in runAnalyzer

Fixes #2013

See also #2017 for the master branch.

## Problem
  `VectorService.runAnalyzer()` unconditionally calls `setAnalyzerParams(JsonUtils.toJson(request.getAnalyzerParams()))`. Since `RunAnalyzerReqBuilder` initializes `analyzerParams` to an
     empty `HashMap`, the collection-based mode (passing `collectionName` / `fieldName` without `analyzerParams`) results in `analyzer_params = "{}"`, which the server rejects with:

```
run analyzer can't use analyzer params and (collection,field) in same time
```

## Fix

Only set `analyzer_params` on the gRPC request when `analyzerParams` is non-empty. The `!isEmpty()` check is the operative fix (the builder always initializes `analyzerParams` to an empty map); the `!= null` check is defensive-only.

## Verification

- Before: `runAnalyzer(collectionName=..., fieldName="page_content", texts=[...])` fails with the error above.
- After: the same request succeeds, while the `analyzerParams`-only mode still works as before.