### PR TITLE
fix: avoid sending empty analyzer params in runAnalyzer (#2017)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -744,14 +744,16 @@ public class VectorService extends BaseService {
 
         String params = JsonUtils.toJson(request.getAnalyzerParams());
         logger.debug(params);
-        RunAnalyzerRequest runRequest = builder.addAllPlaceholder(byteStrings)
-                .setAnalyzerParams(params)
+        RunAnalyzerRequest.Builder runRequestBuilder = builder.addAllPlaceholder(byteStrings)
                 .setWithDetail(request.getWithDetail())
                 .setWithHash(request.getWithHash())
-                .setDbName(request.getDatabaseName())
+                .setDbName(actualDbName(request.getDatabaseName()))
                 .setCollectionName(request.getCollectionName())
-                .setFieldName(request.getFieldName())
-                .build();
+                .setFieldName(request.getFieldName());
+        if (request.getAnalyzerParams() != null && !request.getAnalyzerParams().isEmpty()) {
+            runRequestBuilder.setAnalyzerParams(params);
+        }
+        RunAnalyzerRequest runRequest = runRequestBuilder.build();
         RunAnalyzerResponse response = blockingStub.runAnalyzer(runRequest);
         rpcUtils.handleResponse(title, response.getStatus());
 

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2DockerTest.java
@@ -4735,6 +4735,64 @@ class MilvusClientV2DockerTest {
     }
 
     @Test
+    void testRunAnalyzerCollectionMode() {
+        String collectionName = generator.generate(10);
+        CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(Boolean.TRUE)
+                .autoID(Boolean.FALSE)
+                .build());
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("vector")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+        Map<String, Object> analyzerParams = new HashMap<>();
+        analyzerParams.put("tokenizer", "standard");
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName("text")
+                .dataType(DataType.VarChar)
+                .maxLength(100)
+                .enableAnalyzer(true)
+                .analyzerParams(analyzerParams)
+                .build());
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(collectionSchema)
+                .build());
+
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("vector")
+                .indexType(IndexParam.IndexType.AUTOINDEX)
+                .metricType(IndexParam.MetricType.COSINE)
+                .build();
+        client.createIndex(CreateIndexReq.builder()
+                .collectionName(collectionName)
+                .indexParams(Collections.singletonList(indexParam))
+                .build());
+
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+
+        try {
+            RunAnalyzerResp resp = client.runAnalyzer(RunAnalyzerReq.builder()
+                    .collectionName(collectionName)
+                    .fieldName("text")
+                    .texts(Arrays.asList("Analyzers tokenizers for multi languages"))
+                    .build());
+            List<RunAnalyzerResp.AnalyzerResult> results = resp.getResults();
+            Assertions.assertEquals(1, results.size());
+            Assertions.assertFalse(results.get(0).getTokens().isEmpty());
+        } finally {
+            client.dropCollection(DropCollectionReq.builder().collectionName(collectionName).build());
+        }
+    }
+
+    @Test
     void testConsistencyLevel() throws InterruptedException {
         String randomCollectionName = generator.generate(10);
         String pkName = "pk";


### PR DESCRIPTION
* fix: avoid sending empty analyzer params in runAnalyzer



* fix: resolve database name in runAnalyzer

Use actualDbName() to resolve the target database, consistent with other vector operations, so runAnalyzer in collection mode works with non-default databases.



* fix: load collection with index for runAnalyzer collection mode test

The server requires the collection to be loaded when running the analyzer in collection mode. Create an index on the vector field and load the collection before calling runAnalyzer.



---------