### PR TITLE
[cherry-pick] feat: add client telemetry support (#2040)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/client/AbstractMilvusGrpcClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/AbstractMilvusGrpcClient.java
@@ -37,6 +37,7 @@ import io.milvus.exception.ServerException;
 import io.milvus.grpc.*;
 import io.milvus.orm.iterator.QueryIterator;
 import io.milvus.orm.iterator.RpcStubWrapper;
+import io.milvus.telemetry.TelemetryInterceptor;
 import io.milvus.orm.iterator.SearchIterator;
 import io.milvus.param.*;
 import io.milvus.param.alias.AlterAliasParam;
@@ -89,7 +90,9 @@ public abstract class AbstractMilvusGrpcClient implements MilvusClient {
     protected abstract String currentEndpoint();
 
     private RpcStubWrapper createIteratorRpcStub(String databaseName) {
-        return new RpcStubWrapper(blockingStub(), 0L, currentEndpoint(), actualDbName(databaseName));
+        return new RpcStubWrapper(blockingStub().withOption(
+                TelemetryInterceptor.LOGICAL_OPERATION_OPTION, true),
+                0L, currentEndpoint(), actualDbName(databaseName));
     }
 
     private String actualDbName(String overwriteName) {

--- a/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
+++ b/sdk-core/src/main/java/io/milvus/client/MilvusServiceClient.java
@@ -19,12 +19,17 @@
 
 package io.milvus.client;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.*;
 import io.grpc.Status;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.stub.MetadataUtils;
+import io.milvus.common.interceptor.ClientRequestInterceptor;
 import io.milvus.common.interceptor.IdentifierInterceptor;
 import io.milvus.common.utils.ExceptionUtils;
 import io.milvus.exception.MilvusException;
@@ -56,6 +61,8 @@ import io.milvus.param.index.*;
 import io.milvus.param.partition.*;
 import io.milvus.param.resourcegroup.*;
 import io.milvus.param.role.*;
+import io.milvus.telemetry.ClientTelemetryManager;
+import io.milvus.telemetry.TelemetryInterceptor;
 import io.milvus.v2.utils.ClientUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,7 +72,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -79,11 +88,24 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
     private RetryParam retryParam = RetryParam.newBuilder().build();
     private String currentDatabaseName;
     private final String endpoint;
+    private final ClientTelemetryManager telemetry;
+    private final boolean ownsTelemetry;
+    private final ThreadLocal<String> clientRequestId;
+    private final ThreadLocal<Integer> logicalOperationDepth =
+            ThreadLocal.withInitial(() -> 0);
 
     public MilvusServiceClient(ConnectParam connectParam) {
         ExceptionUtils.checkNotNull(connectParam, connectParam.getClass().getSimpleName());
         this.rpcDeadlineMs = connectParam.getRpcDeadlineMs();
         this.endpoint = connectParam.getHost() + ":" + connectParam.getPort();
+        this.telemetry = new ClientTelemetryManager(
+                connectParam.getTelemetryConfig(),
+                connectParam.getUserName(),
+                getSDKVersion(),
+                () -> currentDatabaseName,
+                () -> telemetryUserConfig(connectParam));
+        this.ownsTelemetry = true;
+        this.clientRequestId = connectParam.getClientRequestId();
 
         Metadata metadata = new Metadata();
         metadata.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), connectParam.getAuthorization());
@@ -94,22 +116,8 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
 
         List<ClientInterceptor> clientInterceptors = new ArrayList<>();
         clientInterceptors.add(MetadataUtils.newAttachHeadersInterceptor(metadata));
-        //client interceptor used to fetch client_request_id from threadlocal variable and set it for every grpc request
-        clientInterceptors.add(new ClientInterceptor() {
-            @Override
-            public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-                return new ForwardingClientCall
-                        .SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-                    @Override
-                    public void start(ClientCall.Listener<RespT> responseListener, Metadata headers) {
-                        if (connectParam.getClientRequestId() != null && !StringUtils.isEmpty(connectParam.getClientRequestId().get())) {
-                            headers.put(Metadata.Key.of("client_request_id", Metadata.ASCII_STRING_MARSHALLER), connectParam.getClientRequestId().get());
-                        }
-                        super.start(responseListener, headers);
-                    }
-                };
-            }
-        });
+        clientInterceptors.add(new ClientRequestInterceptor(connectParam.getClientRequestId()));
+        clientInterceptors.add(new TelemetryInterceptor(telemetry, connectParam.getClientRequestId()));
 
         try {
             if (StringUtils.isNotEmpty(connectParam.getServerPemPath())) {
@@ -210,6 +218,8 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
                     new IdentifierInterceptor(identifier));
             blockingStub = MilvusServiceGrpc.newBlockingStub(interceptedChannel);
             futureStub = MilvusServiceGrpc.newFutureStub(interceptedChannel);
+            telemetry.setStub(ClientTelemetryServiceGrpc.newBlockingStub(interceptedChannel));
+            telemetry.start();
         } catch (Exception e) {
             // close the channel if connect() throws exception, avoid leakage
             try {
@@ -232,6 +242,11 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
         this.retryParam = src.retryParam;
         this.currentDatabaseName = src.currentDatabaseName;
         this.endpoint = src.endpoint;
+        this.telemetry = src.telemetry;
+        // Fluent wrappers share the channel and therefore share its lifecycle. Closing any
+        // wrapper closes that channel, so it must close the shared telemetry worker as well.
+        this.ownsTelemetry = true;
+        this.clientRequestId = src.clientRequestId;
     }
 
     @Override
@@ -265,8 +280,27 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
 
     @Override
     public void close(long maxWaitSeconds) throws InterruptedException {
+        if (ownsTelemetry) {
+            telemetry.close();
+        }
         channel.shutdownNow();
         channel.awaitTermination(maxWaitSeconds, TimeUnit.SECONDS);
+    }
+
+    /** Returns the telemetry manager for metrics inspection and custom command handlers. */
+    public ClientTelemetryManager getTelemetry() {
+        return telemetry;
+    }
+
+    private static Map<String, Object> telemetryUserConfig(ConnectParam connectParam) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("address", connectParam.getHost() + ":" + connectParam.getPort());
+        result.put("username", connectParam.getUserName());
+        result.put("db_name", connectParam.getDatabaseName());
+        result.put("secure", connectParam.isSecure());
+        result.put("connect_timeout_ms", connectParam.getConnectTimeoutMs());
+        result.put("rpc_deadline_ms", connectParam.getRpcDeadlineMs());
+        return result;
     }
 
     private static class TimeoutInterceptor implements ClientInterceptor {
@@ -437,6 +471,98 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
         String msg = String.format("Finish %d retry times, stop retry", maxRetryTimes);
         logError(msg);
         return R.failed(new RuntimeException(msg));
+    }
+
+    private String captureClientRequestId() {
+        String value = clientRequestId == null ? null : clientRequestId.get();
+        return ClientRequestInterceptor.isValidClientRequestId(value) ? value : "";
+    }
+
+    private <T> R<T> recordLogicalOperation(
+            String operation, String collection, java.util.function.Supplier<R<T>> supplier) {
+        int depth = logicalOperationDepth.get();
+        logicalOperationDepth.set(depth + 1);
+        long startNanos = System.nanoTime();
+        String requestId = captureClientRequestId();
+        try (ClientTelemetryManager.LogicalOperationScope ignored =
+                     telemetry.beginLogicalOperation()) {
+            R<T> result = supplier.get();
+            if (depth == 0) {
+                recordLogicalResult(operation, collection, startNanos, resultError(result), requestId);
+            }
+            return result;
+        } catch (RuntimeException | Error throwable) {
+            if (depth == 0) {
+                recordLogicalResult(operation, collection, startNanos, throwable.toString(), requestId);
+            }
+            throw throwable;
+        } finally {
+            resetLogicalOperationDepth(depth);
+        }
+    }
+
+    private <T> ListenableFuture<R<T>> recordLogicalOperationAsync(
+            String operation, String collection,
+            java.util.function.Supplier<ListenableFuture<R<T>>> supplier) {
+        int depth = logicalOperationDepth.get();
+        logicalOperationDepth.set(depth + 1);
+        long startNanos = System.nanoTime();
+        String requestId = captureClientRequestId();
+        final ListenableFuture<R<T>> future;
+        try (ClientTelemetryManager.LogicalOperationScope ignored =
+                     telemetry.beginLogicalOperation()) {
+            future = supplier.get();
+        } catch (RuntimeException | Error throwable) {
+            if (depth == 0) {
+                recordLogicalResult(operation, collection, startNanos, throwable.toString(), requestId);
+            }
+            throw throwable;
+        } finally {
+            resetLogicalOperationDepth(depth);
+        }
+        if (depth == 0) {
+            Futures.addCallback(future, new FutureCallback<R<T>>() {
+                @Override
+                public void onSuccess(R<T> result) {
+                    recordLogicalResult(operation, collection, startNanos, resultError(result), requestId);
+                }
+
+                @Override
+                public void onFailure(Throwable throwable) {
+                    recordLogicalResult(operation, collection, startNanos, throwable.toString(), requestId);
+                }
+            }, MoreExecutors.directExecutor());
+        }
+        return future;
+    }
+
+    private void resetLogicalOperationDepth(int depth) {
+        if (depth == 0) {
+            logicalOperationDepth.remove();
+        } else {
+            logicalOperationDepth.set(depth);
+        }
+    }
+
+    private static String resultError(R<?> result) {
+        if (result != null && Integer.valueOf(R.Status.Success.getCode()).equals(result.getStatus())) {
+            return "";
+        }
+        if (result != null && result.getException() != null) {
+            return result.getException().toString();
+        }
+        return result == null ? "Milvus operation returned null"
+                : "Milvus operation failed with status " + result.getStatus();
+    }
+
+    private void recordLogicalResult(
+            String operation, String collection, long startNanos, String error, String requestId) {
+        try {
+            telemetry.recordOperation(operation, collection == null ? "" : collection,
+                    startNanos, error, requestId);
+        } catch (RuntimeException ignored) {
+            // Telemetry is best-effort and must never replace the operation result.
+        }
     }
 
     /**
@@ -670,32 +796,79 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
 
     @Override
     public R<MutationResult> insert(InsertParam requestParam) {
-        return retry(() -> super.insert(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Insert", collection,
+                () -> retry(() -> super.insert(requestParam)));
     }
 
     @Override
     public R<MutationResult> upsert(UpsertParam requestParam) {
-        return retry(() -> super.upsert(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Upsert", collection,
+                () -> retry(() -> super.upsert(requestParam)));
     }
 
     @Override
     public R<MutationResult> delete(DeleteParam requestParam) {
-        return retry(() -> super.delete(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Delete", collection,
+                () -> retry(() -> super.delete(requestParam)));
     }
 
     @Override
     public R<SearchResults> search(SearchParam requestParam) {
-        return retry(() -> super.search(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Search", collection,
+                () -> retry(() -> super.search(requestParam)));
     }
 
     @Override
     public R<SearchResults> hybridSearch(HybridSearchParam requestParam) {
-        return retry(() -> super.hybridSearch(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("HybridSearch", collection,
+                () -> retry(() -> super.hybridSearch(requestParam)));
     }
 
     @Override
     public R<QueryResults> query(QueryParam requestParam) {
-        return retry(() -> super.query(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Query", collection,
+                () -> retry(() -> super.query(requestParam)));
+    }
+
+    @Override
+    public ListenableFuture<R<MutationResult>> insertAsync(InsertParam requestParam) {
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperationAsync("Insert", collection,
+                () -> super.insertAsync(requestParam));
+    }
+
+    @Override
+    public ListenableFuture<R<MutationResult>> upsertAsync(UpsertParam requestParam) {
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperationAsync("Upsert", collection,
+                () -> super.upsertAsync(requestParam));
+    }
+
+    @Override
+    public ListenableFuture<R<SearchResults>> searchAsync(SearchParam requestParam) {
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperationAsync("Search", collection,
+                () -> super.searchAsync(requestParam));
+    }
+
+    @Override
+    public ListenableFuture<R<SearchResults>> hybridSearchAsync(HybridSearchParam requestParam) {
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperationAsync("HybridSearch", collection,
+                () -> super.hybridSearchAsync(requestParam));
+    }
+
+    @Override
+    public ListenableFuture<R<QueryResults>> queryAsync(QueryParam requestParam) {
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperationAsync("Query", collection,
+                () -> super.queryAsync(requestParam));
     }
 
     @Override
@@ -910,27 +1083,38 @@ public class MilvusServiceClient extends AbstractMilvusGrpcClient {
 
     @Override
     public R<InsertResponse> insert(InsertRowsParam requestParam) {
-        return retry(() -> super.insert(requestParam));
+        String collection = requestParam == null || requestParam.getInsertParam() == null
+                ? "" : requestParam.getInsertParam().getCollectionName();
+        return recordLogicalOperation("Insert", collection,
+                () -> retry(() -> super.insert(requestParam)));
     }
 
     @Override
     public R<DeleteResponse> delete(DeleteIdsParam requestParam) {
-        return retry(() -> super.delete(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Delete", collection,
+                () -> retry(() -> super.delete(requestParam)));
     }
 
     @Override
     public R<GetResponse> get(GetIdsParam requestParam) {
-        return retry(() -> super.get(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Query", collection,
+                () -> retry(() -> super.get(requestParam)));
     }
 
     @Override
     public R<QueryResponse> query(QuerySimpleParam requestParam) {
-        return retry(() -> super.query(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Query", collection,
+                () -> retry(() -> super.query(requestParam)));
     }
 
     @Override
     public R<SearchResponse> search(SearchSimpleParam requestParam) {
-        return retry(() -> super.search(requestParam));
+        String collection = requestParam == null ? "" : requestParam.getCollectionName();
+        return recordLogicalOperation("Search", collection,
+                () -> retry(() -> super.search(requestParam)));
     }
 
     @Override

--- a/sdk-core/src/main/java/io/milvus/common/interceptor/ClientRequestInterceptor.java
+++ b/sdk-core/src/main/java/io/milvus/common/interceptor/ClientRequestInterceptor.java
@@ -56,11 +56,30 @@ public class ClientRequestInterceptor implements ClientInterceptor {
                 if (requestId == null && clientRequestId != null) {
                     requestId = clientRequestId.get();
                 }
+                // client_request_id predates telemetry and accepts arbitrary caller-provided
+                // correlation IDs. Telemetry separately applies the strict OTel trace-ID check
+                // before copying this value into error details.
                 if (StringUtils.isNotEmpty(requestId)) {
                     headers.put(CLIENT_REQUEST_ID_HEADER, requestId);
                 }
                 super.start(responseListener, headers);
             }
         };
+    }
+
+    /** Mirrors the server's OpenTelemetry TraceID parser. */
+    public static boolean isValidClientRequestId(String requestId) {
+        if (StringUtils.length(requestId) != 32) {
+            return false;
+        }
+        boolean nonZero = false;
+        for (int index = 0; index < requestId.length(); index++) {
+            char value = requestId.charAt(index);
+            if (!((value >= '0' && value <= '9') || (value >= 'a' && value <= 'f'))) {
+                return false;
+            }
+            nonZero |= value != '0';
+        }
+        return nonZero;
     }
 }

--- a/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/ConnectParam.java
@@ -21,6 +21,7 @@ package io.milvus.param;
 
 import io.milvus.common.utils.URLParser;
 import io.milvus.exception.ParamException;
+import io.milvus.telemetry.TelemetryConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -61,6 +62,7 @@ public class ConnectParam {
     private final ThreadLocal<String> clientRequestId;
     private final String proxyAddress;
     private final Map<String, String> option;
+    private final TelemetryConfig telemetryConfig;
 
     protected ConnectParam(Builder builder) {
         if (builder == null) {
@@ -88,6 +90,7 @@ public class ConnectParam {
         this.clientRequestId = builder.clientRequestId;
         this.proxyAddress = builder.proxyAddress;
         this.option = builder.option;
+        this.telemetryConfig = builder.telemetryConfig;
     }
 
     public static Builder newBuilder() {
@@ -182,6 +185,10 @@ public class ConnectParam {
         return option;
     }
 
+    public TelemetryConfig getTelemetryConfig() {
+        return telemetryConfig;
+    }
+
     @Override
     public String toString() {
         return "ConnectParam{" +
@@ -244,6 +251,7 @@ public class ConnectParam {
 
         private String proxyAddress;
         private Map<String, String> option = new HashMap<>();
+        private TelemetryConfig telemetryConfig = TelemetryConfig.defaults();
 
         protected Builder() {
         }
@@ -334,6 +342,10 @@ public class ConnectParam {
 
         public Map<String, String> getOption() {
             return option;
+        }
+
+        public TelemetryConfig getTelemetryConfig() {
+            return telemetryConfig;
         }
 
         /**
@@ -640,6 +652,11 @@ public class ConnectParam {
          */
         public Builder withOption(Map<String, String> option) {
             this.option = option;
+            return this;
+        }
+
+        public Builder withTelemetryConfig(TelemetryConfig telemetryConfig) {
+            this.telemetryConfig = telemetryConfig == null ? TelemetryConfig.defaults() : telemetryConfig;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/telemetry/ClientTelemetryManager.java
+++ b/sdk-core/src/main/java/io/milvus/telemetry/ClientTelemetryManager.java
@@ -1,0 +1,1628 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.milvus.grpc.ClientCommand;
+import io.milvus.grpc.ClientHeartbeatRequest;
+import io.milvus.grpc.ClientHeartbeatResponse;
+import io.milvus.grpc.ClientInfo;
+import io.milvus.grpc.ClientTelemetryServiceGrpc;
+import io.milvus.grpc.CommandReply;
+import io.milvus.grpc.Metrics;
+import io.milvus.grpc.OperationMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.OffsetDateTime;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Collects client operation metrics and exchanges heartbeat commands with Milvus.
+ *
+ * <p>The manager is thread-safe. Command replies remain queued until a heartbeat succeeds,
+ * and persistent command hashes are deterministic across SDK languages.</p>
+ */
+public final class ClientTelemetryManager implements AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(ClientTelemetryManager.class);
+    private static final Gson GSON = new Gson();
+    private static final int SAMPLE_BUFFER_SIZE = 1000;
+    private static final int HISTORY_SAMPLE_SIZE = 128;
+    private static final long SNAPSHOT_HISTORY_TTL_MS = TimeUnit.HOURS.toMillis(1);
+    private static final int SNAPSHOT_HARD_LIMIT = 4096;
+    /**
+     * Fixed-point unit for accumulating a fractional sampling rate. A rate becomes an
+     * integer step of this many units, so the smallest rate that still samples is 1e-9 --
+     * far below anything an operator would set, which is the point: a configured rate must
+     * never round down to "off".
+     */
+    private static final long SAMPLING_SCALE = 1_000_000_000L;
+    private static final int MAX_REPLY_BYTES = 1024 * 1024;
+    private static final long MAX_UNIMPLEMENTED_BACKOFF_MS = TimeUnit.MINUTES.toMillis(30);
+    private static final SecureRandom REQUEST_ID_RANDOM = new SecureRandom();
+    private static final List<String> PUSH_CONFIG_KEYS = Arrays.asList(
+            "enabled", "heartbeat_interval_ms", "sampling_rate");
+    private static final Pattern RFC3339_TIMESTAMP = Pattern.compile(
+            "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2})(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$");
+
+    private final TelemetryConfig config;
+    private final String clientId;
+    private final boolean stableClientId;
+    private final String user;
+    private final String sdkVersion;
+    private final Supplier<String> databaseProvider;
+    private final Supplier<Map<String, Object>> configProvider;
+    private final Map<String, Collector> collectors = new HashMap<>();
+    private final Set<String> enabledCollections = new HashSet<>();
+    private final Deque<ErrorInfo> errors;
+    private final Deque<MetricsSnapshot> snapshots = new ArrayDeque<>();
+    private final List<CommandReply> pendingReplies = new ArrayList<>();
+    private final Map<String, Long> executedCommands = new HashMap<>();
+    private final Map<String, CommandHandler> handlers = new HashMap<>();
+    private final Map<String, CommandHandler> customHandlers = new HashMap<>();
+    /**
+     * Carries the fractional sampling rate between calls, in SAMPLING_SCALE units: each
+     * operation adds the rate and the one that pushes it past a whole unit is the one
+     * sampled. See shouldSample.
+     */
+    private final AtomicLong samplingAccum = new AtomicLong();
+    private final ThreadLocal<Integer> logicalOperationDepth =
+            ThreadLocal.withInitial(() -> 0);
+    private final AtomicBoolean ready = new AtomicBoolean();
+    private final AtomicBoolean controlPlaneActivated = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final ScheduledExecutorService executor;
+    private final Object heartbeatLifecycle = new Object();
+    private final Object heartbeatRetirement = new Object();
+    private final Object runtimeStateHandoff = new Object();
+
+    private volatile ClientTelemetryServiceGrpc.ClientTelemetryServiceBlockingStub stub;
+    private volatile ClientTelemetryManager handoffTarget;
+    private volatile boolean allCollectionsEnabled;
+    private volatile long lastCommandTimestamp;
+    private volatile String configHash = "";
+    private volatile int unsupportedStreak;
+    private volatile Throwable lastHeartbeatError;
+    private volatile long lastSnapshotEnd;
+    private long heartbeatGeneration;
+    private boolean retirementPending;
+
+    public ClientTelemetryManager(
+            TelemetryConfig config,
+            String user,
+            String sdkVersion,
+            Supplier<String> databaseProvider,
+            Supplier<Map<String, Object>> configProvider) {
+        this(config, user, sdkVersion, databaseProvider, configProvider, "");
+    }
+
+    public ClientTelemetryManager(
+            TelemetryConfig config,
+            String user,
+            String sdkVersion,
+            Supplier<String> databaseProvider,
+            Supplier<Map<String, Object>> configProvider,
+            String runtimeClientId) {
+        this.config = config == null ? TelemetryConfig.defaults() : config;
+        this.stableClientId = this.config.getClientId() != null && !this.config.getClientId().isEmpty();
+        this.clientId = stableClientId
+                ? this.config.getClientId()
+                : (runtimeClientId == null || runtimeClientId.isEmpty()
+                        ? UUID.randomUUID().toString() : runtimeClientId);
+        this.user = user == null ? "" : user;
+        this.sdkVersion = sdkVersion == null ? "" : sdkVersion;
+        this.databaseProvider = databaseProvider == null ? () -> "" : databaseProvider;
+        this.configProvider = configProvider == null ? HashMap::new : configProvider;
+        this.errors = new ArrayDeque<>(this.config.getErrorMaxCount());
+        this.executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "milvus-telemetry-" + clientId.substring(0, Math.min(8, clientId.length())));
+            thread.setDaemon(true);
+            return thread;
+        });
+        registerDefaultHandlers();
+    }
+
+    public void setStub(ClientTelemetryServiceGrpc.ClientTelemetryServiceBlockingStub stub) {
+        this.stub = stub;
+    }
+
+    public void start() {
+        if (closed.get()) {
+            return;
+        }
+        if (!ready.compareAndSet(false, true)) {
+            return;
+        }
+        if (closed.get()) {
+            ready.compareAndSet(true, false);
+            return;
+        }
+        if (!config.isEnabled() && !controlPlaneActivated.get()) {
+            return;
+        }
+        controlPlaneActivated.set(true);
+        try {
+            executor.execute(this::heartbeatAndScheduleNext);
+        } catch (RuntimeException exception) {
+            lastHeartbeatError = exception;
+            ready.compareAndSet(true, false);
+        }
+    }
+
+    public boolean isReady() {
+        return ready.get();
+    }
+
+    public boolean isClosed() {
+        return closed.get();
+    }
+
+    public boolean isSupported() {
+        return unsupportedStreak == 0;
+    }
+
+    public Throwable getLastHeartbeatError() {
+        return lastHeartbeatError;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    /** Returns a non-zero lowercase OpenTelemetry TraceID for client_request_id. */
+    public static String newClientRequestId() {
+        byte[] value = new byte[16];
+        do {
+            REQUEST_ID_RANDOM.nextBytes(value);
+        } while (allZero(value));
+        StringBuilder result = new StringBuilder(32);
+        for (byte item : value) {
+            result.append(String.format("%02x", item & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static boolean allZero(byte[] value) {
+        for (byte item : value) {
+            if (item != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public String getConfigHash() {
+        return configHash;
+    }
+
+    public long getLastCommandTimestamp() {
+        return lastCommandTimestamp;
+    }
+
+    public TelemetryConfig getConfig() {
+        return config;
+    }
+
+    public synchronized void registerCommandHandler(String type, CommandHandler handler) {
+        handlers.put(type, handler);
+        customHandlers.put(type, handler);
+    }
+
+    public synchronized RuntimeState snapshotRuntimeState() {
+        List<ErrorInfo> errorValues;
+        synchronized (errors) {
+            errorValues = new ArrayList<>(errors);
+        }
+        List<MetricsSnapshot> snapshotValues;
+        synchronized (snapshots) {
+            pruneSnapshotsLocked(System.currentTimeMillis());
+            snapshotValues = new ArrayList<>(snapshots);
+        }
+        List<CommandReply> replyValues;
+        synchronized (pendingReplies) {
+            replyValues = new ArrayList<>(pendingReplies);
+        }
+        Map<String, Long> commandValues;
+        synchronized (executedCommands) {
+            commandValues = new HashMap<>(executedCommands);
+        }
+        Set<String> collectionValues;
+        boolean allCollections;
+        synchronized (enabledCollections) {
+            collectionValues = new HashSet<>(enabledCollections);
+            allCollections = allCollectionsEnabled;
+        }
+        Map<String, CommandHandler> handlerValues = new HashMap<>(customHandlers);
+        Map<String, Collector> collectorValues = new HashMap<>();
+        synchronized (collectors) {
+            for (Map.Entry<String, Collector> entry : collectors.entrySet()) {
+                collectorValues.put(entry.getKey(), entry.getValue().copy());
+            }
+        }
+        return new RuntimeState(
+                clientId,
+                configHash,
+                lastCommandTimestamp,
+                replyValues,
+                commandValues,
+                collectionValues,
+                allCollections,
+                handlerValues,
+                errorValues,
+                snapshotValues,
+                collectorValues,
+                samplingAccum.get(),
+                lastSnapshotEnd,
+                unsupportedStreak,
+                lastHeartbeatError,
+                controlPlaneActivated.get(),
+                config.isEnabled(),
+                config.getHeartbeatIntervalMs(),
+                config.getSamplingRate());
+    }
+
+    public synchronized void restoreRuntimeState(RuntimeState state) {
+        if (state == null) {
+            return;
+        }
+        if (!clientId.equals(state.clientId)) {
+            throw new IllegalArgumentException("telemetry runtime state belongs to a different client ID");
+        }
+        config.setEnabled(state.enabled);
+        config.setHeartbeatIntervalMs(state.heartbeatIntervalMs);
+        config.setSamplingRate(state.samplingRate);
+        configHash = state.configHash;
+        lastCommandTimestamp = state.lastCommandTimestamp;
+        samplingAccum.set(state.samplingAccum);
+        lastSnapshotEnd = state.lastSnapshotEnd;
+        unsupportedStreak = state.unsupportedStreak;
+        lastHeartbeatError = state.lastHeartbeatError;
+        controlPlaneActivated.set(state.controlPlaneActivated);
+        synchronized (pendingReplies) {
+            pendingReplies.clear();
+            pendingReplies.addAll(state.pendingReplies);
+        }
+        synchronized (executedCommands) {
+            executedCommands.clear();
+            executedCommands.putAll(state.executedCommands);
+        }
+        synchronized (enabledCollections) {
+            enabledCollections.clear();
+            enabledCollections.addAll(state.enabledCollections);
+            allCollectionsEnabled = state.allCollectionsEnabled;
+        }
+        synchronized (errors) {
+            errors.clear();
+            errors.addAll(state.errors);
+            while (errors.size() > config.getErrorMaxCount()) {
+                errors.removeFirst();
+            }
+        }
+        synchronized (snapshots) {
+            snapshots.clear();
+            snapshots.addAll(state.snapshots);
+            pruneSnapshotsLocked(System.currentTimeMillis());
+        }
+        synchronized (collectors) {
+            collectors.clear();
+            for (Map.Entry<String, Collector> entry : state.collectors.entrySet()) {
+                collectors.put(entry.getKey(), entry.getValue().copy());
+            }
+        }
+        customHandlers.clear();
+        customHandlers.putAll(state.customHandlers);
+        handlers.putAll(state.customHandlers);
+    }
+
+    /** Atomically hands state to a replacement manager after its last heartbeat finishes. */
+    public RuntimeState snapshotAndCloseRuntimeState() {
+        synchronized (heartbeatLifecycle) {
+            RuntimeState state = snapshotRuntimeState();
+            close();
+            return state;
+        }
+    }
+
+    /**
+     * Invalidates an in-flight heartbeat and prevents another one from starting while the
+     * surrounding connection switch is pending. The token can be cancelled if that switch
+     * rolls back, without making the old manager unusable.
+     */
+    public long beginRuntimeStateRetirement() {
+        synchronized (heartbeatRetirement) {
+            if (retirementPending) {
+                throw new IllegalStateException("telemetry retirement is already pending");
+            }
+            retirementPending = true;
+            return ++heartbeatGeneration;
+        }
+    }
+
+    /** Restores the old manager after the surrounding connection switch rolls back. */
+    public void cancelRuntimeStateRetirement(long retirementToken) {
+        synchronized (heartbeatRetirement) {
+            if (retirementPending && retirementToken == heartbeatGeneration) {
+                retirementPending = false;
+            }
+        }
+    }
+
+    /** Completes a state handoff that was fenced before the outer client switch committed. */
+    public void handoffRuntimeStateTo(
+            ClientTelemetryManager replacement, long retirementToken) {
+        if (replacement == null || replacement == this) {
+            throw new IllegalArgumentException("replacement telemetry manager is required");
+        }
+        if (replacement.isReady()) {
+            throw new IllegalStateException("replacement telemetry worker must be deferred");
+        }
+        synchronized (heartbeatRetirement) {
+            if (!retirementPending || retirementToken != heartbeatGeneration) {
+                throw new IllegalStateException("telemetry retirement token is not active");
+            }
+        }
+        synchronized (heartbeatLifecycle) {
+            synchronized (runtimeStateHandoff) {
+                if (closed.get()) {
+                    throw new IllegalStateException("telemetry manager is already closed");
+                }
+                synchronized (replacement.runtimeStateHandoff) {
+                    if (replacement.handoffTarget != this) {
+                        throw new IllegalStateException("replacement telemetry manager was not prepared");
+                    }
+                    replacement.restoreRuntimeState(snapshotRuntimeState());
+                    replacement.handoffTarget = null;
+                    handoffTarget = replacement;
+                    close();
+                }
+            }
+        }
+        replacement.start();
+    }
+
+    /** Redirects replacement-client operations to the active manager until the switch commits. */
+    public void prepareRuntimeStateHandoffFrom(ClientTelemetryManager activeManager) {
+        if (activeManager == null || activeManager == this) {
+            throw new IllegalArgumentException("active telemetry manager is required");
+        }
+        if (isReady() || isClosed()) {
+            throw new IllegalStateException("replacement telemetry worker must be deferred and open");
+        }
+        synchronized (runtimeStateHandoff) {
+            handoffTarget = activeManager;
+        }
+    }
+
+    /** Cancels a prepared handoff after the surrounding client switch failed. */
+    public void cancelRuntimeStateHandoffFrom(ClientTelemetryManager activeManager) {
+        synchronized (runtimeStateHandoff) {
+            if (handoffTarget == activeManager) {
+                handoffTarget = null;
+            }
+        }
+    }
+
+    public void recordOperation(
+            String operation, String collection, long startNanos, String error, String requestId) {
+        ClientTelemetryManager target;
+        synchronized (runtimeStateHandoff) {
+            target = handoffTarget;
+            if (target == null) {
+                recordOperationLocally(operation, collection, startNanos, error, requestId);
+            }
+        }
+        if (target != null) {
+            target.recordOperation(operation, collection, startNanos, error, requestId);
+        }
+    }
+
+    /** Suppresses per-attempt interceptor metrics for this manager only. */
+    public LogicalOperationScope beginLogicalOperation() {
+        logicalOperationDepth.set(logicalOperationDepth.get() + 1);
+        return new LogicalOperationScope();
+    }
+
+    boolean isLogicalOperationActive() {
+        return logicalOperationDepth.get() > 0;
+    }
+
+    private void recordOperationLocally(
+            String operation, String collection, long startNanos, String error, String requestId) {
+        if (!config.isEnabled() || !shouldSample(config.getSamplingRate())) {
+            return;
+        }
+        long latencyMicros = Math.max(0, TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - startNanos));
+        String collectionKey;
+        synchronized (enabledCollections) {
+            collectionKey = allCollectionsEnabled || enabledCollections.contains(collection) ? collection : "";
+        }
+        synchronized (collectors) {
+            collectors.computeIfAbsent(operation, ignored -> new Collector())
+                    .record(collectionKey, latencyMicros, error == null || error.isEmpty());
+        }
+        if (error != null && !error.isEmpty()) {
+            synchronized (errors) {
+                while (errors.size() >= config.getErrorMaxCount()) {
+                    errors.removeFirst();
+                }
+                errors.addLast(new ErrorInfo(
+                        System.currentTimeMillis(), operation, error,
+                        collection == null ? "" : collection, requestId == null ? "" : requestId));
+            }
+        }
+    }
+
+    public List<ErrorInfo> getRecentErrors(int maxCount) {
+        List<ErrorInfo> result;
+        synchronized (errors) {
+            result = new ArrayList<>(errors);
+        }
+        Collections.reverse(result);
+        if (maxCount >= 0 && result.size() > maxCount) {
+            return new ArrayList<>(result.subList(0, maxCount));
+        }
+        return result;
+    }
+
+    public List<MetricsSnapshot> getMetricsSnapshots() {
+        synchronized (snapshots) {
+            pruneSnapshotsLocked(System.currentTimeMillis());
+            return new ArrayList<>(snapshots);
+        }
+    }
+
+    public synchronized void processCommands(List<ClientCommand> commands) {
+        long previousTimestamp = lastCommandTimestamp;
+        long maxTimestamp = previousTimestamp;
+        boolean hasPersistent = false;
+        for (ClientCommand command : commands) {
+            maxTimestamp = Math.max(maxTimestamp, command.getCreateTime());
+            hasPersistent |= command.getPersistent();
+            if (command.getCreateTime() < previousTimestamp) {
+                queueReply(successReply(command.getCommandId(), ByteString.EMPTY));
+                continue;
+            }
+            synchronized (executedCommands) {
+                if (executedCommands.containsKey(command.getCommandId())) {
+                    queueReply(successReply(command.getCommandId(), ByteString.EMPTY));
+                    continue;
+                }
+            }
+            CommandReply reply = handleCommand(command);
+            synchronized (executedCommands) {
+                executedCommands.put(command.getCommandId(), command.getCreateTime());
+            }
+            if (reply != null) {
+                queueReply(reply);
+            }
+        }
+        long cursorTimestamp = maxTimestamp;
+        synchronized (executedCommands) {
+            // Keep every ID at the current cursor. The server may resend a batch with the same
+            // timestamp more than once; retaining those IDs prevents the third delivery from
+            // executing after the second delivery's cleanup.
+            executedCommands.entrySet().removeIf(entry -> entry.getValue() < cursorTimestamp);
+        }
+        if (hasPersistent) {
+            configHash = calculateConfigHash(commands);
+        }
+        lastCommandTimestamp = Math.max(lastCommandTimestamp, maxTimestamp);
+    }
+
+    public static String calculateConfigHash(List<ClientCommand> commands) {
+        List<ClientCommand> persistent = new ArrayList<>();
+        for (ClientCommand command : commands) {
+            if (command.getPersistent()) {
+                persistent.add(command);
+            }
+        }
+        if (persistent.isEmpty()) {
+            return "";
+        }
+        persistent.sort(Comparator.comparing(ClientCommand::getCommandId));
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (ClientCommand command : persistent) {
+                digest.update(command.getCommandId().getBytes(StandardCharsets.UTF_8));
+                digest.update(command.getCommandType().getBytes(StandardCharsets.UTF_8));
+                digest.update(command.getPayload().toByteArray());
+            }
+            byte[] hash = digest.digest();
+            StringBuilder result = new StringBuilder(16);
+            for (int index = 0; index < 8; index++) {
+                result.append(String.format("%02x", hash[index]));
+            }
+            return result.toString();
+        } catch (Exception exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+
+    private void heartbeatAndScheduleNext() {
+        synchronized (heartbeatLifecycle) {
+            if (closed.get()) {
+                return;
+            }
+            createSnapshot();
+            sendHeartbeat();
+            if (!closed.get()) {
+                executor.schedule(this::heartbeatAndScheduleNext, nextDelayMs(), TimeUnit.MILLISECONDS);
+            }
+        }
+    }
+
+    private long nextDelayMs() {
+        long interval = Math.max(1, config.getHeartbeatIntervalMs());
+        if (unsupportedStreak <= 0) {
+            return interval;
+        }
+        int exponent = Math.min(unsupportedStreak, 30);
+        long multiplier = 1L << Math.min(exponent, 20);
+        long delay = interval > Long.MAX_VALUE / multiplier ? Long.MAX_VALUE : interval * multiplier;
+        return Math.max(interval, Math.min(MAX_UNIMPLEMENTED_BACKOFF_MS, delay));
+    }
+
+    private void sendHeartbeat() {
+        ClientTelemetryServiceGrpc.ClientTelemetryServiceBlockingStub currentStub;
+        long requestGeneration;
+        boolean metricsEnabled;
+        synchronized (heartbeatRetirement) {
+            if (retirementPending) {
+                return;
+            }
+            currentStub = stub;
+            requestGeneration = heartbeatGeneration;
+            metricsEnabled = config.isEnabled();
+            if (currentStub == null) {
+                return;
+            }
+        }
+        MetricsSnapshot latest;
+        synchronized (snapshots) {
+            latest = metricsEnabled ? snapshots.peekLast() : null;
+        }
+        List<CommandReply> replies;
+        synchronized (pendingReplies) {
+            replies = new ArrayList<>(pendingReplies);
+        }
+        ClientHeartbeatRequest request = ClientHeartbeatRequest.newBuilder()
+                .setClientInfo(buildClientInfo())
+                .setReportTimestamp(System.currentTimeMillis())
+                .addAllMetrics(toProtoMetrics(latest == null ? Collections.emptyList() : latest.metrics))
+                .addAllCommandReplies(replies)
+                .setConfigHash(configHash)
+                .setLastCommandTimestamp(lastCommandTimestamp)
+                .build();
+        try {
+            ClientHeartbeatResponse response = currentStub.withDeadlineAfter(10, TimeUnit.SECONDS)
+                    .clientHeartbeat(request);
+            synchronized (heartbeatRetirement) {
+                if (retirementPending || requestGeneration != heartbeatGeneration) {
+                    return;
+                }
+                // Any real response proves the server implements telemetry. Business errors must
+                // not preserve an earlier UNIMPLEMENTED backoff.
+                unsupportedStreak = 0;
+                if (response.getStatus().getCode() != 0
+                        || response.getStatus().getErrorCodeValue() != 0) {
+                    lastHeartbeatError = new IllegalStateException(
+                            response.getStatus().getReason());
+                    return;
+                }
+                lastHeartbeatError = null;
+                synchronized (pendingReplies) {
+                    int sent = Math.min(replies.size(), pendingReplies.size());
+                    pendingReplies.subList(0, sent).clear();
+                }
+                processCommands(response.getCommandsList());
+            }
+        } catch (StatusRuntimeException exception) {
+            synchronized (heartbeatRetirement) {
+                if (retirementPending || requestGeneration != heartbeatGeneration) {
+                    return;
+                }
+                lastHeartbeatError = exception;
+                if (exception.getStatus().getCode() == Status.Code.UNIMPLEMENTED) {
+                    unsupportedStreak++;
+                }
+            }
+        } catch (RuntimeException exception) {
+            synchronized (heartbeatRetirement) {
+                if (retirementPending || requestGeneration != heartbeatGeneration) {
+                    return;
+                }
+                lastHeartbeatError = exception;
+                logger.debug("Client telemetry heartbeat failed", exception);
+            }
+        }
+    }
+
+    private ClientInfo buildClientInfo() {
+        Map<String, String> reserved = new HashMap<>();
+        reserved.put("client_id", clientId);
+        reserved.put("client_id_stable", String.valueOf(stableClientId));
+        String database = databaseProvider.get();
+        if (database != null && !database.isEmpty()) {
+            reserved.put("db_name", database);
+        }
+        String host = "Unknown";
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (Exception ignored) {
+            // Best effort metadata.
+        }
+        return ClientInfo.newBuilder()
+                .setSdkType("Java")
+                .setSdkVersion(sdkVersion)
+                .setUser(user)
+                .setHost(host)
+                .setLocalTime(OffsetDateTime.now().toString())
+                .putAllReserved(reserved)
+                .build();
+    }
+
+    /**
+     * Decides whether this operation is recorded, spreading the sampled ones evenly rather
+     * than in runs.
+     *
+     * <p>Each call adds the rate to a shared accumulator and samples on the call that
+     * carries it across a whole unit: at 0.25 that is every fourth operation. What matters
+     * is that the ratio holds over any stretch of calls, not only over a long one --
+     * metrics are reported per heartbeat window, and a window is tens or hundreds of
+     * operations. A scheme that sampled a contiguous run and then dropped one would give
+     * the right long-run ratio while making every individual window either complete or
+     * empty.
+     *
+     * <p>The accumulator is shared, so concurrent callers reorder which of them observes a
+     * crossing, but each crossing is observed exactly once: addAndGet hands every caller a
+     * distinct interval and the step is smaller than one unit, so no interval spans two
+     * crossings.
+     */
+    private boolean shouldSample(double rate) {
+        if (rate >= 1.0) {
+            return true;
+        }
+        if (rate <= 0.0) {
+            return false;
+        }
+        // A rate too small to represent still means "sample rarely", never "sample never":
+        // silently disabling telemetry for a positive rate is the one outcome nobody could
+        // have intended.
+        long step = Math.max(1L, (long) (rate * SAMPLING_SCALE));
+        long after = samplingAccum.addAndGet(step);
+        long before = after - step;
+        return after / SAMPLING_SCALE != before / SAMPLING_SCALE;
+    }
+
+    private void createSnapshot() {
+        if (!config.isEnabled()) {
+            return;
+        }
+        CollectionScope collectionScope = snapshotCollectionScope();
+        List<OperationSnapshot> metrics = new ArrayList<>();
+        synchronized (collectors) {
+            for (Map.Entry<String, Collector> entry : collectors.entrySet()) {
+                OperationSnapshot snapshot = entry.getValue().snapshot(entry.getKey());
+                if (snapshot != null) {
+                    metrics.add(filterCollectionMetrics(snapshot, collectionScope));
+                }
+            }
+        }
+        long now = System.currentTimeMillis();
+        long start = lastSnapshotEnd == 0 || lastSnapshotEnd > now
+                ? now - config.getHeartbeatIntervalMs() : lastSnapshotEnd;
+        lastSnapshotEnd = now;
+        synchronized (snapshots) {
+            snapshots.addLast(new MetricsSnapshot(start, now, metrics));
+            pruneSnapshotsLocked(now);
+        }
+    }
+
+    private void pruneSnapshotsLocked(long now) {
+        long cutoff = now - SNAPSHOT_HISTORY_TTL_MS;
+        while (!snapshots.isEmpty() && snapshots.peekFirst().end_time < cutoff) {
+            snapshots.removeFirst();
+        }
+        while (snapshots.size() > SNAPSHOT_HARD_LIMIT) {
+            snapshots.removeFirst();
+        }
+    }
+
+    private List<OperationMetrics> toProtoMetrics(List<OperationSnapshot> snapshots) {
+        CollectionScope collectionScope = snapshotCollectionScope();
+        List<OperationMetrics> result = new ArrayList<>();
+        for (OperationSnapshot operation : snapshots) {
+            OperationMetrics.Builder builder = OperationMetrics.newBuilder()
+                    .setOperation(operation.operation)
+                    .setGlobal(toProtoMetric(operation.global));
+            for (Map.Entry<String, MetricSnapshot> entry : operation.collection_metrics.entrySet()) {
+                if (collectionScope.includes(entry.getKey())) {
+                    builder.putCollectionMetrics(entry.getKey(), toProtoMetric(entry.getValue()));
+                }
+            }
+            result.add(builder.build());
+        }
+        return result;
+    }
+
+    private CollectionScope snapshotCollectionScope() {
+        synchronized (enabledCollections) {
+            return new CollectionScope(allCollectionsEnabled, new HashSet<>(enabledCollections));
+        }
+    }
+
+    private static OperationSnapshot filterCollectionMetrics(
+            OperationSnapshot operation, CollectionScope collectionScope) {
+        Map<String, MetricSnapshot> collections = new LinkedHashMap<>();
+        for (Map.Entry<String, MetricSnapshot> entry : operation.collection_metrics.entrySet()) {
+            if (collectionScope.includes(entry.getKey())) {
+                collections.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return new OperationSnapshot(operation.operation, operation.global, collections);
+    }
+
+    private static Metrics toProtoMetric(MetricSnapshot metric) {
+        return Metrics.newBuilder()
+                .setRequestCount(metric.request_count)
+                .setSuccessCount(metric.success_count)
+                .setErrorCount(metric.error_count)
+                .setAvgLatencyMs(metric.avg_latency_ms)
+                .setP99LatencyMs(metric.p99_latency_ms)
+                .setMaxLatencyMs(metric.max_latency_ms)
+                .build();
+    }
+
+    private synchronized CommandReply handleCommand(ClientCommand command) {
+        CommandHandler handler = handlers.get(command.getCommandType());
+        if (handler == null) {
+            return failedReply(command.getCommandId(), "unknown command type: " + command.getCommandType());
+        }
+        try {
+            return handler.handle(command);
+        } catch (Exception exception) {
+            return failedReply(command.getCommandId(), exception.getMessage());
+        }
+    }
+
+    private void queueReply(CommandReply reply) {
+        synchronized (pendingReplies) {
+            pendingReplies.add(reply);
+        }
+    }
+
+    private void registerDefaultHandlers() {
+        registerDefaultCommandHandler("push_config", this::handlePushConfig);
+        registerDefaultCommandHandler("collection_metrics", this::handleCollectionMetrics);
+        registerDefaultCommandHandler("show_errors", this::handleShowErrors);
+        registerDefaultCommandHandler("show_latency_history", this::handleLatencyHistory);
+        registerDefaultCommandHandler("get_config", this::handleGetConfig);
+    }
+
+    private synchronized void registerDefaultCommandHandler(String type, CommandHandler handler) {
+        handlers.put(type, handler);
+    }
+
+    private CommandReply handlePushConfig(ClientCommand command) {
+        JsonObject payload = payload(command);
+        Boolean enabled = optionalBoolean(payload, "enabled");
+        Long heartbeatIntervalMs = optionalLong(payload, "heartbeat_interval_ms");
+        Double samplingRate = optionalDouble(payload, "sampling_rate");
+        // Go decodes ttl_seconds into an int64 before deciding that Java does not apply it.
+        // Preserve that typed-payload validation while still reporting the field as ignored.
+        optionalLong(payload, "ttl_seconds");
+
+        if (heartbeatIntervalMs != null && heartbeatIntervalMs <= 0) {
+            throw new IllegalArgumentException("heartbeat_interval_ms must be positive");
+        }
+
+        // No mutation occurs before every supplied value is known to be valid.
+        synchronized (config) {
+            if (enabled != null) {
+                config.setEnabled(enabled);
+            }
+            if (heartbeatIntervalMs != null) {
+                config.setHeartbeatIntervalMs(heartbeatIntervalMs);
+            }
+            if (samplingRate != null) {
+                config.setSamplingRate(samplingRate);
+            }
+        }
+
+        JsonArray applied = new JsonArray();
+        for (String key : PUSH_CONFIG_KEYS) {
+            if (payload.has(key) && !payload.get(key).isJsonNull()) {
+                applied.add(key);
+            }
+        }
+        List<String> ignoredKeys = new ArrayList<>();
+        for (Map.Entry<String, JsonElement> entry : payload.entrySet()) {
+            if (!PUSH_CONFIG_KEYS.contains(entry.getKey())) {
+                ignoredKeys.add(entry.getKey());
+            }
+        }
+        Collections.sort(ignoredKeys);
+        JsonObject result = new JsonObject();
+        result.add("applied", applied);
+        if (!ignoredKeys.isEmpty()) {
+            JsonArray ignored = new JsonArray();
+            for (String key : ignoredKeys) {
+                ignored.add(key);
+            }
+            result.add("ignored", ignored);
+        }
+        return successReply(command.getCommandId(), bytes(result));
+    }
+
+    private CommandReply handleCollectionMetrics(ClientCommand command) {
+        if (command.getPayload().isEmpty()) {
+            JsonObject result = new JsonObject();
+            JsonArray names = new JsonArray();
+            synchronized (enabledCollections) {
+                List<String> sorted = new ArrayList<>(enabledCollections);
+                Collections.sort(sorted);
+                for (String name : sorted) {
+                    names.add(name);
+                }
+                result.add("enabled_collections", names);
+                result.addProperty("all_collections_enabled", allCollectionsEnabled);
+            }
+            return successReply(command.getCommandId(), bytes(result));
+        }
+        JsonObject payload = payload(command);
+        boolean enabled = Boolean.TRUE.equals(optionalBoolean(payload, "enabled"));
+        List<String> collections = optionalStringArray(payload, "collections");
+        // The server currently treats metric types as advisory, but Go still strongly types
+        // the field while decoding the command payload.
+        optionalStringArray(payload, "metrics_types");
+        boolean wildcard = collections.contains("*");
+        synchronized (enabledCollections) {
+            if (enabled) {
+                if (collections.isEmpty()) {
+                    throw new IllegalArgumentException("collections list cannot be empty when enabled=true");
+                }
+                if (wildcard) {
+                    allCollectionsEnabled = true;
+                } else {
+                    enabledCollections.addAll(collections);
+                }
+            } else if (wildcard || collections.isEmpty()) {
+                allCollectionsEnabled = false;
+                enabledCollections.clear();
+            } else {
+                enabledCollections.removeAll(collections);
+            }
+        }
+        return successReply(command.getCommandId(), ByteString.EMPTY);
+    }
+
+    private CommandReply handleShowErrors(ClientCommand command) {
+        JsonObject payload = payload(command);
+        Integer suppliedMaxCount = optionalInt(payload, "max_count");
+        int maxCount = suppliedMaxCount == null ? 100 : suppliedMaxCount;
+        if (maxCount <= 0) {
+            maxCount = 100;
+        }
+        List<ErrorInfo> recent = getRecentErrors(maxCount);
+        if (recent.isEmpty()) {
+            return successReply(command.getCommandId(), ByteString.EMPTY);
+        }
+        byte[] encoded = GSON.toJson(recent).getBytes(StandardCharsets.UTF_8);
+        while (encoded.length > MAX_REPLY_BYTES && recent.size() > 1) {
+            recent = new ArrayList<>(recent.subList(0, Math.max(1, recent.size() / 2)));
+            encoded = GSON.toJson(recent).getBytes(StandardCharsets.UTF_8);
+        }
+        while (encoded.length > MAX_REPLY_BYTES && recent.size() == 1
+                && recent.get(0).error_msg.length() > 1) {
+            ErrorInfo current = recent.get(0);
+            String message = current.error_msg.substring(0, Math.max(1, current.error_msg.length() / 2))
+                    + "...(truncated)";
+            recent.set(0, new ErrorInfo(current.timestamp, current.operation, message,
+                    current.collection, current.request_id));
+            encoded = GSON.toJson(recent).getBytes(StandardCharsets.UTF_8);
+        }
+        if (encoded.length > MAX_REPLY_BYTES) {
+            return failedReply(command.getCommandId(), "show_errors response exceeds the 1MB payload limit");
+        }
+        return successReply(command.getCommandId(), ByteString.copyFrom(encoded));
+    }
+
+    private CommandReply handleGetConfig(ClientCommand command) {
+        Map<String, Object> userConfig = new LinkedHashMap<>();
+        Map<String, Object> supplied = configProvider.get();
+        if (supplied != null) {
+            userConfig.putAll(supplied);
+        }
+        for (String key : Arrays.asList("password", "token", "api_key", "authorization")) {
+            userConfig.remove(key);
+        }
+        userConfig.put("telemetry_enabled", config.isEnabled());
+        userConfig.put("telemetry_heartbeat_interval_ms", config.getHeartbeatIntervalMs());
+        userConfig.put("telemetry_sampling_rate", config.getSamplingRate());
+        synchronized (enabledCollections) {
+            List<String> collections = allCollectionsEnabled
+                    ? Collections.singletonList("*") : new ArrayList<>(enabledCollections);
+            Collections.sort(collections);
+            userConfig.put("enabled_collections", collections);
+            userConfig.put("all_collections_enabled", allCollectionsEnabled);
+        }
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("user_config", userConfig);
+        return successReply(command.getCommandId(), ByteString.copyFromUtf8(GSON.toJson(response)));
+    }
+
+    private CommandReply handleLatencyHistory(ClientCommand command) {
+        JsonObject payload = payload(command);
+        String startTime = optionalString(payload, "start_time");
+        String endTime = optionalString(payload, "end_time");
+        Boolean detail = optionalBoolean(payload, "detail");
+        if (startTime == null || endTime == null) {
+            throw new IllegalArgumentException("payload is required with start_time and end_time");
+        }
+        long start = parseTimestamp(startTime);
+        long end = parseTimestamp(endTime);
+        if (end < start) {
+            throw new IllegalArgumentException("end_time must be after start_time");
+        }
+        if (end - start > TimeUnit.HOURS.toMillis(1)) {
+            throw new IllegalArgumentException("time range cannot exceed 1 hour");
+        }
+        List<MetricsSnapshot> matching = new ArrayList<>();
+        for (MetricsSnapshot snapshot : getMetricsSnapshots()) {
+            if (snapshot.end_time >= start && snapshot.timestamp <= end) {
+                matching.add(snapshot);
+            }
+        }
+        Object response = Boolean.TRUE.equals(detail)
+                ? detailHistory(matching) : aggregateHistory(matching, start, end);
+        byte[] encoded = GSON.toJson(response).getBytes(StandardCharsets.UTF_8);
+        if (encoded.length > MAX_REPLY_BYTES) {
+            throw new IllegalArgumentException("response too large, try a smaller time range");
+        }
+        return successReply(command.getCommandId(), ByteString.copyFrom(encoded));
+    }
+
+    private static Map<String, Object> detailHistory(List<MetricsSnapshot> snapshots) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        List<Map<String, Object>> details = new ArrayList<>();
+        for (MetricsSnapshot snapshot : snapshots) {
+            Map<String, Object> metrics = new LinkedHashMap<>();
+            for (OperationSnapshot operation : snapshot.metrics) {
+                metrics.put(operation.operation, metricHistory(operation.global));
+            }
+            Map<String, Object> detail = new LinkedHashMap<>();
+            detail.put("timestamp", snapshot.timestamp);
+            detail.put("end_time", snapshot.end_time);
+            detail.put("metrics", metrics);
+            details.add(detail);
+        }
+        result.put("snapshots", details);
+        result.put("total_snapshots", snapshots.size());
+        return result;
+    }
+
+    private static Map<String, Object> metricHistory(MetricSnapshot value) {
+        Map<String, Object> metric = new LinkedHashMap<>();
+        metric.put("request_count", value.request_count);
+        metric.put("success_count", value.success_count);
+        metric.put("error_count", value.error_count);
+        metric.put("avg_latency_ms", value.avg_latency_ms);
+        metric.put("p99_latency_ms", value.p99_latency_ms);
+        metric.put("max_latency_ms", value.max_latency_ms);
+        return metric;
+    }
+
+    private static Map<String, Object> aggregateHistory(
+            List<MetricsSnapshot> snapshots, long start, long end) {
+        Map<String, HistoryAggregate> totals = new LinkedHashMap<>();
+        for (MetricsSnapshot snapshot : snapshots) {
+            for (OperationSnapshot operation : snapshot.metrics) {
+                totals.computeIfAbsent(operation.operation, ignored -> new HistoryAggregate())
+                        .add(operation.global);
+            }
+        }
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        for (Map.Entry<String, HistoryAggregate> entry : totals.entrySet()) {
+            HistoryAggregate total = entry.getValue();
+            Map<String, Object> metric = new LinkedHashMap<>();
+            metric.put("request_count", total.requests);
+            metric.put("success_count", total.successes);
+            metric.put("error_count", total.failures);
+            metric.put("avg_latency_ms",
+                    total.requests == 0 ? 0.0 : total.weightedLatencyMs / total.requests);
+            metric.put("p99_latency_ms", total.p99LatencyMs());
+            metric.put("max_latency_ms", total.maxLatencyMs);
+            metrics.put(entry.getKey(), metric);
+        }
+        Map<String, Object> aggregated = new LinkedHashMap<>();
+        aggregated.put("start_time", start);
+        aggregated.put("end_time", end);
+        aggregated.put("metrics", metrics);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("aggregated", aggregated);
+        response.put("snapshot_count", snapshots.size());
+        return response;
+    }
+
+    private static final class HistoryAggregate {
+        private long requests;
+        private long successes;
+        private long failures;
+        private double weightedLatencyMs;
+        private double maxLatencyMs;
+        private final List<WeightedSampleSet> sampleSets = new ArrayList<>();
+
+        private void add(MetricSnapshot metric) {
+            requests += metric.request_count;
+            successes += metric.success_count;
+            failures += metric.error_count;
+            weightedLatencyMs += metric.avg_latency_ms * metric.request_count;
+            maxLatencyMs = Math.max(maxLatencyMs, metric.max_latency_ms);
+            if (metric.request_count == 0) {
+                return;
+            }
+            if (metric.latencySamplesMicros.length == 0) {
+                sampleSets.add(WeightedSampleSet.fallback(
+                        metric.p99_latency_ms, metric.request_count));
+                return;
+            }
+            double weight = (double) metric.request_count / metric.latencySamplesMicros.length;
+            sampleSets.add(new WeightedSampleSet(metric.latencySamplesMicros, weight));
+        }
+
+        private double p99LatencyMs() {
+            if (requests == 0 || sampleSets.isEmpty()) {
+                return 0.0;
+            }
+            PriorityQueue<WeightedSampleCursor> cursors = new PriorityQueue<>(
+                    Comparator.comparingDouble(WeightedSampleCursor::latencyMs));
+            for (WeightedSampleSet samples : sampleSets) {
+                cursors.add(new WeightedSampleCursor(samples));
+            }
+            double threshold = requests * 0.99;
+            double cumulative = 0.0;
+            double lastLatencyMs = 0.0;
+            while (!cursors.isEmpty()) {
+                WeightedSampleCursor cursor = cursors.remove();
+                lastLatencyMs = cursor.latencyMs();
+                cumulative += cursor.samples.weight;
+                if (cumulative > threshold) {
+                    return lastLatencyMs;
+                }
+                if (cursor.advance()) {
+                    cursors.add(cursor);
+                }
+            }
+            return lastLatencyMs;
+        }
+    }
+
+    private static final class WeightedSampleSet {
+        private final long[] latencyMicros;
+        private final double fallbackLatencyMs;
+        private final double weight;
+
+        private WeightedSampleSet(long[] latencyMicros, double weight) {
+            this.latencyMicros = latencyMicros;
+            this.fallbackLatencyMs = 0.0;
+            this.weight = weight;
+        }
+
+        private WeightedSampleSet(double fallbackLatencyMs, double weight) {
+            this.latencyMicros = new long[0];
+            this.fallbackLatencyMs = fallbackLatencyMs;
+            this.weight = weight;
+        }
+
+        private static WeightedSampleSet fallback(double latencyMs, double weight) {
+            return new WeightedSampleSet(latencyMs, weight);
+        }
+
+        private int size() {
+            return latencyMicros.length == 0 ? 1 : latencyMicros.length;
+        }
+
+        private double latencyMs(int index) {
+            return latencyMicros.length == 0 ? fallbackLatencyMs : latencyMicros[index] / 1000.0;
+        }
+    }
+
+    private static final class WeightedSampleCursor {
+        private final WeightedSampleSet samples;
+        private int index;
+
+        private WeightedSampleCursor(WeightedSampleSet samples) {
+            this.samples = samples;
+        }
+
+        private double latencyMs() {
+            return samples.latencyMs(index);
+        }
+
+        private boolean advance() {
+            index++;
+            return index < samples.size();
+        }
+    }
+
+    private static long parseTimestamp(String value) {
+        Matcher matcher = RFC3339_TIMESTAMP.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("timestamp must use RFC3339 with seconds and timezone");
+        }
+        String fraction = matcher.group(2);
+        // OffsetDateTime stores nanoseconds while Go accepts a longer RFC3339 secfrac and
+        // ultimately reports milliseconds. Truncating beyond nine digits preserves that result.
+        if (fraction != null && fraction.length() > 10) {
+            fraction = fraction.substring(0, 10);
+        }
+        String normalized = matcher.group(1) + (fraction == null ? "" : fraction) + matcher.group(3);
+        return OffsetDateTime.parse(normalized).toInstant().toEpochMilli();
+    }
+
+    private static JsonObject payload(ClientCommand command) {
+        if (command.getPayload().isEmpty()) {
+            return new JsonObject();
+        }
+        JsonElement decoded = JsonParser.parseString(command.getPayload().toStringUtf8());
+        if (!decoded.isJsonObject()) {
+            throw new IllegalArgumentException("payload must be a JSON object");
+        }
+        return decoded.getAsJsonObject();
+    }
+
+    private static Boolean optionalBoolean(JsonObject payload, String name) {
+        JsonElement value = payload.get(name);
+        if (value == null || value.isJsonNull()) {
+            return null;
+        }
+        if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isBoolean()) {
+            throw new IllegalArgumentException(name + " must be a boolean");
+        }
+        return value.getAsBoolean();
+    }
+
+    private static String optionalString(JsonObject payload, String name) {
+        JsonElement value = payload.get(name);
+        if (value == null || value.isJsonNull()) {
+            return null;
+        }
+        if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+            throw new IllegalArgumentException(name + " must be a string");
+        }
+        return value.getAsString();
+    }
+
+    private static Long optionalLong(JsonObject payload, String name) {
+        JsonElement value = payload.get(name);
+        if (value == null || value.isJsonNull()) {
+            return null;
+        }
+        if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isNumber()) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        String encoded = value.getAsString();
+        if (!encoded.matches("-?(0|[1-9][0-9]*)")) {
+            throw new IllegalArgumentException(name + " must be an integer");
+        }
+        try {
+            return Long.parseLong(encoded);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(name + " is out of range", exception);
+        }
+    }
+
+    private static Integer optionalInt(JsonObject payload, String name) {
+        Long value = optionalLong(payload, name);
+        if (value == null) {
+            return null;
+        }
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(name + " is out of range");
+        }
+        return value.intValue();
+    }
+
+    private static Double optionalDouble(JsonObject payload, String name) {
+        JsonElement value = payload.get(name);
+        if (value == null || value.isJsonNull()) {
+            return null;
+        }
+        if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isNumber()) {
+            throw new IllegalArgumentException(name + " must be a number");
+        }
+        double decoded = value.getAsDouble();
+        if (!Double.isFinite(decoded)) {
+            throw new IllegalArgumentException(name + " is out of range");
+        }
+        return decoded;
+    }
+
+    private static List<String> optionalStringArray(JsonObject payload, String name) {
+        JsonElement value = payload.get(name);
+        if (value == null || value.isJsonNull()) {
+            return new ArrayList<>();
+        }
+        if (!value.isJsonArray()) {
+            throw new IllegalArgumentException(name + " must be an array of strings");
+        }
+        List<String> decoded = new ArrayList<>();
+        for (JsonElement item : value.getAsJsonArray()) {
+            if (!item.isJsonPrimitive() || !item.getAsJsonPrimitive().isString()) {
+                throw new IllegalArgumentException(name + " must be an array of strings");
+            }
+            decoded.add(item.getAsString());
+        }
+        return decoded;
+    }
+
+    private static ByteString bytes(JsonObject value) {
+        return ByteString.copyFromUtf8(GSON.toJson(value));
+    }
+
+    private static CommandReply successReply(String commandId, ByteString payload) {
+        return CommandReply.newBuilder()
+                .setCommandId(commandId)
+                .setSuccess(true)
+                .setPayload(payload)
+                .build();
+    }
+
+    private static CommandReply failedReply(String commandId, String error) {
+        return CommandReply.newBuilder()
+                .setCommandId(commandId)
+                .setSuccess(false)
+                .setErrorMessage(error == null ? "command failed" : error)
+                .build();
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            executor.shutdownNow();
+        }
+    }
+
+    @FunctionalInterface
+    public interface CommandHandler {
+        CommandReply handle(ClientCommand command) throws Exception;
+    }
+
+    /** In-memory telemetry and command state transferred to a replacement connection manager. */
+    public static final class RuntimeState {
+        private final String clientId;
+        private final String configHash;
+        private final long lastCommandTimestamp;
+        private final List<CommandReply> pendingReplies;
+        private final Map<String, Long> executedCommands;
+        private final Set<String> enabledCollections;
+        private final boolean allCollectionsEnabled;
+        private final Map<String, CommandHandler> customHandlers;
+        private final List<ErrorInfo> errors;
+        private final List<MetricsSnapshot> snapshots;
+        private final Map<String, Collector> collectors;
+        private final long samplingAccum;
+        private final long lastSnapshotEnd;
+        private final int unsupportedStreak;
+        private final Throwable lastHeartbeatError;
+        private final boolean controlPlaneActivated;
+        private final boolean enabled;
+        private final long heartbeatIntervalMs;
+        private final double samplingRate;
+
+        private RuntimeState(
+                String clientId,
+                String configHash,
+                long lastCommandTimestamp,
+                List<CommandReply> pendingReplies,
+                Map<String, Long> executedCommands,
+                Set<String> enabledCollections,
+                boolean allCollectionsEnabled,
+                Map<String, CommandHandler> customHandlers,
+                List<ErrorInfo> errors,
+                List<MetricsSnapshot> snapshots,
+                Map<String, Collector> collectors,
+                long samplingAccum,
+                long lastSnapshotEnd,
+                int unsupportedStreak,
+                Throwable lastHeartbeatError,
+                boolean controlPlaneActivated,
+                boolean enabled,
+                long heartbeatIntervalMs,
+                double samplingRate) {
+            this.clientId = clientId;
+            this.configHash = configHash;
+            this.lastCommandTimestamp = lastCommandTimestamp;
+            this.pendingReplies = new ArrayList<>(pendingReplies);
+            this.executedCommands = new HashMap<>(executedCommands);
+            this.enabledCollections = new HashSet<>(enabledCollections);
+            this.allCollectionsEnabled = allCollectionsEnabled;
+            this.customHandlers = new HashMap<>(customHandlers);
+            this.errors = new ArrayList<>(errors);
+            this.snapshots = new ArrayList<>(snapshots);
+            this.collectors = new HashMap<>();
+            for (Map.Entry<String, Collector> entry : collectors.entrySet()) {
+                this.collectors.put(entry.getKey(), entry.getValue().copy());
+            }
+            this.samplingAccum = samplingAccum;
+            this.lastSnapshotEnd = lastSnapshotEnd;
+            this.unsupportedStreak = unsupportedStreak;
+            this.lastHeartbeatError = lastHeartbeatError;
+            this.controlPlaneActivated = controlPlaneActivated;
+            this.enabled = enabled;
+            this.heartbeatIntervalMs = heartbeatIntervalMs;
+            this.samplingRate = samplingRate;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public int getPendingReplyCount() {
+            return pendingReplies.size();
+        }
+    }
+
+    public static final class ErrorInfo {
+        public final long timestamp;
+        public final String operation;
+        public final String error_msg;
+        public final String collection;
+        public final String request_id;
+
+        ErrorInfo(long timestamp, String operation, String error, String collection, String requestId) {
+            this.timestamp = timestamp;
+            this.operation = operation;
+            this.error_msg = error;
+            this.collection = collection;
+            this.request_id = requestId;
+        }
+    }
+
+    public final class LogicalOperationScope implements AutoCloseable {
+        private boolean closed;
+
+        private LogicalOperationScope() {
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            int depth = logicalOperationDepth.get() - 1;
+            if (depth <= 0) {
+                logicalOperationDepth.remove();
+            } else {
+                logicalOperationDepth.set(depth);
+            }
+        }
+    }
+
+    public static final class MetricsSnapshot {
+        public final long timestamp;
+        public final long end_time;
+        public final List<OperationSnapshot> metrics;
+
+        MetricsSnapshot(long timestamp, long endTime, List<OperationSnapshot> metrics) {
+            this.timestamp = timestamp;
+            this.end_time = endTime;
+            this.metrics = metrics;
+        }
+    }
+
+    public static final class OperationSnapshot {
+        public final String operation;
+        public final MetricSnapshot global;
+        public final Map<String, MetricSnapshot> collection_metrics;
+
+        OperationSnapshot(String operation, MetricSnapshot global, Map<String, MetricSnapshot> collections) {
+            this.operation = operation;
+            this.global = global;
+            this.collection_metrics = collections;
+        }
+    }
+
+    public static final class MetricSnapshot {
+        public final long request_count;
+        public final long success_count;
+        public final long error_count;
+        public final double avg_latency_ms;
+        public final double p99_latency_ms;
+        public final double max_latency_ms;
+        private final transient long[] latencySamplesMicros;
+
+        MetricSnapshot(long requests, long successes, long failures, double average, double p99, double max) {
+            this(requests, successes, failures, average, p99, max, new long[0]);
+        }
+
+        MetricSnapshot(
+                long requests,
+                long successes,
+                long failures,
+                double average,
+                double p99,
+                double max,
+                long[] latencySamplesMicros) {
+            this.request_count = requests;
+            this.success_count = successes;
+            this.error_count = failures;
+            this.avg_latency_ms = average;
+            this.p99_latency_ms = p99;
+            this.max_latency_ms = max;
+            this.latencySamplesMicros = Arrays.copyOf(
+                    latencySamplesMicros, latencySamplesMicros.length);
+        }
+    }
+
+    private static final class Collector {
+        private MetricBucket global = new MetricBucket();
+        private final Map<String, MetricBucket> collections = new HashMap<>();
+
+        Collector copy() {
+            Collector result = new Collector();
+            result.global = global.copy();
+            for (Map.Entry<String, MetricBucket> entry : collections.entrySet()) {
+                result.collections.put(entry.getKey(), entry.getValue().copy());
+            }
+            return result;
+        }
+
+        void record(String collection, long latencyMicros, boolean success) {
+            global.record(latencyMicros, success);
+            if (collection != null && !collection.isEmpty()) {
+                collections.computeIfAbsent(collection, ignored -> new MetricBucket())
+                        .record(latencyMicros, success);
+            }
+        }
+
+        OperationSnapshot snapshot(String operation) {
+            MetricSnapshot globalSnapshot = global.snapshot(true);
+            if (globalSnapshot == null) {
+                return null;
+            }
+            Map<String, MetricSnapshot> collectionSnapshots = new LinkedHashMap<>();
+            for (Map.Entry<String, MetricBucket> entry : collections.entrySet()) {
+                MetricSnapshot snapshot = entry.getValue().snapshot(false);
+                if (snapshot != null) {
+                    collectionSnapshots.put(entry.getKey(), snapshot);
+                }
+            }
+            global = new MetricBucket();
+            collections.clear();
+            return new OperationSnapshot(operation, globalSnapshot, collectionSnapshots);
+        }
+    }
+
+    private static final class MetricBucket {
+        private long requests;
+        private long successes;
+        private long failures;
+        private long totalLatencyMicros;
+        private long maxLatencyMicros;
+        private final long[] samples = new long[SAMPLE_BUFFER_SIZE];
+        private int sampleCount;
+        private int sampleIndex;
+
+        MetricBucket copy() {
+            MetricBucket result = new MetricBucket();
+            result.requests = requests;
+            result.successes = successes;
+            result.failures = failures;
+            result.totalLatencyMicros = totalLatencyMicros;
+            result.maxLatencyMicros = maxLatencyMicros;
+            System.arraycopy(samples, 0, result.samples, 0, samples.length);
+            result.sampleCount = sampleCount;
+            result.sampleIndex = sampleIndex;
+            return result;
+        }
+
+        void record(long latencyMicros, boolean success) {
+            requests++;
+            if (success) {
+                successes++;
+            } else {
+                failures++;
+            }
+            totalLatencyMicros += latencyMicros;
+            maxLatencyMicros = Math.max(maxLatencyMicros, latencyMicros);
+            samples[sampleIndex] = latencyMicros;
+            sampleIndex = (sampleIndex + 1) % SAMPLE_BUFFER_SIZE;
+            sampleCount = Math.min(sampleCount + 1, SAMPLE_BUFFER_SIZE);
+        }
+
+        MetricSnapshot snapshot(boolean retainHistorySamples) {
+            if (requests == 0) {
+                return null;
+            }
+            long[] sorted = Arrays.copyOf(samples, sampleCount);
+            Arrays.sort(sorted);
+            long p99 = sorted.length == 0 ? 0 : sorted[Math.min(sorted.length - 1, (int) (sorted.length * 0.99))];
+            long[] historySamples = retainHistorySamples
+                    ? retainEvenlySpacedSamples(sorted) : new long[0];
+            return new MetricSnapshot(
+                    requests, successes, failures,
+                    (double) totalLatencyMicros / requests / 1000.0,
+                    p99 / 1000.0,
+                    maxLatencyMicros / 1000.0,
+                    historySamples);
+        }
+
+        private static long[] retainEvenlySpacedSamples(long[] sorted) {
+            if (sorted.length <= HISTORY_SAMPLE_SIZE) {
+                return sorted;
+            }
+            long[] retained = new long[HISTORY_SAMPLE_SIZE];
+            for (int index = 0; index < retained.length; index++) {
+                int source = (int) Math.round(
+                        (double) index * (sorted.length - 1) / (retained.length - 1));
+                retained[index] = sorted[source];
+            }
+            return retained;
+        }
+    }
+
+    private static final class CollectionScope {
+        private final boolean all;
+        private final Set<String> enabled;
+
+        private CollectionScope(boolean all, Set<String> enabled) {
+            this.all = all;
+            this.enabled = enabled;
+        }
+
+        private boolean includes(String collection) {
+            return all || enabled.contains(collection);
+        }
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/telemetry/TelemetryConfig.java
+++ b/sdk-core/src/main/java/io/milvus/telemetry/TelemetryConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+/** Configuration for client telemetry and server-pushed commands. */
+public final class TelemetryConfig {
+    private volatile boolean enabled;
+    private volatile long heartbeatIntervalMs;
+    private volatile double samplingRate;
+    private final int errorMaxCount;
+    private final String clientId;
+
+    private TelemetryConfig(Builder builder) {
+        if (builder.heartbeatIntervalMs <= 0) {
+            throw new IllegalArgumentException("heartbeatIntervalMs must be positive");
+        }
+        this.enabled = builder.enabled;
+        this.heartbeatIntervalMs = builder.heartbeatIntervalMs;
+        this.samplingRate = clampSamplingRate(builder.samplingRate);
+        this.errorMaxCount = builder.errorMaxCount > 0 ? builder.errorMaxCount : 100;
+        this.clientId = builder.clientId == null ? "" : builder.clientId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static TelemetryConfig defaults() {
+        return builder().build();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public long getHeartbeatIntervalMs() {
+        return heartbeatIntervalMs;
+    }
+
+    public double getSamplingRate() {
+        return samplingRate;
+    }
+
+    public int getErrorMaxCount() {
+        return errorMaxCount;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    void setHeartbeatIntervalMs(long heartbeatIntervalMs) {
+        if (heartbeatIntervalMs <= 0) {
+            throw new IllegalArgumentException("heartbeat_interval_ms must be positive");
+        }
+        this.heartbeatIntervalMs = heartbeatIntervalMs;
+    }
+
+    void setSamplingRate(double samplingRate) {
+        this.samplingRate = clampSamplingRate(samplingRate);
+    }
+
+    private static double clampSamplingRate(double samplingRate) {
+        return Math.max(0.0, Math.min(1.0, samplingRate));
+    }
+
+    public static final class Builder {
+        private boolean enabled = true;
+        // Milliseconds between heartbeats, and therefore the metrics window: each heartbeat
+        // carries the operations since the last one. The coordinator answers a telemetry
+        // query from the window before the newest, so what a caller reads is between one
+        // and two intervals old.
+        private long heartbeatIntervalMs = 10_000;
+        private double samplingRate = 1.0;
+        private int errorMaxCount = 100;
+        private String clientId = "";
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder heartbeatIntervalMs(long heartbeatIntervalMs) {
+            this.heartbeatIntervalMs = heartbeatIntervalMs;
+            return this;
+        }
+
+        public Builder samplingRate(double samplingRate) {
+            this.samplingRate = samplingRate;
+            return this;
+        }
+
+        public Builder errorMaxCount(int errorMaxCount) {
+            this.errorMaxCount = errorMaxCount;
+            return this;
+        }
+
+        /** Pins the telemetry client ID across process restarts. */
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public TelemetryConfig build() {
+            return new TelemetryConfig(this);
+        }
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/telemetry/TelemetryInterceptor.java
+++ b/sdk-core/src/main/java/io/milvus/telemetry/TelemetryInterceptor.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.milvus.common.interceptor.ClientRequestInterceptor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Records operation telemetry at the common unary gRPC boundary. */
+public final class TelemetryInterceptor implements ClientInterceptor {
+    private static final Set<String> OPERATIONS = new HashSet<>(Arrays.asList(
+            "Insert", "Delete", "Upsert", "Search", "HybridSearch", "Query", "RunAnalyzer"));
+    public static final CallOptions.Key<Boolean> LOGICAL_OPERATION_OPTION =
+            CallOptions.Key.create("milvus-telemetry-logical-operation");
+
+    private final ClientTelemetryManager manager;
+    private final ThreadLocal<String> requestId;
+
+    public TelemetryInterceptor(ClientTelemetryManager manager, ThreadLocal<String> requestId) {
+        this.manager = manager;
+        this.requestId = requestId;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        String operation = method.getBareMethodName();
+        if (!OPERATIONS.contains(operation)) {
+            return next.newCall(method, callOptions);
+        }
+        if (Boolean.TRUE.equals(callOptions.getOption(LOGICAL_OPERATION_OPTION))
+                || manager.isLogicalOperationActive()) {
+            return next.newCall(method, callOptions);
+        }
+        long startNanos = System.nanoTime();
+        String currentRequestId = requestId(callOptions, requestId);
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                next.newCall(method, callOptions)) {
+            private String collection = "";
+            private boolean businessSuccess = true;
+            private String businessError = "";
+
+            @Override
+            public void sendMessage(ReqT message) {
+                collection = collectionName(message);
+                super.sendMessage(message);
+            }
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                Listener<RespT> listener = new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onMessage(RespT message) {
+                        businessSuccess = responseSucceeded(message);
+                        if (!businessSuccess) {
+                            businessError = responseError(message);
+                        }
+                        super.onMessage(message);
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        String error = status.isOk() && businessSuccess
+                                ? ""
+                                : (!status.isOk() ? status.toString() : businessError);
+                        try {
+                            manager.recordOperation(
+                                    operation, collection, startNanos, error, currentRequestId);
+                        } catch (RuntimeException ignored) {
+                            // Telemetry is best-effort and must not suppress the business callback.
+                        }
+                        super.onClose(status, trailers);
+                    }
+                };
+                super.start(listener, headers);
+            }
+        };
+    }
+
+    static String requestId(CallOptions callOptions, ThreadLocal<String> fallback) {
+        String value = callOptions.getOption(ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION);
+        if (value == null && fallback != null) {
+            value = fallback.get();
+        }
+        return ClientRequestInterceptor.isValidClientRequestId(value) ? value : "";
+    }
+
+    private static String collectionName(Object request) {
+        if (!(request instanceof Message)) {
+            return "";
+        }
+        Message message = (Message) request;
+        Descriptors.FieldDescriptor field = message.getDescriptorForType().findFieldByName("collection_name");
+        if (field == null) {
+            return "";
+        }
+        return String.valueOf(message.getField(field));
+    }
+
+    private static boolean responseSucceeded(Object response) {
+        Message status = statusMessage(response);
+        if (status == null) {
+            return true;
+        }
+        Descriptors.FieldDescriptor code = status.getDescriptorForType().findFieldByName("code");
+        Descriptors.FieldDescriptor errorCode = status.getDescriptorForType().findFieldByName("error_code");
+        return numericValue(status, code) == 0 && numericValue(status, errorCode) == 0;
+    }
+
+    private static String responseError(Object response) {
+        Message status = statusMessage(response);
+        if (status == null) {
+            return "Milvus operation failed";
+        }
+        Descriptors.FieldDescriptor reason = status.getDescriptorForType().findFieldByName("reason");
+        return reason == null ? "Milvus operation failed" : String.valueOf(status.getField(reason));
+    }
+
+    private static Message statusMessage(Object response) {
+        if (!(response instanceof Message)) {
+            return null;
+        }
+        Message message = (Message) response;
+        Descriptors.FieldDescriptor field = message.getDescriptorForType().findFieldByName("status");
+        if (field == null || !message.hasField(field)) {
+            return null;
+        }
+        Object value = message.getField(field);
+        return value instanceof Message ? (Message) value : null;
+    }
+
+    private static int numericValue(Message message, Descriptors.FieldDescriptor field) {
+        if (field == null) {
+            return 0;
+        }
+        Object value = message.getField(field);
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        if (value instanceof Descriptors.EnumValueDescriptor) {
+            return ((Descriptors.EnumValueDescriptor) value).getNumber();
+        }
+        return 0;
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/ConnectConfig.java
@@ -20,6 +20,8 @@
 package io.milvus.v2.client;
 
 import io.milvus.common.utils.URLParser;
+import io.milvus.telemetry.ClientTelemetryManager;
+import io.milvus.telemetry.TelemetryConfig;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.net.ssl.SSLContext;
@@ -59,6 +61,10 @@ public class ConnectConfig {
     // clientRequestId maintains a map for different threads, each thread can assign a specific id.
     // the specific id is passed to the server, from the access log we can know which client calls the interface
     private ThreadLocal<String> clientRequestId;
+    private TelemetryConfig telemetryConfig = TelemetryConfig.defaults();
+    private String telemetryClientId = "";
+    private ClientTelemetryManager.RuntimeState telemetryRuntimeState;
+    private boolean deferTelemetryStart;
 
     // Constructor for builder
     private ConnectConfig(ConnectConfigBuilder builder) {
@@ -85,6 +91,10 @@ public class ConnectConfig {
         this.idleTimeoutMs = builder.idleTimeoutMs;
         this.sslContext = builder.sslContext;
         this.clientRequestId = builder.clientRequestId;
+        this.telemetryConfig = builder.telemetryConfig;
+        this.telemetryClientId = builder.telemetryClientId;
+        this.telemetryRuntimeState = builder.telemetryRuntimeState;
+        this.deferTelemetryStart = builder.deferTelemetryStart;
         this.enablePrecheck = builder.enablePrecheck;
         this.option = builder.option;
     }
@@ -164,6 +174,24 @@ public class ConnectConfig {
 
     public ThreadLocal<String> getClientRequestId() {
         return clientRequestId;
+    }
+
+    public TelemetryConfig getTelemetryConfig() {
+        return telemetryConfig;
+    }
+
+    public String getTelemetryClientId() {
+        return telemetryClientId;
+    }
+
+    public synchronized ClientTelemetryManager.RuntimeState takeTelemetryRuntimeState() {
+        ClientTelemetryManager.RuntimeState state = telemetryRuntimeState;
+        telemetryRuntimeState = null;
+        return state;
+    }
+
+    public boolean isDeferTelemetryStart() {
+        return deferTelemetryStart;
     }
 
     public String getProxyAddress() {
@@ -269,6 +297,18 @@ public class ConnectConfig {
         this.clientRequestId = clientRequestId;
     }
 
+    public void setTelemetryConfig(TelemetryConfig telemetryConfig) {
+        this.telemetryConfig = telemetryConfig == null ? TelemetryConfig.defaults() : telemetryConfig;
+    }
+
+    public void setTelemetryClientId(String telemetryClientId) {
+        this.telemetryClientId = telemetryClientId == null ? "" : telemetryClientId;
+    }
+
+    public synchronized void setTelemetryRuntimeState(ClientTelemetryManager.RuntimeState telemetryRuntimeState) {
+        this.telemetryRuntimeState = telemetryRuntimeState;
+    }
+
     public String getHost() {
         URLParser urlParser = new URLParser(this.uri);
         return urlParser.getHostname();
@@ -352,6 +392,10 @@ public class ConnectConfig {
         private long idleTimeoutMs = TimeUnit.MILLISECONDS.convert(24, TimeUnit.HOURS);
         private SSLContext sslContext;
         private ThreadLocal<String> clientRequestId;
+        private TelemetryConfig telemetryConfig = TelemetryConfig.defaults();
+        private String telemetryClientId = "";
+        private ClientTelemetryManager.RuntimeState telemetryRuntimeState;
+        private boolean deferTelemetryStart;
         private boolean enablePrecheck = false;
         private Map<String, String> option = new HashMap<>();
 
@@ -463,6 +507,31 @@ public class ConnectConfig {
 
         public ConnectConfigBuilder clientRequestId(ThreadLocal<String> clientRequestId) {
             this.clientRequestId = clientRequestId;
+            return this;
+        }
+
+        public ConnectConfigBuilder telemetryConfig(TelemetryConfig telemetryConfig) {
+            this.telemetryConfig = telemetryConfig == null ? TelemetryConfig.defaults() : telemetryConfig;
+            return this;
+        }
+
+        public ConnectConfigBuilder telemetryClientId(String telemetryClientId) {
+            this.telemetryClientId = telemetryClientId == null ? "" : telemetryClientId;
+            return this;
+        }
+
+        public ConnectConfigBuilder telemetryRuntimeState(
+                ClientTelemetryManager.RuntimeState telemetryRuntimeState) {
+            this.telemetryRuntimeState = telemetryRuntimeState;
+            return this;
+        }
+
+        /**
+         * Builds the connection and telemetry stub without starting the telemetry worker.
+         * Used only while a global-cluster replacement is prepared for an atomic handoff.
+         */
+        public ConnectConfigBuilder deferTelemetryStart(boolean deferTelemetryStart) {
+            this.deferTelemetryStart = deferTelemetryStart;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/MilvusClientV2.java
@@ -32,6 +32,8 @@ import io.milvus.orm.iterator.QueryIterator;
 import io.milvus.orm.iterator.RpcStubWrapper;
 import io.milvus.orm.iterator.SearchIterator;
 import io.milvus.orm.iterator.SearchIteratorV2;
+import io.milvus.telemetry.ClientTelemetryManager;
+import io.milvus.telemetry.TelemetryInterceptor;
 import io.milvus.v2.service.cdc.CDCService;
 import io.milvus.v2.service.cdc.request.DumpMessagesReq;
 import io.milvus.v2.service.cdc.request.GetReplicateInfoReq;
@@ -90,9 +92,13 @@ import io.milvus.v2.exception.ErrorCode;
 import io.milvus.v2.exception.MilvusClientException;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static io.milvus.common.utils.RedactCredential.redactUriUserInfo;
 
@@ -132,6 +138,7 @@ public class MilvusClientV2 {
     private ConnectConfig connectConfig;
     private GlobalStub globalStub;
     private String cacheEndpoint = "";
+    private ClientTelemetryManager telemetry;
 
     /**
      * Creates a Milvus client instance.
@@ -217,7 +224,20 @@ public class MilvusClientV2 {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        channel = clientUtils.getChannel(connectConfig);
+        ClientTelemetryManager.RuntimeState telemetryRuntimeState = connectConfig.takeTelemetryRuntimeState();
+        String runtimeClientId = telemetryRuntimeState == null
+                ? connectConfig.getTelemetryClientId() : telemetryRuntimeState.getClientId();
+        telemetry = new ClientTelemetryManager(
+                connectConfig.getTelemetryConfig(),
+                connectConfig.getUsername(),
+                clientUtils.getSDKVersion(),
+                this::configuredDatabaseName,
+                this::telemetryUserConfig,
+                runtimeClientId);
+        telemetry.restoreRuntimeState(telemetryRuntimeState);
+        connectConfig.setTelemetryClientId(telemetry.getClientId());
+        channel = clientUtils.getChannel(connectConfig,
+                new TelemetryInterceptor(telemetry, connectConfig.getClientRequestId()));
 
         try {
             blockingStub = MilvusServiceGrpc.newBlockingStub(channel).withWaitForReady();
@@ -229,6 +249,10 @@ public class MilvusClientV2 {
                     new IdentifierInterceptor(identifier));
             blockingStub = MilvusServiceGrpc.newBlockingStub(interceptedChannel).withWaitForReady();
             futureStub = MilvusServiceGrpc.newFutureStub(interceptedChannel).withWaitForReady();
+            telemetry.setStub(io.milvus.grpc.ClientTelemetryServiceGrpc.newBlockingStub(interceptedChannel));
+            if (!connectConfig.isDeferTelemetryStart()) {
+                telemetry.start();
+            }
 
             if (connectConfig.getDbName() != null) {
                 // check if database exists
@@ -249,11 +273,23 @@ public class MilvusClientV2 {
         this.channel = primaryClient.channel;
         this.blockingStub = primaryClient.blockingStub;
         this.futureStub = primaryClient.futureStub;
+        this.telemetry = primaryClient.telemetry;
+        if (connectConfig != null && telemetry != null) {
+            connectConfig.setTelemetryClientId(telemetry.getClientId());
+        }
         // Keep cacheEndpoint scoped to the logical global-cluster endpoint. Replacing it with the
         // physical primary endpoint would make session timestamps and schemas recorded before a
         // failover unreachable after the primary changes.
         if (connectConfig != null) {
             initServices(connectConfig.getDbName());
+        }
+    }
+
+    /** Starts a telemetry manager whose worker was intentionally deferred during connection setup. */
+    public void startTelemetry() {
+        ClientTelemetryManager manager = getTelemetry();
+        if (manager != null) {
+            manager.start();
         }
     }
 
@@ -286,14 +322,85 @@ public class MilvusClientV2 {
     private MilvusServiceGrpc.MilvusServiceFutureStub getFutureRpcStub(String clientRequestId) {
         return getFutureRpcStub().withOption(
                 ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
-                clientRequestId == null ? "" : clientRequestId);
+                clientRequestId == null ? "" : clientRequestId).withOption(
+                TelemetryInterceptor.LOGICAL_OPERATION_OPTION, true);
     }
 
     private String captureClientRequestId() {
         if (connectConfig == null || connectConfig.getClientRequestId() == null) {
-            return null;
+            return "";
         }
-        return connectConfig.getClientRequestId().get();
+        String requestId = connectConfig.getClientRequestId().get();
+        return requestId == null ? "" : requestId;
+    }
+
+    private String captureTelemetryRequestId() {
+        String requestId = captureClientRequestId();
+        return ClientRequestInterceptor.isValidClientRequestId(requestId) ? requestId : "";
+    }
+
+    private <T> T recordLogicalOperation(
+            String operation, String collection, Supplier<T> supplier) {
+        ClientTelemetryManager manager = getTelemetry();
+        if (manager == null) {
+            return supplier.get();
+        }
+        long startNanos = System.nanoTime();
+        String requestId = captureTelemetryRequestId();
+        try (ClientTelemetryManager.LogicalOperationScope ignored =
+                     manager.beginLogicalOperation()) {
+            T result = supplier.get();
+            recordLogicalResult(manager, operation, collection, startNanos, "", requestId);
+            return result;
+        } catch (RuntimeException | Error throwable) {
+            recordLogicalResult(manager, operation, collection, startNanos,
+                    telemetryError(throwable), requestId);
+            throw throwable;
+        }
+    }
+
+    private <T> CompletableFuture<T> recordLogicalOperationAsync(
+            String operation, String collection, Supplier<CompletableFuture<T>> supplier) {
+        ClientTelemetryManager manager = getTelemetry();
+        if (manager == null) {
+            return supplier.get();
+        }
+        long startNanos = System.nanoTime();
+        String requestId = captureTelemetryRequestId();
+        final CompletableFuture<T> future;
+        try (ClientTelemetryManager.LogicalOperationScope ignored =
+                     manager.beginLogicalOperation()) {
+            future = supplier.get();
+        } catch (RuntimeException | Error throwable) {
+            recordLogicalResult(manager, operation, collection, startNanos,
+                    telemetryError(throwable), requestId);
+            throw throwable;
+        }
+        future.whenComplete((result, throwable) -> recordLogicalResult(manager,
+                operation,
+                collection,
+                startNanos,
+                throwable == null ? "" : telemetryError(throwable),
+                requestId));
+        return future;
+    }
+
+    private static void recordLogicalResult(
+            ClientTelemetryManager manager, String operation, String collection,
+            long startNanos, String error, String requestId) {
+        try {
+            manager.recordOperation(operation, collection, startNanos, error, requestId);
+        } catch (RuntimeException ignored) {
+            // Telemetry is best-effort and must never replace the operation result.
+        }
+    }
+
+    private static String telemetryError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current instanceof CompletionException && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.toString();
     }
 
     /**
@@ -360,6 +467,34 @@ public class MilvusClientV2 {
         return dbName;
     }
 
+    private String configuredDatabaseName() {
+        return connectConfig == null ? null : connectConfig.getDbName();
+    }
+
+    /** Returns the telemetry manager for metrics inspection and custom command handlers. */
+    public ClientTelemetryManager getTelemetry() {
+        if (globalStub != null) {
+            MilvusClientV2 primaryClient = globalStub.getPrimaryClient();
+            return primaryClient == null ? null : primaryClient.getTelemetry();
+        }
+        return telemetry;
+    }
+
+    private Map<String, Object> telemetryUserConfig() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (connectConfig == null) {
+            return result;
+        }
+        result.put("address", connectConfig.getHost() + ":" + connectConfig.getPort());
+        result.put("username", connectConfig.getUsername());
+        result.put("db_name", connectConfig.getDbName());
+        result.put("secure", connectConfig.isSecure());
+        result.put("connect_timeout_ms", connectConfig.getConnectTimeoutMs());
+        result.put("rpc_deadline_ms", connectConfig.getRpcDeadlineMs());
+        result.put("current_db", currentUsedDatabase());
+        return result;
+    }
+
     public MilvusClientV2Session session(String clusterId) {
         if (StringUtils.isEmpty(clusterId)) {
             throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "clusterId cannot be null or empty");
@@ -380,17 +515,162 @@ public class MilvusClientV2 {
         if (dbName == null) {
             throw new IllegalArgumentException("dbName cannot be null");
         }
-        // check if database exists
-        clientUtils.checkDatabaseExist(this.getRpcStub(), dbName);
-        try {
-            this.connectConfig.setDbName(dbName);
-            this.close(3);
-            this.connect(this.connectConfig);
-            this.initServices(dbName);
-        } catch (InterruptedException e) {
-            logger.error("close connect error");
-            throw new RuntimeException(e);
+        if (connectConfig != null && dbName.equals(connectConfig.getDbName())) {
+            return;
         }
+
+        ClientTelemetryManager oldTelemetry = getTelemetry();
+        String telemetryClientId = oldTelemetry == null
+                ? connectConfig.getTelemetryClientId() : oldTelemetry.getClientId();
+        ConnectConfig candidateConfig = copyConnectConfigForDatabase(
+                connectConfig, dbName, telemetryClientId);
+        // Construct and validate the replacement before fencing or mutating the active client.
+        MilvusClientV2 candidate = createDatabaseCandidate(candidateConfig);
+        ClientTelemetryManager newTelemetry = candidate.getTelemetry();
+        ManagedChannel oldChannel = this.channel;
+        MilvusServiceGrpc.MilvusServiceBlockingStub oldBlockingStub = this.blockingStub;
+        MilvusServiceGrpc.MilvusServiceFutureStub oldFutureStub = this.futureStub;
+        ConnectConfig oldConfig = this.connectConfig;
+        GlobalStub oldGlobalStub = this.globalStub;
+        String oldCacheEndpoint = this.cacheEndpoint;
+        long retirementToken = 0L;
+        boolean retirementPending = false;
+        try {
+            if (oldTelemetry != null) {
+                if (newTelemetry == null) {
+                    throw new IllegalStateException("replacement client has no telemetry manager");
+                }
+                newTelemetry.prepareRuntimeStateHandoffFrom(oldTelemetry);
+                retirementToken = oldTelemetry.beginRuntimeStateRetirement();
+                retirementPending = true;
+            }
+
+            this.channel = candidate.channel;
+            this.blockingStub = candidate.blockingStub;
+            this.futureStub = candidate.futureStub;
+            this.connectConfig = candidate.connectConfig;
+            this.globalStub = candidate.globalStub;
+            this.cacheEndpoint = candidate.cacheEndpoint;
+            this.telemetry = candidate.telemetry;
+            if (this.globalStub != null) {
+                this.globalStub.retargetPrimaryChange(this::updatePrimaryConnection);
+                this.rpcUtils.setGlobalRefreshTrigger(() -> {
+                    if (globalStub != null) {
+                        globalStub.triggerRefresh();
+                    }
+                });
+            } else {
+                this.rpcUtils.setGlobalRefreshTrigger(null);
+            }
+            this.initServices(dbName);
+
+            if (oldTelemetry != null) {
+                oldTelemetry.handoffRuntimeStateTo(newTelemetry, retirementToken);
+                retirementPending = false;
+            } else {
+                candidate.startTelemetry();
+            }
+            // Preserve the caller-visible ConnectConfig identity used by the existing API,
+            // but mutate it only after the replacement and telemetry handoff have committed.
+            oldConfig.setDbName(dbName);
+            if (newTelemetry != null) {
+                oldConfig.setTelemetryClientId(newTelemetry.getClientId());
+            }
+            this.connectConfig = oldConfig;
+            candidate.connectConfig = oldConfig;
+        } catch (RuntimeException | Error exception) {
+            this.channel = oldChannel;
+            this.blockingStub = oldBlockingStub;
+            this.futureStub = oldFutureStub;
+            this.connectConfig = oldConfig;
+            this.globalStub = oldGlobalStub;
+            this.cacheEndpoint = oldCacheEndpoint;
+            this.telemetry = oldTelemetry;
+            if (this.globalStub != null) {
+                this.rpcUtils.setGlobalRefreshTrigger(() -> {
+                    if (globalStub != null) {
+                        globalStub.triggerRefresh();
+                    }
+                });
+            } else {
+                this.rpcUtils.setGlobalRefreshTrigger(null);
+            }
+            this.initServices(oldConfig.getDbName());
+            if (newTelemetry != null && oldTelemetry != null) {
+                newTelemetry.cancelRuntimeStateHandoffFrom(oldTelemetry);
+            }
+            if (retirementPending && oldTelemetry != null) {
+                oldTelemetry.cancelRuntimeStateRetirement(retirementToken);
+            }
+            try {
+                candidate.close();
+            } catch (Exception closeException) {
+                exception.addSuppressed(closeException);
+            }
+            throw exception;
+        }
+
+        // The replacement now owns the public stubs. Dispose only resources that were
+        // owned by the discarded outer/candidate connection; telemetry was closed by handoff.
+        candidate.rpcUtils.shutdown();
+        if (oldGlobalStub != null) {
+            try {
+                oldGlobalStub.close();
+            } catch (RuntimeException exception) {
+                logger.warn("Failed to close the previous global connection", exception);
+            }
+        } else if (oldChannel != null) {
+            try {
+                oldChannel.shutdownNow();
+                oldChannel.awaitTermination(3, TimeUnit.SECONDS);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                logger.warn("Interrupted while closing the previous database connection", exception);
+            } catch (RuntimeException exception) {
+                logger.warn("Failed to close the previous database connection", exception);
+            }
+        }
+    }
+
+    MilvusClientV2 createDatabaseCandidate(ConnectConfig config) {
+        return new MilvusClientV2(config);
+    }
+
+    private static ConnectConfig copyConnectConfigForDatabase(
+            ConnectConfig original, String dbName, String telemetryClientId) {
+        ConnectConfig.ConnectConfigBuilder builder = ConnectConfig.builder()
+                .uri(original.getUri())
+                .token(original.getToken())
+                .dbName(dbName);
+        if (original.getUsername() != null) {
+            builder.username(original.getUsername());
+        }
+        if (original.getPassword() != null) {
+            builder.password(original.getPassword());
+        }
+        return builder
+                .connectTimeoutMs(original.getConnectTimeoutMs())
+                .keepAliveTimeMs(original.getKeepAliveTimeMs())
+                .keepAliveTimeoutMs(original.getKeepAliveTimeoutMs())
+                .keepAliveWithoutCalls(original.isKeepAliveWithoutCalls())
+                .rpcDeadlineMs(original.getRpcDeadlineMs())
+                .clientKeyPath(original.getClientKeyPath())
+                .clientPemPath(original.getClientPemPath())
+                .caPemPath(original.getCaPemPath())
+                .serverPemPath(original.getServerPemPath())
+                .serverName(original.getServerName())
+                .proxyAddress(original.getProxyAddress())
+                .secure(original.getSecure())
+                .idleTimeoutMs(original.getIdleTimeoutMs())
+                .sslContext(original.getSslContext())
+                .clientRequestId(original.getClientRequestId())
+                .telemetryConfig(original.getTelemetryConfig())
+                .telemetryClientId(telemetryClientId)
+                .deferTelemetryStart(true)
+                .enablePrecheck(original.isEnablePrecheck())
+                .option(original.getOption() == null
+                        ? new LinkedHashMap<>() : new LinkedHashMap<>(original.getOption()))
+                .build();
     }
 
     /**
@@ -858,7 +1138,9 @@ public class MilvusClientV2 {
      * @return InsertResp
      */
     public InsertResp insert(InsertReq request) {
-        return rpcUtils.retry(() -> vectorService.insert(this.getRpcStub(), request));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Insert", collection,
+                () -> rpcUtils.retry(() -> vectorService.insert(this.getRpcStub(), request)));
     }
 
     /**
@@ -868,7 +1150,9 @@ public class MilvusClientV2 {
      * @return UpsertResp
      */
     public UpsertResp upsert(UpsertReq request) {
-        return rpcUtils.retry(() -> vectorService.upsert(this.getRpcStub(), request));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Upsert", collection,
+                () -> rpcUtils.retry(() -> vectorService.upsert(this.getRpcStub(), request)));
     }
 
     /**
@@ -878,7 +1162,9 @@ public class MilvusClientV2 {
      * @return DeleteResp
      */
     public DeleteResp delete(DeleteReq request) {
-        return rpcUtils.retry(() -> vectorService.delete(this.getRpcStub(), request));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Delete", collection,
+                () -> rpcUtils.retry(() -> vectorService.delete(this.getRpcStub(), request)));
     }
 
     /**
@@ -888,11 +1174,13 @@ public class MilvusClientV2 {
      * @return GetResp
      */
     public GetResp get(GetReq request) {
-        return rpcUtils.retry(() -> vectorService.get(this.getRpcStub(), request));
+        return get(request, null);
     }
 
     GetResp get(GetReq request, String clusterId) {
-        return rpcUtils.retry(() -> vectorService.get(this.getRpcStub(), request, clusterId));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Query", collection,
+                () -> rpcUtils.retry(() -> vectorService.get(this.getRpcStub(), request, clusterId)));
     }
 
     /**
@@ -907,8 +1195,10 @@ public class MilvusClientV2 {
 
     CompletableFuture<GetResp> getAsync(GetReq request, String clusterId) {
         String clientRequestId = captureClientRequestId();
-        return vectorService.getAsync(
-                () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils);
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperationAsync("Query", collection,
+                () -> vectorService.getAsync(
+                        () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils));
     }
 
     /**
@@ -918,11 +1208,13 @@ public class MilvusClientV2 {
      * @return QueryResp
      */
     public QueryResp query(QueryReq request) {
-        return rpcUtils.retry(() -> vectorService.query(this.getRpcStub(), request));
+        return query(request, null);
     }
 
     QueryResp query(QueryReq request, String clusterId) {
-        return rpcUtils.retry(() -> vectorService.query(this.getRpcStub(), request, clusterId));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Query", collection,
+                () -> rpcUtils.retry(() -> vectorService.query(this.getRpcStub(), request, clusterId)));
     }
 
     /**
@@ -937,8 +1229,10 @@ public class MilvusClientV2 {
 
     CompletableFuture<QueryResp> queryAsync(QueryReq request, String clusterId) {
         String clientRequestId = captureClientRequestId();
-        return vectorService.queryAsync(
-                () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils);
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperationAsync("Query", collection,
+                () -> vectorService.queryAsync(
+                        () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils));
     }
 
     /**
@@ -948,11 +1242,13 @@ public class MilvusClientV2 {
      * @return SearchResp
      */
     public SearchResp search(SearchReq request) {
-        return rpcUtils.retry(() -> vectorService.search(this.getRpcStub(), request));
+        return search(request, null);
     }
 
     SearchResp search(SearchReq request, String clusterId) {
-        return rpcUtils.retry(() -> vectorService.search(this.getRpcStub(), request, clusterId));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("Search", collection,
+                () -> rpcUtils.retry(() -> vectorService.search(this.getRpcStub(), request, clusterId)));
     }
 
     /**
@@ -967,8 +1263,10 @@ public class MilvusClientV2 {
 
     CompletableFuture<SearchResp> searchAsync(SearchReq request, String clusterId) {
         String clientRequestId = captureClientRequestId();
-        return vectorService.searchAsync(
-                () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils);
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperationAsync("Search", collection,
+                () -> vectorService.searchAsync(
+                        () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils));
     }
 
     /**
@@ -978,11 +1276,13 @@ public class MilvusClientV2 {
      * @return SearchResp
      */
     public SearchResp hybridSearch(HybridSearchReq request) {
-        return rpcUtils.retry(() -> vectorService.hybridSearch(this.getRpcStub(), request));
+        return hybridSearch(request, null);
     }
 
     SearchResp hybridSearch(HybridSearchReq request, String clusterId) {
-        return rpcUtils.retry(() -> vectorService.hybridSearch(this.getRpcStub(), request, clusterId));
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperation("HybridSearch", collection,
+                () -> rpcUtils.retry(() -> vectorService.hybridSearch(this.getRpcStub(), request, clusterId)));
     }
 
     /**
@@ -997,8 +1297,10 @@ public class MilvusClientV2 {
 
     CompletableFuture<SearchResp> hybridSearchAsync(HybridSearchReq request, String clusterId) {
         String clientRequestId = captureClientRequestId();
-        return vectorService.hybridSearchAsync(
-                () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils);
+        String collection = request == null ? "" : request.getCollectionName();
+        return recordLogicalOperationAsync("HybridSearch", collection,
+                () -> vectorService.hybridSearchAsync(
+                        () -> getFutureRpcStub(clientRequestId), request, clusterId, rpcUtils));
     }
 
     /**
@@ -1050,7 +1352,8 @@ public class MilvusClientV2 {
     private RpcStubWrapper createIteratorRpcStub(String requestDatabaseName) {
         String databaseName = StringUtils.isNotEmpty(requestDatabaseName)
                 ? requestDatabaseName : connectConfig.getDbName();
-        return new RpcStubWrapper(this.getRpcStub(), connectConfig.getRpcDeadlineMs(),
+        return new RpcStubWrapper(this.getRpcStub().withOption(
+                TelemetryInterceptor.LOGICAL_OPERATION_OPTION, true), connectConfig.getRpcDeadlineMs(),
                 cacheEndpoint, databaseName);
     }
 
@@ -1062,7 +1365,8 @@ public class MilvusClientV2 {
      * @return RunAnalyzerResp
      */
     public RunAnalyzerResp runAnalyzer(RunAnalyzerReq request) {
-        return rpcUtils.retry(() -> vectorService.runAnalyzer(this.getRpcStub(), request));
+        return recordLogicalOperation("RunAnalyzer", "",
+                () -> rpcUtils.retry(() -> vectorService.runAnalyzer(this.getRpcStub(), request)));
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -1938,7 +2242,12 @@ public class MilvusClientV2 {
             channel = null;
             blockingStub = null;
             futureStub = null;
+            telemetry = null;
             return;
+        }
+        if (telemetry != null) {
+            telemetry.close();
+            telemetry = null;
         }
         if (channel != null) {
             channel.shutdownNow();

--- a/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/GlobalStub.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/GlobalStub.java
@@ -19,6 +19,7 @@
 
 package io.milvus.v2.client.globalcluster;
 
+import io.milvus.telemetry.ClientTelemetryManager;
 import io.milvus.v2.client.ConnectConfig;
 import io.milvus.v2.client.MilvusClientV2;
 import org.slf4j.Logger;
@@ -34,7 +35,8 @@ public class GlobalStub {
 
     private final String globalEndpoint;
     private final ConnectConfig originalConfig;
-    private final Consumer<MilvusClientV2> onPrimaryChange;
+    private volatile Consumer<MilvusClientV2> onPrimaryChange;
+    private final ClientFactory clientFactory;
     private final ReentrantLock lock = new ReentrantLock();
 
     private volatile MilvusClientV2 innerClient;
@@ -47,6 +49,7 @@ public class GlobalStub {
         this.globalEndpoint = globalEndpoint;
         this.originalConfig = originalConfig;
         this.onPrimaryChange = onPrimaryChange;
+        this.clientFactory = this::createClientForEndpoint;
 
         // Fetch initial topology and connect to primary
         String authorization = originalConfig.getAuthorization();
@@ -55,12 +58,26 @@ public class GlobalStub {
         this.primaryEndpoint = primary.getEndpoint();
         logger.info("Global cluster: discovered primary endpoint: {}", redactUriUserInfo(primaryEndpoint));
 
-        this.innerClient = createClientForEndpoint(primaryEndpoint);
+        this.innerClient = clientFactory.create(
+                primaryEndpoint, originalConfig.takeTelemetryRuntimeState(),
+                originalConfig.isDeferTelemetryStart());
 
         // Start background refresher
         this.refresher = new TopologyRefresher(globalEndpoint, authorization,
                 topology.getVersion(), this::onTopologyChange);
         this.refresher.start();
+    }
+
+    GlobalStub(String globalEndpoint, ConnectConfig originalConfig,
+               Consumer<MilvusClientV2> onPrimaryChange, GlobalTopology topology,
+               MilvusClientV2 innerClient, ClientFactory clientFactory) {
+        this.globalEndpoint = globalEndpoint;
+        this.originalConfig = originalConfig;
+        this.onPrimaryChange = onPrimaryChange;
+        this.topology = topology;
+        this.innerClient = innerClient;
+        this.primaryEndpoint = topology.getPrimary().getEndpoint();
+        this.clientFactory = clientFactory;
     }
 
     public MilvusClientV2 getPrimaryClient() {
@@ -81,6 +98,29 @@ public class GlobalStub {
         }
     }
 
+    /**
+     * Retargets primary-change publication when a prepared global connection is adopted,
+     * and publishes the current primary under the same topology lock.
+     */
+    public void retargetPrimaryChange(Consumer<MilvusClientV2> callback) {
+        if (callback == null) {
+            throw new IllegalArgumentException("primary-change callback is required");
+        }
+        lock.lock();
+        try {
+            Consumer<MilvusClientV2> previous = this.onPrimaryChange;
+            this.onPrimaryChange = callback;
+            try {
+                callback.accept(innerClient);
+            } catch (RuntimeException | Error exception) {
+                this.onPrimaryChange = previous;
+                throw exception;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
     public void close() {
         lock.lock();
         try {
@@ -97,7 +137,7 @@ public class GlobalStub {
         }
     }
 
-    private void onTopologyChange(GlobalTopology newTopology) {
+    void onTopologyChange(GlobalTopology newTopology) {
         lock.lock();
         try {
             ClusterInfo newPrimary = newTopology.getPrimary();
@@ -114,14 +154,65 @@ public class GlobalStub {
                     redactUriUserInfo(this.primaryEndpoint), redactUriUserInfo(newEndpoint));
 
             MilvusClientV2 oldClient = this.innerClient;
-            MilvusClientV2 newClient = createClientForEndpoint(newEndpoint);
+            ClientTelemetryManager oldTelemetry = oldClient == null ? null : oldClient.getTelemetry();
+            ClientTelemetryManager.RuntimeState telemetrySeed = oldTelemetry == null
+                    ? null : oldTelemetry.snapshotRuntimeState();
+            MilvusClientV2 newClient = clientFactory.create(newEndpoint, telemetrySeed, true);
+            ClientTelemetryManager newTelemetry = newClient.getTelemetry();
+            String oldEndpoint = this.primaryEndpoint;
+            GlobalTopology oldTopology = this.topology;
+            long retirementToken = 0L;
+            boolean retirementPending = false;
+            try {
+                if (oldTelemetry != null) {
+                    if (newTelemetry == null) {
+                        throw new IllegalStateException("replacement client has no telemetry manager");
+                    }
+                    // Calls that begin after the outer stub switch but before the final state
+                    // transfer are redirected into the still-active old manager.
+                    newTelemetry.prepareRuntimeStateHandoffFrom(oldTelemetry);
+                    // Fence the old endpoint before publishing the replacement. A heartbeat
+                    // already in flight may finish later, but its response must not mutate the
+                    // runtime state that will be handed to the new primary.
+                    retirementToken = oldTelemetry.beginRuntimeStateRetirement();
+                    retirementPending = true;
+                }
 
-            this.innerClient = newClient;
-            this.primaryEndpoint = newEndpoint;
-            this.topology = newTopology;
+                this.innerClient = newClient;
+                this.primaryEndpoint = newEndpoint;
+                this.topology = newTopology;
+                onPrimaryChange.accept(newClient);
 
-            // Notify the outer client to swap its stub/channel
-            onPrimaryChange.accept(newClient);
+                if (oldTelemetry != null) {
+                    oldTelemetry.handoffRuntimeStateTo(newTelemetry, retirementToken);
+                    retirementPending = false;
+                } else {
+                    newClient.startTelemetry();
+                }
+            } catch (RuntimeException | Error exception) {
+                this.innerClient = oldClient;
+                this.primaryEndpoint = oldEndpoint;
+                this.topology = oldTopology;
+                if (newTelemetry != null && oldTelemetry != null) {
+                    newTelemetry.cancelRuntimeStateHandoffFrom(oldTelemetry);
+                }
+                if (retirementPending && oldTelemetry != null) {
+                    oldTelemetry.cancelRuntimeStateRetirement(retirementToken);
+                }
+                if (oldClient != null) {
+                    try {
+                        onPrimaryChange.accept(oldClient);
+                    } catch (RuntimeException | Error rollbackException) {
+                        exception.addSuppressed(rollbackException);
+                    }
+                }
+                try {
+                    newClient.close();
+                } catch (Exception closeException) {
+                    exception.addSuppressed(closeException);
+                }
+                throw exception;
+            }
 
             // Close old client
             if (oldClient != null) {
@@ -136,12 +227,19 @@ public class GlobalStub {
         }
     }
 
-    private MilvusClientV2 createClientForEndpoint(String endpoint) {
-        ConnectConfig primaryConfig = cloneConfigWithNewUri(originalConfig, endpoint);
+    private MilvusClientV2 createClientForEndpoint(
+            String endpoint, ClientTelemetryManager.RuntimeState telemetryRuntimeState,
+            boolean deferTelemetryStart) {
+        ConnectConfig primaryConfig = cloneConfigWithNewUri(
+                originalConfig, endpoint, telemetryRuntimeState, deferTelemetryStart);
         return new MilvusClientV2(primaryConfig);
     }
 
-    private static ConnectConfig cloneConfigWithNewUri(ConnectConfig original, String newUri) {
+    private static ConnectConfig cloneConfigWithNewUri(
+            ConnectConfig original,
+            String newUri,
+            ClientTelemetryManager.RuntimeState telemetryRuntimeState,
+            boolean deferTelemetryStart) {
         // Construct the full URI for the primary endpoint
         // The endpoint from topology is typically just a hostname or hostname:port
         // We need to preserve the scheme (https) from the original URI
@@ -183,7 +281,18 @@ public class GlobalStub {
                 .idleTimeoutMs(original.getIdleTimeoutMs())
                 .sslContext(original.getSslContext())
                 .clientRequestId(original.getClientRequestId())
+                .telemetryConfig(original.getTelemetryConfig())
+                .telemetryClientId(original.getTelemetryClientId())
+                .telemetryRuntimeState(telemetryRuntimeState)
+                .deferTelemetryStart(deferTelemetryStart)
                 .enablePrecheck(original.isEnablePrecheck())
                 .build();
+    }
+
+    @FunctionalInterface
+    interface ClientFactory {
+        MilvusClientV2 create(String endpoint,
+                              ClientTelemetryManager.RuntimeState telemetryRuntimeState,
+                              boolean deferTelemetryStart);
     }
 }

--- a/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/TopologyRefresher.java
+++ b/sdk-core/src/main/java/io/milvus/v2/client/globalcluster/TopologyRefresher.java
@@ -95,8 +95,10 @@ public class TopologyRefresher {
             long oldVersion = currentVersion.get();
             if (newVersion != oldVersion) {
                 logger.info("Global topology version changed from {} to {}, triggering reconnection", oldVersion, newVersion);
-                currentVersion.set(newVersion);
                 onTopologyChange.accept(topology);
+                // Only acknowledge the version after the replacement client has been installed.
+                // A failed reconnect must be retried on the next refresh rather than cached away.
+                currentVersion.set(newVersion);
             } else {
                 logger.debug("Global topology version unchanged ({}), no action needed", oldVersion);
             }

--- a/sdk-core/src/main/java/io/milvus/v2/utils/ClientUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/ClientUtils.java
@@ -56,6 +56,10 @@ public class ClientUtils {
     RpcUtils rpcUtils = new RpcUtils();
 
     public ManagedChannel getChannel(ConnectConfig connectConfig) {
+        return getChannel(connectConfig, null);
+    }
+
+    public ManagedChannel getChannel(ConnectConfig connectConfig, ClientInterceptor additionalInterceptor) {
         ManagedChannel channel = null;
 
         Metadata metadata = new Metadata();
@@ -69,6 +73,9 @@ public class ClientUtils {
         List<ClientInterceptor> clientInterceptors = new ArrayList<>();
         clientInterceptors.add(MetadataUtils.newAttachHeadersInterceptor(metadata));
         clientInterceptors.add(new ClientRequestInterceptor(connectConfig.getClientRequestId()));
+        if (additionalInterceptor != null) {
+            clientInterceptors.add(additionalInterceptor);
+        }
 
         try {
             if (connectConfig.getSslContext() != null) {

--- a/sdk-core/src/test/java/io/milvus/common/interceptor/ClientRequestInterceptorTest.java
+++ b/sdk-core/src/test/java/io/milvus/common/interceptor/ClientRequestInterceptorTest.java
@@ -29,27 +29,31 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClientRequestInterceptorTest {
+    private static final String CALL_OPTION_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+    private static final String THREAD_LOCAL_ID = "0af7651916cd43dd8448eb211c80319c";
     private static final Metadata.Key<String> CLIENT_REQUEST_ID_HEADER =
             Metadata.Key.of("client_request_id", Metadata.ASCII_STRING_MARSHALLER);
 
     @Test
     void explicitRequestIdOverridesExecutingThread() {
         ThreadLocal<String> requestId = new ThreadLocal<>();
-        requestId.set("executing-thread");
+        requestId.set(THREAD_LOCAL_ID);
 
         String captured = intercept(requestId, CallOptions.DEFAULT.withOption(
-                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "caller-thread"));
+                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, CALL_OPTION_ID));
 
-        assertEquals("caller-thread", captured);
+        assertEquals(CALL_OPTION_ID, captured);
     }
 
     @Test
     void explicitEmptyRequestIdSuppressesExecutingThread() {
         ThreadLocal<String> requestId = new ThreadLocal<>();
-        requestId.set("executing-thread");
+        requestId.set(THREAD_LOCAL_ID);
 
         String captured = intercept(requestId, CallOptions.DEFAULT.withOption(
                 ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, ""));
@@ -60,9 +64,33 @@ class ClientRequestInterceptorTest {
     @Test
     void fallsBackToThreadLocalWithoutExplicitRequestId() {
         ThreadLocal<String> requestId = new ThreadLocal<>();
-        requestId.set("executing-thread");
+        requestId.set(THREAD_LOCAL_ID);
 
-        assertEquals("executing-thread", intercept(requestId, CallOptions.DEFAULT));
+        assertEquals(THREAD_LOCAL_ID, intercept(requestId, CallOptions.DEFAULT));
+    }
+
+    @Test
+    void preservesArbitraryAndUppercaseWireCorrelationIds() {
+        ThreadLocal<String> requestId = new ThreadLocal<>();
+        requestId.set(THREAD_LOCAL_ID);
+
+        assertEquals("query-request", intercept(requestId, CallOptions.DEFAULT.withOption(
+                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "query-request")));
+        assertEquals("4BF92F3577B34DA6A3CE929D0E0E4736",
+                intercept(requestId, CallOptions.DEFAULT.withOption(
+                        ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                        "4BF92F3577B34DA6A3CE929D0E0E4736")));
+        requestId.set("not-a-trace-id");
+        assertEquals("not-a-trace-id", intercept(requestId, CallOptions.DEFAULT));
+    }
+
+    @Test
+    void validatesNonZeroLowercaseTraceIds() {
+        assertTrue(ClientRequestInterceptor.isValidClientRequestId(CALL_OPTION_ID));
+        assertFalse(ClientRequestInterceptor.isValidClientRequestId("00000000000000000000000000000000"));
+        assertFalse(ClientRequestInterceptor.isValidClientRequestId("4BF92F3577B34DA6A3CE929D0E0E4736"));
+        assertFalse(ClientRequestInterceptor.isValidClientRequestId("4bf92f3577b34da6a3ce929d0e0e473g"));
+        assertFalse(ClientRequestInterceptor.isValidClientRequestId("4bf92f35"));
     }
 
     private String intercept(ThreadLocal<String> requestId, CallOptions callOptions) {

--- a/sdk-core/src/test/java/io/milvus/telemetry/ClientTelemetryE2ETest.java
+++ b/sdk-core/src/test/java/io/milvus/telemetry/ClientTelemetryE2ETest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.RunAnalyzerReq;
+import io.milvus.v2.service.vector.response.RunAnalyzerResp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfEnvironmentVariable(named = "MILVUS_TELEMETRY_E2E", matches = "true")
+class ClientTelemetryE2ETest {
+    private static final Gson GSON = new Gson();
+    private static final String MILVUS_URI = System.getenv().getOrDefault(
+            "MILVUS_URI", "http://127.0.0.1:19530");
+    private static final String TELEMETRY_API = System.getenv().getOrDefault(
+            "MILVUS_TELEMETRY_API", "http://127.0.0.1:9091/api/v1/_telemetry");
+
+    @Test
+    void defaultTelemetryRegistersAutomatically() throws Exception {
+        MilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
+                .uri(MILVUS_URI)
+                .build());
+        try {
+            ClientTelemetryManager manager = client.getTelemetry();
+            assertNotNull(manager);
+            assertTrue(manager.getConfig().getClientId().isEmpty());
+            waitFor("default client registration", manager.getClientId(),
+                    state -> "active".equals(state.get("status").getAsString()));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void legacyClientRegistersAutomatically() throws Exception {
+        String clientId = "e2e-java-legacy-" + UUID.randomUUID();
+        MilvusServiceClient client = new MilvusServiceClient(ConnectParam.newBuilder()
+                .withUri(MILVUS_URI)
+                .withTelemetryConfig(TelemetryConfig.builder()
+                        .heartbeatIntervalMs(500)
+                        .clientId(clientId)
+                        .build())
+                .build());
+        try {
+            assertEquals(clientId, client.getTelemetry().getClientId());
+            waitFor("legacy client registration", clientId,
+                    state -> "active".equals(state.get("status").getAsString()));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void telemetryCommandsMetricsAndTracingRoundTrip() throws Exception {
+        String clientId = "e2e-java-" + UUID.randomUUID();
+        ThreadLocal<String> requestId = new ThreadLocal<>();
+        MilvusClientV2 client = new MilvusClientV2(ConnectConfig.builder()
+                .uri(MILVUS_URI)
+                .clientRequestId(requestId)
+                .telemetryConfig(TelemetryConfig.builder()
+                        .heartbeatIntervalMs(500)
+                        .samplingRate(1.0)
+                        .clientId(clientId)
+                        .build())
+                .build());
+        try {
+            ClientTelemetryManager manager = client.getTelemetry();
+            assertNotNull(manager);
+            assertEquals(clientId, manager.getClientId());
+            waitFor("client registration", clientId,
+                    state -> "active".equals(state.get("status").getAsString()));
+
+            RunAnalyzerResp analyzer = client.runAnalyzer(RunAnalyzerReq.builder()
+                    .texts(Collections.singletonList("hello milvus telemetry"))
+                    .analyzerParams(Collections.singletonMap("type", "standard"))
+                    .withDetail(true)
+                    .withHash(false)
+                    .build());
+            assertEquals(Arrays.asList("hello", "milvus", "telemetry"), Arrays.asList(
+                    analyzer.getResults().get(0).getTokens().get(0).getToken(),
+                    analyzer.getResults().get(0).getTokens().get(1).getToken(),
+                    analyzer.getResults().get(0).getTokens().get(2).getToken()));
+            waitFor("RunAnalyzer metric", clientId,
+                    state -> hasMetric(state, "RunAnalyzer", "success_count", 1, null));
+
+            JsonObject collectionsPayload = new JsonObject();
+            collectionsPayload.add("collections", GSON.toJsonTree(Collections.singletonList("*")));
+            collectionsPayload.addProperty("enabled", true);
+            String collectionsCommand = pushCommand(clientId, "collection_metrics", collectionsPayload, false);
+            JsonObject collectionsReply = waitForReply(clientId, collectionsCommand);
+            assertTrue(collectionsReply.get("success").getAsBoolean());
+
+            String traceId = ClientTelemetryManager.newClientRequestId();
+            requestId.set(traceId);
+            assertThrows(RuntimeException.class, () -> client.query(QueryReq.builder()
+                    .collectionName("telemetry_e2e_missing")
+                    .filter("id > 0")
+                    .build()));
+            requestId.remove();
+            waitFor("failed Query collection metric", clientId,
+                    state -> hasMetric(state, "Query", "error_count", 1, "telemetry_e2e_missing"));
+
+            JsonObject errorsPayload = new JsonObject();
+            errorsPayload.addProperty("max_count", 10);
+            JsonObject errorsReply = waitForReply(
+                    clientId, pushCommand(clientId, "show_errors", errorsPayload, false));
+            assertTrue(errorsReply.get("success").getAsBoolean());
+            JsonArray errors = JsonParser.parseString(errorsReply.get("payload").getAsString()).getAsJsonArray();
+            assertTrue(containsTrace(errors, traceId));
+
+            JsonObject configPayload = new JsonObject();
+            configPayload.addProperty("sampling_rate", 0.75);
+            configPayload.addProperty("heartbeat_interval_ms", 600);
+            String configPayloadJson = GSON.toJson(configPayload);
+            String configCommand = pushCommand(clientId, "push_config", configPayload, true);
+            JsonObject configReply = waitForReply(clientId, configCommand);
+            assertTrue(configReply.get("success").getAsBoolean());
+            assertEquals(hash(configCommand + "push_config" + configPayloadJson), manager.getConfigHash());
+            assertTrue(manager.getLastCommandTimestamp() > 0);
+
+            JsonObject getConfigReply = waitForReply(
+                    clientId, pushCommand(clientId, "get_config", null, false));
+            JsonObject userConfig = JsonParser.parseString(getConfigReply.get("payload").getAsString())
+                    .getAsJsonObject().getAsJsonObject("user_config");
+            assertEquals(0.75, userConfig.get("telemetry_sampling_rate").getAsDouble());
+            assertEquals(600, userConfig.get("telemetry_heartbeat_interval_ms").getAsLong());
+            assertTrue(userConfig.get("all_collections_enabled").getAsBoolean());
+        } finally {
+            requestId.remove();
+            client.close();
+        }
+    }
+
+    private static JsonObject waitFor(String label, String clientId, Predicate<JsonObject> predicate)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + 15_000;
+        JsonObject last = null;
+        while (System.currentTimeMillis() < deadline) {
+            last = clientState(clientId);
+            if (last != null && predicate.test(last)) {
+                return last;
+            }
+            Thread.sleep(250);
+        }
+        throw new AssertionError("Timed out waiting for " + label + "; last=" + last);
+    }
+
+    private static JsonObject waitForReply(String clientId, String commandId) throws Exception {
+        JsonObject state = waitFor("command reply " + commandId, clientId,
+                candidate -> findReply(candidate, commandId) != null);
+        return findReply(state, commandId);
+    }
+
+    private static JsonObject clientState(String clientId) throws IOException {
+        String query = "client_id=" + URLEncoder.encode(clientId, "UTF-8") + "&include_metrics=true";
+        JsonArray clients = request("GET", TELEMETRY_API + "/clients?" + query, null)
+                .getAsJsonArray("clients");
+        return clients.size() == 0 ? null : clients.get(0).getAsJsonObject();
+    }
+
+    private static String pushCommand(
+            String clientId, String commandType, JsonElement payload, boolean persistent) throws IOException {
+        JsonObject body = new JsonObject();
+        body.addProperty("command_type", commandType);
+        body.addProperty("target_client_id", clientId);
+        body.add("payload", payload == null ? new JsonObject() : payload);
+        body.addProperty("ttl_seconds", 30);
+        body.addProperty("persistent", persistent);
+        return request("POST", TELEMETRY_API + "/commands", body)
+                .get("command_id").getAsString();
+    }
+
+    private static JsonObject request(String method, String url, JsonObject body) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setRequestMethod(method);
+        connection.setConnectTimeout(5_000);
+        connection.setReadTimeout(5_000);
+        if (body != null) {
+            byte[] bytes = GSON.toJson(body).getBytes(StandardCharsets.UTF_8);
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Type", "application/json");
+            try (OutputStream output = connection.getOutputStream()) {
+                output.write(bytes);
+            }
+        }
+        int status = connection.getResponseCode();
+        InputStream input = status >= 200 && status < 300
+                ? connection.getInputStream() : connection.getErrorStream();
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+        } finally {
+            connection.disconnect();
+        }
+        if (status < 200 || status >= 300) {
+            throw new IOException("HTTP " + status + ": " + response);
+        }
+        return JsonParser.parseString(response.toString()).getAsJsonObject();
+    }
+
+    private static JsonObject findReply(JsonObject state, String commandId) {
+        JsonArray replies = state.has("command_replies")
+                ? state.getAsJsonArray("command_replies") : new JsonArray();
+        for (JsonElement element : replies) {
+            JsonObject reply = element.getAsJsonObject();
+            if (commandId.equals(reply.get("command_id").getAsString())) {
+                return reply;
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasMetric(
+            JsonObject state, String operation, String counter, long minimum, String collection) {
+        JsonArray metrics = state.has("metrics") ? state.getAsJsonArray("metrics") : new JsonArray();
+        for (JsonElement element : metrics) {
+            JsonObject metric = element.getAsJsonObject();
+            if (!operation.equals(metric.get("operation").getAsString())) {
+                continue;
+            }
+            JsonObject global = metric.getAsJsonObject("global");
+            if (!global.has(counter) || global.get(counter).getAsLong() < minimum) {
+                continue;
+            }
+            if (collection == null) {
+                return true;
+            }
+            return metric.has("collection_metrics")
+                    && metric.getAsJsonObject("collection_metrics").has(collection);
+        }
+        return false;
+    }
+
+    private static boolean containsTrace(JsonArray errors, String traceId) {
+        for (JsonElement element : errors) {
+            JsonObject error = element.getAsJsonObject();
+            if (traceId.equals(error.get("request_id").getAsString())
+                    && "Query".equals(error.get("operation").getAsString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String hash(String value) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8));
+        StringBuilder result = new StringBuilder(16);
+        for (int index = 0; index < 8; index++) {
+            result.append(String.format("%02x", digest[index]));
+        }
+        assertFalse(result.toString().isEmpty());
+        return result.toString();
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/telemetry/ClientTelemetryManagerTest.java
+++ b/sdk-core/src/test/java/io/milvus/telemetry/ClientTelemetryManagerTest.java
@@ -1,0 +1,1267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.protobuf.ByteString;
+import io.grpc.CallOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.milvus.grpc.ClientCommand;
+import io.milvus.grpc.ClientHeartbeatRequest;
+import io.milvus.grpc.ClientHeartbeatResponse;
+import io.milvus.grpc.ClientTelemetryServiceGrpc;
+import io.milvus.grpc.CommandReply;
+import io.milvus.grpc.OperationMetrics;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientTelemetryManagerTest {
+    @Test
+    void startSchedulingFailureIsBestEffortAndClosedManagerStaysStopped() throws Exception {
+        ClientTelemetryManager rejected = manager();
+        ClientTelemetryManager closed = manager();
+        try {
+            ScheduledExecutorService executor =
+                    (ScheduledExecutorService) getField(rejected, "executor");
+            executor.shutdownNow();
+
+            rejected.start();
+            assertFalse(rejected.isReady());
+            assertTrue(rejected.getLastHeartbeatError() instanceof RejectedExecutionException);
+            rejected.start();
+            assertFalse(rejected.isReady());
+
+            closed.close();
+            closed.start();
+            assertFalse(closed.isReady());
+            assertTrue(closed.isClosed());
+        } finally {
+            rejected.close();
+            closed.close();
+        }
+    }
+
+    @Test
+    void configHashMatchesCrossSdkVector() {
+        ClientCommand commandB = ClientCommand.newBuilder()
+                .setCommandId("cfg-b")
+                .setCommandType("push_config")
+                .setPayload(ByteString.copyFromUtf8("{\"sampling_rate\":0.5}"))
+                .setPersistent(true)
+                .build();
+        ClientCommand commandA = ClientCommand.newBuilder()
+                .setCommandId("cfg-a")
+                .setCommandType("push_config")
+                .setPayload(ByteString.copyFromUtf8("{\"heartbeat_interval_ms\":5000}"))
+                .setPersistent(true)
+                .build();
+
+        assertEquals("a271ff0bb1941777",
+                ClientTelemetryManager.calculateConfigHash(Arrays.asList(commandB, commandA)));
+    }
+
+    @Test
+    void pushConfigAndCollectionMetricsCommandsAreApplied() {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        try {
+            manager.processCommands(Arrays.asList(
+                    ClientCommand.newBuilder()
+                            .setCommandId("config")
+                            .setCommandType("push_config")
+                            .setPayload(ByteString.copyFromUtf8(
+                                    "{\"heartbeat_interval_ms\":5000,\"sampling_rate\":0.25}"))
+                            .setCreateTime(1)
+                            .setPersistent(true)
+                            .build(),
+                    ClientCommand.newBuilder()
+                            .setCommandId("collections")
+                            .setCommandType("collection_metrics")
+                            .setPayload(ByteString.copyFromUtf8(
+                                    "{\"enabled\":true,\"collections\":[\"books\"]}"))
+                            .setCreateTime(2)
+                            .build()));
+
+            assertEquals(5000, manager.getConfig().getHeartbeatIntervalMs());
+            assertEquals(0.25, manager.getConfig().getSamplingRate());
+            assertFalse(manager.getConfigHash().isEmpty());
+            assertEquals(2, manager.getLastCommandTimestamp());
+            assertTrue(manager.getRecentErrors(10).isEmpty());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void pushConfigReportsAppliedAndIgnoredKeysInGoOrder() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            CommandReply reply = processOne(manager, command(
+                    "config", "push_config",
+                    "{\"zzz\":1,\"sampling_rate\":1.5,\"ttl_seconds\":30,"
+                            + "\"enabled\":false,\"heartbeat_interval_ms\":5000,\"aaa\":true}", 1));
+
+            assertTrue(reply.getSuccess());
+            assertEquals(false, manager.getConfig().isEnabled());
+            assertEquals(5000, manager.getConfig().getHeartbeatIntervalMs());
+            assertEquals(1.0, manager.getConfig().getSamplingRate());
+            JsonObject body = JsonParser.parseString(reply.getPayload().toStringUtf8()).getAsJsonObject();
+            assertEquals("[\"enabled\",\"heartbeat_interval_ms\",\"sampling_rate\"]",
+                    body.getAsJsonArray("applied").toString());
+            assertEquals("[\"aaa\",\"ttl_seconds\",\"zzz\"]",
+                    body.getAsJsonArray("ignored").toString());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void pushConfigValidatesWholePayloadBeforeMutation() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            CommandReply invalidInterval = processOne(manager, command(
+                    "bad-interval", "push_config",
+                    "{\"enabled\":false,\"heartbeat_interval_ms\":0}", 1));
+            assertFalse(invalidInterval.getSuccess());
+            assertTrue(manager.getConfig().isEnabled());
+            assertEquals(10_000, manager.getConfig().getHeartbeatIntervalMs());
+
+            assertFalse(processOne(manager, command(
+                    "string-bool", "push_config", "{\"enabled\":\"false\"}", 2)).getSuccess());
+            assertFalse(processOne(manager, command(
+                    "fractional-interval", "push_config",
+                    "{\"heartbeat_interval_ms\":1.5}", 3)).getSuccess());
+            assertFalse(processOne(manager, command(
+                    "string-rate", "push_config", "{\"sampling_rate\":\"0.5\"}", 4)).getSuccess());
+            assertTrue(manager.getConfig().isEnabled());
+            assertEquals(10_000, manager.getConfig().getHeartbeatIntervalMs());
+            assertEquals(1.0, manager.getConfig().getSamplingRate());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void pushConfigStrictlyValidatesIgnoredTtlBeforeMutation() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            List<String> invalidTtlValues = Arrays.asList(
+                    "\"30\"", "1.5", "true", "9223372036854775808");
+            for (int index = 0; index < invalidTtlValues.size(); index++) {
+                CommandReply reply = processOne(manager, command(
+                        "bad-ttl-" + index, "push_config",
+                        "{\"enabled\":false,\"ttl_seconds\":" + invalidTtlValues.get(index) + "}",
+                        index + 1));
+                assertFalse(reply.getSuccess());
+                assertTrue(manager.getConfig().isEnabled());
+            }
+
+            CommandReply nullTtl = processOne(manager, command(
+                    "null-ttl", "push_config", "{\"ttl_seconds\":null}", 10));
+            assertTrue(nullTtl.getSuccess());
+            assertEquals("{\"applied\":[],\"ignored\":[\"ttl_seconds\"]}",
+                    nullTtl.getPayload().toStringUtf8());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void commandPayloadMustBeJsonObject() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            List<String> invalidPayloads = Arrays.asList("[]", "\"text\"", "null", "true");
+            for (int index = 0; index < invalidPayloads.size(); index++) {
+                assertFalse(processOne(manager, command(
+                        "bad-payload-" + index, "show_errors", invalidPayloads.get(index),
+                        index + 1)).getSuccess());
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void collectionMetricsUsesStrictJsonTypes() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            List<String> invalidPayloads = Arrays.asList(
+                    "{\"enabled\":\"true\",\"collections\":[\"books\"]}",
+                    "{\"enabled\":true,\"collections\":\"books\"}",
+                    "{\"enabled\":true,\"collections\":[\"books\",1]}",
+                    "{\"enabled\":true,\"collections\":[\"books\"],\"metrics_types\":true}",
+                    "{\"enabled\":true,\"collections\":[\"books\"],"
+                            + "\"metrics_types\":[\"latency\",null]}");
+            for (int index = 0; index < invalidPayloads.size(); index++) {
+                assertFalse(processOne(manager, command(
+                        "bad-collections-" + index, "collection_metrics",
+                        invalidPayloads.get(index), index + 1)).getSuccess());
+            }
+
+            assertTrue(processOne(manager, command(
+                    "null-collections", "collection_metrics",
+                    "{\"enabled\":null,\"collections\":null,\"metrics_types\":null}", 10))
+                    .getSuccess());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void queryCommandsUseStrictJsonTypes() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            List<String> invalidMaxCounts = Arrays.asList("\"1\"", "1.5", "2147483648");
+            for (int index = 0; index < invalidMaxCounts.size(); index++) {
+                assertFalse(processOne(manager, command(
+                        "bad-max-" + index, "show_errors",
+                        "{\"max_count\":" + invalidMaxCounts.get(index) + "}", index + 1))
+                        .getSuccess());
+            }
+
+            String start = "2026-08-23T00:00:00Z";
+            String end = "2026-08-23T00:01:00Z";
+            List<String> invalidHistoryPayloads = Arrays.asList(
+                    "{\"start_time\":1,\"end_time\":\"" + end + "\"}",
+                    "{\"start_time\":\"" + start + "\",\"end_time\":true}",
+                    "{\"start_time\":\"" + start + "\",\"end_time\":\"" + end
+                            + "\",\"detail\":\"true\"}");
+            for (int index = 0; index < invalidHistoryPayloads.size(); index++) {
+                assertFalse(processOne(manager, command(
+                        "bad-history-" + index, "show_latency_history",
+                        invalidHistoryPayloads.get(index), 10 + index)).getSuccess());
+            }
+
+            assertTrue(processOne(manager, command(
+                    "null-query-values", "show_errors", "{\"max_count\":null}", 20))
+                    .getSuccess());
+            assertTrue(processOne(manager, command(
+                    "null-detail", "show_latency_history",
+                    "{\"start_time\":\"" + start + "\",\"end_time\":\"" + end
+                            + "\",\"detail\":null}", 21)).getSuccess());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void latencyHistoryRequiresRfc3339SecondsAndTimezone() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            List<String> invalidPayloads = Arrays.asList(
+                    "{\"start_time\":\"2026-08-23T12:34Z\","
+                            + "\"end_time\":\"2026-08-23T12:35:00Z\"}",
+                    "{\"start_time\":\"2026-08-23T12:34:00\","
+                            + "\"end_time\":\"2026-08-23T12:35:00Z\"}",
+                    "{\"start_time\":\"2026-08-23\","
+                            + "\"end_time\":\"2026-08-23T12:35:00Z\"}");
+            for (int index = 0; index < invalidPayloads.size(); index++) {
+                assertFalse(processOne(manager, command(
+                        "bad-rfc3339-" + index, "show_latency_history",
+                        invalidPayloads.get(index), index + 1)).getSuccess());
+            }
+
+            assertTrue(processOne(manager, command(
+                    "offset-history", "show_latency_history",
+                    "{\"start_time\":\"2026-08-23T12:34:00.123456789123+08:00\","
+                            + "\"end_time\":\"2026-08-23T12:35:00.987654321987+08:00\"}",
+                    10)).getSuccess());
+            assertTrue(processOne(manager, command(
+                    "zulu-history", "show_latency_history",
+                    "{\"start_time\":\"2026-08-23T04:34:00.1Z\","
+                            + "\"end_time\":\"2026-08-23T04:35:00.2Z\"}",
+                    11)).getSuccess());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void pushConfigEmptyPayloadReportsEmptyAppliedList() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            CommandReply reply = processOne(manager, command(
+                    "empty-config", "push_config", "", 1));
+
+            assertTrue(reply.getSuccess());
+            assertEquals("{\"applied\":[]}", reply.getPayload().toStringUtf8());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void realBusinessErrorResponseClearsUnsupportedBackoff() throws Exception {
+        ClientTelemetryManager manager = manager();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ClientTelemetryServiceGrpc.ClientTelemetryServiceImplBase() {
+                    @Override
+                    public void clientHeartbeat(
+                            io.milvus.grpc.ClientHeartbeatRequest request,
+                            StreamObserver<ClientHeartbeatResponse> responseObserver) {
+                        responseObserver.onNext(ClientHeartbeatResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.newBuilder()
+                                        .setCode(1)
+                                        .setReason("not ready")
+                                        .build())
+                                .build());
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        try {
+            manager.setStub(ClientTelemetryServiceGrpc.newBlockingStub(channel));
+            setField(manager, "unsupportedStreak", 3);
+
+            invoke(manager, "sendHeartbeat");
+
+            assertTrue(manager.isSupported());
+            assertEquals("not ready", manager.getLastHeartbeatError().getMessage());
+        } finally {
+            manager.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void retirementGenerationDropsStaleHeartbeatAndRollbackAllowsNextHeartbeat()
+            throws Exception {
+        ClientTelemetryManager manager = manager();
+        CountDownLatch requestArrived = new CountDownLatch(1);
+        CountDownLatch releaseResponse = new CountDownLatch(1);
+        AtomicInteger calls = new AtomicInteger();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ClientTelemetryServiceGrpc.ClientTelemetryServiceImplBase() {
+                    @Override
+                    public void clientHeartbeat(
+                            io.milvus.grpc.ClientHeartbeatRequest request,
+                            StreamObserver<ClientHeartbeatResponse> responseObserver) {
+                        if (calls.getAndIncrement() == 0) {
+                            requestArrived.countDown();
+                            try {
+                                if (!releaseResponse.await(5, TimeUnit.SECONDS)) {
+                                    throw new IllegalStateException("timed out waiting to release response");
+                                }
+                            } catch (InterruptedException exception) {
+                                Thread.currentThread().interrupt();
+                                throw new IllegalStateException(exception);
+                            }
+                            responseObserver.onNext(ClientHeartbeatResponse.newBuilder()
+                                    .setStatus(io.milvus.grpc.Status.getDefaultInstance())
+                                    .addCommands(command(
+                                            "stale-config",
+                                            "push_config",
+                                            "{\"enabled\":false}",
+                                            10))
+                                    .build());
+                        } else {
+                            responseObserver.onNext(ClientHeartbeatResponse.newBuilder()
+                                    .setStatus(io.milvus.grpc.Status.newBuilder()
+                                            .setCode(1)
+                                            .setReason("after rollback")
+                                            .build())
+                                    .build());
+                        }
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+        RuntimeException originalError = new RuntimeException("original");
+        try {
+            manager.setStub(ClientTelemetryServiceGrpc.newBlockingStub(channel));
+            setField(manager, "unsupportedStreak", 3);
+            setField(manager, "lastHeartbeatError", originalError);
+            Field repliesField = ClientTelemetryManager.class.getDeclaredField("pendingReplies");
+            repliesField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            List<CommandReply> pendingReplies = (List<CommandReply>) repliesField.get(manager);
+            synchronized (pendingReplies) {
+                pendingReplies.add(CommandReply.newBuilder()
+                        .setCommandId("pending")
+                        .setSuccess(true)
+                        .build());
+            }
+            Future<?> heartbeat = caller.submit(() -> {
+                invoke(manager, "sendHeartbeat");
+                return null;
+            });
+            assertTrue(requestArrived.await(5, TimeUnit.SECONDS));
+
+            long retirementToken = manager.beginRuntimeStateRetirement();
+            releaseResponse.countDown();
+            heartbeat.get(5, TimeUnit.SECONDS);
+
+            assertFalse(manager.isSupported());
+            assertSame(originalError, manager.getLastHeartbeatError());
+            assertTrue(manager.getConfig().isEnabled());
+            assertEquals(0, manager.getLastCommandTimestamp());
+            synchronized (pendingReplies) {
+                assertEquals(1, pendingReplies.size());
+                assertEquals("pending", pendingReplies.get(0).getCommandId());
+            }
+
+            manager.cancelRuntimeStateRetirement(retirementToken);
+            invoke(manager, "sendHeartbeat");
+
+            assertTrue(manager.isSupported());
+            assertEquals("after rollback", manager.getLastHeartbeatError().getMessage());
+        } finally {
+            releaseResponse.countDown();
+            caller.shutdownNow();
+            manager.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void processCommandsSerializesAWholeBatch() throws Exception {
+        Method method = ClientTelemetryManager.class.getMethod("processCommands", List.class);
+        assertTrue(java.lang.reflect.Modifier.isSynchronized(method.getModifiers()));
+
+        ClientTelemetryManager manager = manager();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        AtomicInteger calls = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            manager.registerCommandHandler("custom", command -> {
+                calls.incrementAndGet();
+                return CommandReply.newBuilder()
+                        .setCommandId(command.getCommandId())
+                        .setSuccess(true)
+                        .build();
+            });
+            ClientCommand command = command("same", "custom", "", 1);
+            for (int index = 0; index < 2; index++) {
+                executor.submit(() -> {
+                    start.await();
+                    manager.processCommands(Collections.singletonList(command));
+                    return null;
+                });
+            }
+            start.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            assertEquals(1, calls.get());
+        } finally {
+            executor.shutdownNow();
+            manager.close();
+        }
+    }
+
+    @Test
+    void repeatedCursorTimestampCommandsRemainDeduplicated() {
+        ClientTelemetryManager manager = manager();
+        AtomicInteger calls = new AtomicInteger();
+        try {
+            manager.registerCommandHandler("custom", command -> {
+                calls.incrementAndGet();
+                return CommandReply.newBuilder()
+                        .setCommandId(command.getCommandId())
+                        .setSuccess(true)
+                        .build();
+            });
+            List<ClientCommand> commands = Arrays.asList(
+                    command("same-a", "custom", "", 7),
+                    command("same-b", "custom", "", 7));
+
+            manager.processCommands(commands);
+            manager.processCommands(commands);
+            manager.processCommands(commands);
+            manager.processCommands(Collections.singletonList(
+                    command("older", "custom", "", 6)));
+
+            assertEquals(2, calls.get());
+            assertEquals(7, manager.getLastCommandTimestamp());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void successfulHeartbeatConsumesRepliesAndAppliesCommands() throws Exception {
+        AtomicReference<io.milvus.grpc.ClientHeartbeatRequest> captured = new AtomicReference<>();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ClientTelemetryServiceGrpc.ClientTelemetryServiceImplBase() {
+                    @Override
+                    public void clientHeartbeat(
+                            io.milvus.grpc.ClientHeartbeatRequest request,
+                            StreamObserver<ClientHeartbeatResponse> responseObserver) {
+                        captured.set(request);
+                        responseObserver.onNext(ClientHeartbeatResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.getDefaultInstance())
+                                .addCommands(command(
+                                        "server-config", "push_config",
+                                        "{\"heartbeat_interval_ms\":4321}", 2))
+                                .build());
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "user", "test", () -> null, null);
+        try {
+            processOne(manager, command("local-reply", "show_errors", "", 1));
+            manager.setStub(ClientTelemetryServiceGrpc.newBlockingStub(channel));
+
+            invoke(manager, "sendHeartbeat");
+
+            assertEquals(1, captured.get().getCommandRepliesCount());
+            assertFalse(captured.get().getClientInfo().getReservedMap().containsKey("db_name"));
+            // The sent local reply is consumed and the newly applied server command queues its
+            // own acknowledgement for the next heartbeat.
+            assertEquals(1, manager.snapshotRuntimeState().getPendingReplyCount());
+            assertEquals(4321, manager.getConfig().getHeartbeatIntervalMs());
+            assertEquals(2, manager.getLastCommandTimestamp());
+            assertTrue(manager.isSupported());
+        } finally {
+            manager.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void disabledMetricsKeepsScheduledControlPlaneAndCanBeReenabled() throws Exception {
+        List<ClientHeartbeatRequest> captured = new CopyOnWriteArrayList<>();
+        CountDownLatch requests = new CountDownLatch(3);
+        AtomicInteger calls = new AtomicInteger();
+        ClientCommand disable = ClientCommand.newBuilder()
+                .setCommandId("disable")
+                .setCommandType("push_config")
+                .setPayload(ByteString.copyFromUtf8("{\"enabled\":false}"))
+                .setCreateTime(1)
+                .setPersistent(true)
+                .build();
+        ClientCommand enable = ClientCommand.newBuilder()
+                .setCommandId("enable")
+                .setCommandType("push_config")
+                .setPayload(ByteString.copyFromUtf8("{\"enabled\":true}"))
+                .setCreateTime(2)
+                .setPersistent(true)
+                .build();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ClientTelemetryServiceGrpc.ClientTelemetryServiceImplBase() {
+                    @Override
+                    public void clientHeartbeat(
+                            ClientHeartbeatRequest request,
+                            StreamObserver<ClientHeartbeatResponse> responseObserver) {
+                        captured.add(request);
+                        int call = calls.incrementAndGet();
+                        ClientHeartbeatResponse.Builder response = ClientHeartbeatResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.getDefaultInstance());
+                        if (call == 1) {
+                            response.addCommands(disable);
+                        } else if (call == 2) {
+                            response.addCommands(enable);
+                        }
+                        responseObserver.onNext(response.build());
+                        responseObserver.onCompleted();
+                        requests.countDown();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.builder().heartbeatIntervalMs(5).build(),
+                "", "test", () -> "", null);
+        try {
+            manager.recordOperation("Query", "books", System.nanoTime(), "", "");
+            manager.setStub(ClientTelemetryServiceGrpc.newBlockingStub(channel));
+            manager.start();
+
+            assertTrue(requests.await(2, TimeUnit.SECONDS));
+            assertEquals(1, captured.get(0).getMetricsCount());
+            assertEquals(0, captured.get(1).getMetricsCount());
+            assertEquals("disable", captured.get(1).getCommandReplies(0).getCommandId());
+            assertEquals(
+                    ClientTelemetryManager.calculateConfigHash(Collections.singletonList(disable)),
+                    captured.get(1).getConfigHash());
+            assertEquals("enable", captured.get(2).getCommandReplies(0).getCommandId());
+            assertEquals(
+                    ClientTelemetryManager.calculateConfigHash(Collections.singletonList(enable)),
+                    captured.get(2).getConfigHash());
+            assertTrue(manager.getConfig().isEnabled());
+        } finally {
+            manager.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void dynamicDisableKeepsControlPlaneActivatedAcrossRuntimeStateHandoff() throws Exception {
+        ClientTelemetryManager active = new ClientTelemetryManager(
+                TelemetryConfig.builder().heartbeatIntervalMs(60_000).build(),
+                "", "test", () -> "", null);
+        ClientCommand disable = ClientCommand.newBuilder()
+                .setCommandId("disable")
+                .setCommandType("push_config")
+                .setPayload(ByteString.copyFromUtf8("{\"enabled\":false}"))
+                .setCreateTime(1)
+                .setPersistent(true)
+                .build();
+        CountDownLatch requestReceived = new CountDownLatch(1);
+        AtomicReference<ClientHeartbeatRequest> captured = new AtomicReference<>();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ClientTelemetryServiceGrpc.ClientTelemetryServiceImplBase() {
+                    @Override
+                    public void clientHeartbeat(
+                            ClientHeartbeatRequest request,
+                            StreamObserver<ClientHeartbeatResponse> responseObserver) {
+                        captured.set(request);
+                        responseObserver.onNext(ClientHeartbeatResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.getDefaultInstance())
+                                .build());
+                        responseObserver.onCompleted();
+                        requestReceived.countDown();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        ClientTelemetryManager replacement = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null, active.getClientId());
+        try {
+            active.start();
+            active.processCommands(Collections.singletonList(disable));
+            assertFalse(active.getConfig().isEnabled());
+
+            replacement.restoreRuntimeState(active.snapshotRuntimeState());
+            replacement.setStub(ClientTelemetryServiceGrpc.newBlockingStub(channel));
+            replacement.start();
+
+            assertTrue(requestReceived.await(2, TimeUnit.SECONDS));
+            assertFalse(replacement.getConfig().isEnabled());
+            assertEquals(0, captured.get().getMetricsCount());
+            assertEquals("disable", captured.get().getCommandReplies(0).getCommandId());
+            assertEquals(active.getConfigHash(), captured.get().getConfigHash());
+        } finally {
+            active.close();
+            replacement.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void commandQueryRepliesCoverStateRedactionAggregateAndRanges() throws Exception {
+        Map<String, Object> supplied = new HashMap<>();
+        supplied.put("address", "localhost:19530");
+        supplied.put("password", "secret");
+        supplied.put("token", "secret-token");
+        supplied.put("api_key", "secret-key");
+        supplied.put("authorization", "secret-auth");
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "db", () -> supplied);
+        try {
+            assertFalse(processOne(manager, command(
+                    "empty-enable", "collection_metrics", "{\"enabled\":true}", 1)).getSuccess());
+            assertTrue(processOne(manager, command(
+                    "wildcard", "collection_metrics",
+                    "{\"enabled\":true,\"collections\":[\"*\"]}", 2)).getSuccess());
+            assertTrue(processOne(manager, command(
+                    "named", "collection_metrics",
+                    "{\"enabled\":true,\"collections\":[\"books\"]}", 3)).getSuccess());
+            CommandReply collectionState = processOne(manager, command(
+                    "collection-state", "collection_metrics", "", 4));
+            JsonObject collectionBody = JsonParser.parseString(
+                    collectionState.getPayload().toStringUtf8()).getAsJsonObject();
+            assertTrue(collectionBody.get("all_collections_enabled").getAsBoolean());
+
+            CommandReply configReply = processOne(manager, command(
+                    "config-state", "get_config", "", 5));
+            JsonObject userConfig = JsonParser.parseString(configReply.getPayload().toStringUtf8())
+                    .getAsJsonObject().getAsJsonObject("user_config");
+            assertEquals("localhost:19530", userConfig.get("address").getAsString());
+            assertFalse(userConfig.has("password"));
+            assertFalse(userConfig.has("token"));
+            assertFalse(userConfig.has("api_key"));
+            assertFalse(userConfig.has("authorization"));
+            assertEquals("[\"*\"]", userConfig.getAsJsonArray("enabled_collections").toString());
+
+            manager.recordOperation(
+                    "Search", "books", System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(3), "", "");
+            invoke(manager, "createSnapshot");
+            ClientTelemetryManager.MetricsSnapshot snapshot = manager.getMetricsSnapshots().get(0);
+            String start = java.time.Instant.ofEpochMilli(snapshot.timestamp - 1).toString();
+            String end = java.time.Instant.ofEpochMilli(snapshot.end_time + 1).toString();
+            CommandReply aggregate = processOne(manager, command(
+                    "aggregate", "show_latency_history",
+                    String.format("{\"start_time\":\"%s\",\"end_time\":\"%s\"}", start, end), 6));
+            JsonObject aggregateBody = JsonParser.parseString(
+                    aggregate.getPayload().toStringUtf8()).getAsJsonObject();
+            assertEquals(1, aggregateBody.get("snapshot_count").getAsInt());
+            assertEquals(1, aggregateBody.getAsJsonObject("aggregated")
+                    .getAsJsonObject("metrics").getAsJsonObject("Search")
+                    .get("request_count").getAsInt());
+
+            assertFalse(processOne(manager, command(
+                    "missing-range", "show_latency_history", "{}", 6)).getSuccess());
+            assertFalse(processOne(manager, command(
+                    "reverse-range", "show_latency_history",
+                    "{\"start_time\":\"2026-08-23T01:00:00Z\","
+                            + "\"end_time\":\"2026-08-23T00:00:00Z\"}", 8)).getSuccess());
+            assertFalse(processOne(manager, command(
+                    "long-range", "show_latency_history",
+                    "{\"start_time\":\"2026-08-23T00:00:00Z\","
+                            + "\"end_time\":\"2026-08-23T02:00:00Z\"}", 9)).getSuccess());
+
+            assertTrue(processOne(manager, command(
+                    "disable-all", "collection_metrics",
+                    "{\"enabled\":false,\"collections\":[\"*\"]}", 10)).getSuccess());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void lifecycleSamplingErrorBoundsAndHandoffValidation() throws Exception {
+        TelemetryConfig disabledConfig = TelemetryConfig.builder()
+                .enabled(false)
+                .samplingRate(0.0)
+                .errorMaxCount(1)
+                .clientId("stable-client")
+                .build();
+        ClientTelemetryManager disabled = new ClientTelemetryManager(
+                disabledConfig, null, null, null, null);
+        ClientTelemetryManager active = manager();
+        ClientTelemetryManager replacement = manager();
+        ClientTelemetryManager wrongClient = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null, "wrong-client");
+        ClientTelemetryManager zeroSampling = new ClientTelemetryManager(
+                TelemetryConfig.builder().samplingRate(0.0).build(), "", "", null, () -> null);
+        ClientTelemetryManager boundedErrors = new ClientTelemetryManager(
+                TelemetryConfig.builder().errorMaxCount(1).build(), "", "", null, null);
+        ClientTelemetryManager nullConfig = new ClientTelemetryManager(
+                null, null, null, null, null, null);
+        try {
+            disabled.start();
+            assertTrue(disabled.isReady());
+            Field activationField = ClientTelemetryManager.class.getDeclaredField(
+                    "controlPlaneActivated");
+            activationField.setAccessible(true);
+            assertFalse(((AtomicBoolean) activationField.get(disabled)).get());
+            assertEquals("stable-client", disabled.getClientId());
+            disabled.recordOperation("Search", "books", System.nanoTime(), "ignored", "id");
+            invoke(disabled, "createSnapshot");
+            assertTrue(disabled.getMetricsSnapshots().isEmpty());
+            disabled.restoreRuntimeState(null);
+
+            zeroSampling.recordOperation(
+                    "Search", "books", System.nanoTime(), "not sampled", "request");
+            assertTrue(zeroSampling.getRecentErrors(10).isEmpty());
+            boundedErrors.recordOperation(
+                    "Query", "books", System.nanoTime(), "first", "id-1");
+            boundedErrors.recordOperation(
+                    "Query", "books", System.nanoTime(), "second", "id-2");
+            assertEquals(1, boundedErrors.getRecentErrors(10).size());
+            assertEquals("second", boundedErrors.getRecentErrors(10).get(0).error_msg);
+            assertFalse(nullConfig.getClientId().isEmpty());
+            assertEquals("", ClientTelemetryManager.calculateConfigHash(Collections.emptyList()));
+            assertFalse(processOne(active, command(
+                    "unknown", "not_registered", "", 1)).getSuccess());
+            for (int index = 0; index <= 120; index++) {
+                invoke(active, "createSnapshot");
+            }
+            assertEquals(121, active.getMetricsSnapshots().size());
+
+            active.recordOperation("Query", "books", System.nanoTime(), "first", "id-1");
+            active.recordOperation("Query", "books", System.nanoTime(), "second", "id-2");
+            assertEquals(1, active.getRecentErrors(1).size());
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> wrongClient.restoreRuntimeState(active.snapshotRuntimeState()));
+            assertThrows(IllegalArgumentException.class,
+                    () -> replacement.prepareRuntimeStateHandoffFrom(null));
+            replacement.start();
+            assertThrows(IllegalStateException.class,
+                    () -> replacement.prepareRuntimeStateHandoffFrom(active));
+            assertThrows(IllegalArgumentException.class,
+                    () -> active.handoffRuntimeStateTo(null, 1));
+            assertThrows(IllegalStateException.class,
+                    () -> active.handoffRuntimeStateTo(replacement, 1));
+            long token = active.beginRuntimeStateRetirement();
+            assertThrows(IllegalStateException.class, active::beginRuntimeStateRetirement);
+            invoke(active, "sendHeartbeat");
+            active.cancelRuntimeStateRetirement(token + 1);
+            active.cancelRuntimeStateRetirement(token);
+            assertThrows(IllegalStateException.class,
+                    () -> active.handoffRuntimeStateTo(wrongClient, token));
+        } finally {
+            disabled.close();
+            active.close();
+            replacement.close();
+            wrongClient.close();
+            zeroSampling.close();
+            boundedErrors.close();
+            nullConfig.close();
+        }
+    }
+
+    @Test
+    void generatesValidClientRequestId() {
+        String requestId = ClientTelemetryManager.newClientRequestId();
+
+        assertTrue(requestId.matches("[0-9a-f]{32}"));
+        assertFalse(requestId.matches("0{32}"));
+    }
+
+    @Test
+    void snapshotHistoryUsesOneHourTtlWithIndependentHardCap() throws Exception {
+        ClientTelemetryManager manager = manager();
+        try {
+            @SuppressWarnings("unchecked")
+            Deque<ClientTelemetryManager.MetricsSnapshot> snapshots =
+                    (Deque<ClientTelemetryManager.MetricsSnapshot>) getField(manager, "snapshots");
+            long now = System.currentTimeMillis();
+            synchronized (snapshots) {
+                snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                        now - TimeUnit.HOURS.toMillis(1) - 2,
+                        now - TimeUnit.HOURS.toMillis(1) - 1,
+                        Collections.emptyList()));
+                snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                        now - TimeUnit.HOURS.toMillis(1) + 1000,
+                        now - TimeUnit.HOURS.toMillis(1) + 1000,
+                        Collections.emptyList()));
+                snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                        now - TimeUnit.MINUTES.toMillis(30),
+                        now - TimeUnit.MINUTES.toMillis(30),
+                        Collections.emptyList()));
+            }
+
+            manager.getConfig().setHeartbeatIntervalMs(600_000);
+            List<ClientTelemetryManager.MetricsSnapshot> retained = manager.getMetricsSnapshots();
+            assertEquals(2, retained.size());
+            assertEquals(now - TimeUnit.HOURS.toMillis(1) + 1000, retained.get(0).end_time);
+
+            synchronized (snapshots) {
+                snapshots.clear();
+                for (int index = 0; index < 4097; index++) {
+                    snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                            now + index, now + index, Collections.emptyList()));
+                }
+            }
+            retained = manager.getMetricsSnapshots();
+            assertEquals(4096, retained.size());
+            assertEquals(now + 1, retained.get(0).timestamp);
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void latencyDetailUsesOperationKeyedSnakeCaseMetrics() throws Exception {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        try {
+            manager.recordOperation(
+                    "Search", "books", System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(5), "", "");
+            java.lang.reflect.Method createSnapshot = ClientTelemetryManager.class
+                    .getDeclaredMethod("createSnapshot");
+            createSnapshot.setAccessible(true);
+            createSnapshot.invoke(manager);
+            ClientTelemetryManager.MetricsSnapshot snapshot = manager.getMetricsSnapshots().get(0);
+            java.lang.reflect.Method latencyHistory = ClientTelemetryManager.class
+                    .getDeclaredMethod("handleLatencyHistory", ClientCommand.class);
+            latencyHistory.setAccessible(true);
+
+            String payload = String.format(
+                    "{\"start_time\":\"%s\",\"end_time\":\"%s\",\"detail\":true}",
+                    java.time.Instant.ofEpochMilli(snapshot.timestamp - 1),
+                    java.time.Instant.ofEpochMilli(snapshot.end_time + 1));
+            CommandReply reply = (CommandReply) latencyHistory.invoke(manager, ClientCommand.newBuilder()
+                    .setCommandId("latency-detail")
+                    .setCommandType("show_latency_history")
+                    .setPayload(ByteString.copyFromUtf8(payload))
+                    .build());
+            JsonObject body = JsonParser.parseString(reply.getPayload().toStringUtf8()).getAsJsonObject();
+            JsonObject metrics = body.getAsJsonArray("snapshots")
+                    .get(0).getAsJsonObject().getAsJsonObject("metrics");
+            JsonObject search = metrics.getAsJsonObject("Search");
+
+            assertTrue(reply.getSuccess());
+            assertEquals(1, body.get("total_snapshots").getAsInt());
+            assertEquals(1, search.get("request_count").getAsLong());
+            assertFalse(search.has("requestCount"));
+            assertFalse(search.has("latencySamplesMicros"));
+            assertFalse(search.has("latency_samples_micros"));
+            assertFalse(metrics.isJsonArray());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void latencyAggregateMergesWeightedSamplesInsteadOfWindowP99s() throws Exception {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        try {
+            long now = System.currentTimeMillis();
+            ClientTelemetryManager.OperationSnapshot fast = new ClientTelemetryManager.OperationSnapshot(
+                    "Search",
+                    new ClientTelemetryManager.MetricSnapshot(
+                            100, 100, 0, 1.0, 1.0, 1.0, new long[]{1_000}),
+                    Collections.emptyMap());
+            ClientTelemetryManager.OperationSnapshot slow = new ClientTelemetryManager.OperationSnapshot(
+                    "Search",
+                    new ClientTelemetryManager.MetricSnapshot(
+                            100, 100, 0, 100.0, 100.0, 100.0, new long[]{100_000}),
+                    Collections.emptyMap());
+            ClientTelemetryManager.OperationSnapshot legacy = new ClientTelemetryManager.OperationSnapshot(
+                    "Legacy",
+                    new ClientTelemetryManager.MetricSnapshot(10, 10, 0, 42.0, 42.0, 42.0),
+                    Collections.emptyMap());
+            @SuppressWarnings("unchecked")
+            Deque<ClientTelemetryManager.MetricsSnapshot> snapshots =
+                    (Deque<ClientTelemetryManager.MetricsSnapshot>) getField(manager, "snapshots");
+            synchronized (snapshots) {
+                snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                        now - 20, now - 10, Arrays.asList(fast, legacy)));
+                snapshots.addLast(new ClientTelemetryManager.MetricsSnapshot(
+                        now - 10, now, Collections.singletonList(slow)));
+            }
+
+            String payload = String.format(
+                    "{\"start_time\":\"%s\",\"end_time\":\"%s\"}",
+                    java.time.Instant.ofEpochMilli(now - 21),
+                    java.time.Instant.ofEpochMilli(now + 1));
+            CommandReply reply = processOne(manager, command(
+                    "weighted-p99", "show_latency_history", payload, 1));
+            JsonObject metrics = JsonParser.parseString(reply.getPayload().toStringUtf8())
+                    .getAsJsonObject().getAsJsonObject("aggregated").getAsJsonObject("metrics");
+
+            assertTrue(reply.getSuccess());
+            assertEquals(200, metrics.getAsJsonObject("Search").get("request_count").getAsLong());
+            assertEquals(100.0,
+                    metrics.getAsJsonObject("Search").get("p99_latency_ms").getAsDouble());
+            assertEquals(42.0,
+                    metrics.getAsJsonObject("Legacy").get("p99_latency_ms").getAsDouble());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void snapshotsRetainAtMost128GlobalLatencySamples() throws Exception {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        try {
+            assertTrue(processOne(manager, command(
+                    "enable-books",
+                    "collection_metrics",
+                    "{\"enabled\":true,\"collections\":[\"books\"]}",
+                    1)).getSuccess());
+            for (int latencyMs = 1; latencyMs <= 200; latencyMs++) {
+                manager.recordOperation(
+                        "Search",
+                        "books",
+                        System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(latencyMs),
+                        "",
+                        "");
+            }
+            invoke(manager, "createSnapshot");
+            ClientTelemetryManager.OperationSnapshot search =
+                    manager.getMetricsSnapshots().get(0).metrics.get(0);
+            Field samplesField = ClientTelemetryManager.MetricSnapshot.class
+                    .getDeclaredField("latencySamplesMicros");
+            samplesField.setAccessible(true);
+            long[] globalSamples = (long[]) samplesField.get(search.global);
+            long[] collectionSamples = (long[]) samplesField.get(search.collection_metrics.get("books"));
+
+            assertEquals(128, globalSamples.length);
+            assertEquals(0, collectionSamples.length);
+            assertEquals(search.global.max_latency_ms, globalSamples[globalSamples.length - 1] / 1000.0);
+            for (int index = 1; index < globalSamples.length; index++) {
+                assertTrue(globalSamples[index - 1] <= globalSamples[index]);
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void runtimeStatePreservesPendingRepliesDeduplicationAndCustomHandlers() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ClientTelemetryManager first = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null, "runtime-client");
+        ClientTelemetryManager second = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null, "runtime-client");
+        try {
+            first.registerCommandHandler("custom", command -> {
+                calls.incrementAndGet();
+                return CommandReply.newBuilder()
+                        .setCommandId(command.getCommandId())
+                        .setSuccess(true)
+                        .build();
+            });
+            ClientCommand command = ClientCommand.newBuilder()
+                    .setCommandId("custom-command")
+                    .setCommandType("custom")
+                    .setCreateTime(11)
+                    .setPersistent(true)
+                    .build();
+            ClientCommand configCommand = ClientCommand.newBuilder()
+                    .setCommandId("config-command")
+                    .setCommandType("push_config")
+                    .setPayload(ByteString.copyFromUtf8(
+                            "{\"heartbeat_interval_ms\":5000,\"sampling_rate\":0.25}"))
+                    .setCreateTime(10)
+                    .setPersistent(true)
+                    .build();
+            first.processCommands(Arrays.asList(configCommand, command));
+            for (int index = 0; index < 4; index++) {
+                first.recordOperation(
+                        "Query", "books", System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(2), "", "");
+            }
+            RuntimeException heartbeatError = new RuntimeException("unimplemented");
+            setField(first, "unsupportedStreak", 2);
+            setField(first, "lastHeartbeatError", heartbeatError);
+
+            ClientTelemetryManager.RuntimeState state = first.snapshotAndCloseRuntimeState();
+            second.restoreRuntimeState(state);
+
+            assertEquals(2, second.snapshotRuntimeState().getPendingReplyCount());
+            assertEquals(first.getConfigHash(), second.getConfigHash());
+            assertEquals(first.getLastCommandTimestamp(), second.getLastCommandTimestamp());
+            assertEquals(5000, second.getConfig().getHeartbeatIntervalMs());
+            assertEquals(0.25, second.getConfig().getSamplingRate());
+            assertFalse(second.isSupported());
+            assertSame(heartbeatError, second.getLastHeartbeatError());
+            invoke(second, "createSnapshot");
+            assertEquals(1, second.getMetricsSnapshots().get(0).metrics.get(0).global.request_count);
+            second.processCommands(Arrays.asList(command));
+            assertEquals(1, calls.get());
+        } finally {
+            first.close();
+            second.close();
+        }
+    }
+
+    @Test
+    void collectionMetricsAreFilteredAgainAtSnapshotAndWireTime() throws Exception {
+        ClientTelemetryManager snapshotManager = manager();
+        ClientTelemetryManager wireManager = manager();
+        try {
+            snapshotManager.processCommands(Collections.singletonList(collectionCommand(
+                    "enable-snapshot", true, "books", 1)));
+            snapshotManager.recordOperation("Search", "books", System.nanoTime(), "", "");
+            snapshotManager.processCommands(Collections.singletonList(collectionCommand(
+                    "disable-snapshot", false, "books", 2)));
+            invoke(snapshotManager, "createSnapshot");
+            ClientTelemetryManager.OperationSnapshot snapshot =
+                    snapshotManager.getMetricsSnapshots().get(0).metrics.get(0);
+            assertEquals(1, snapshot.global.request_count);
+            assertTrue(snapshot.collection_metrics.isEmpty());
+
+            wireManager.processCommands(Collections.singletonList(collectionCommand(
+                    "enable-wire", true, "books", 1)));
+            wireManager.recordOperation("Query", "books", System.nanoTime(), "", "");
+            invoke(wireManager, "createSnapshot");
+            ClientTelemetryManager.MetricsSnapshot wireSnapshot = wireManager.getMetricsSnapshots().get(0);
+            assertFalse(wireSnapshot.metrics.get(0).collection_metrics.isEmpty());
+            wireManager.processCommands(Collections.singletonList(collectionCommand(
+                    "disable-wire", false, "books", 2)));
+
+            @SuppressWarnings("unchecked")
+            List<OperationMetrics> wireMetrics = (List<OperationMetrics>) invoke(
+                    wireManager, "toProtoMetrics", List.class, wireSnapshot.metrics);
+            assertEquals(1, wireMetrics.get(0).getGlobal().getRequestCount());
+            assertTrue(wireMetrics.get(0).getCollectionMetricsMap().isEmpty());
+        } finally {
+            snapshotManager.close();
+            wireManager.close();
+        }
+    }
+
+    @Test
+    void showErrorsUsesGoBoundarySemantics() throws Exception {
+        ClientTelemetryManager manager = manager();
+        ClientTelemetryManager empty = manager();
+        try {
+            manager.recordOperation("Query", "books", System.nanoTime(), "first", "");
+            manager.recordOperation("Query", "books", System.nanoTime(), "second", "");
+            CommandReply fallback = processOne(manager, command(
+                    "errors", "show_errors", "{\"max_count\":0}", 1));
+            assertEquals(2, JsonParser.parseString(fallback.getPayload().toStringUtf8())
+                    .getAsJsonArray().size());
+
+            CommandReply noErrors = processOne(empty, command(
+                    "no-errors", "show_errors", "", 1));
+            assertTrue(noErrors.getPayload().isEmpty());
+        } finally {
+            manager.close();
+            empty.close();
+        }
+    }
+
+    @Test
+    void telemetryRequestIdPrefersCallOptionAndValidatesBothSources() {
+        String callOptionId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        String threadId = "0af7651916cd43dd8448eb211c80319c";
+        ThreadLocal<String> fallback = new ThreadLocal<>();
+        fallback.set(threadId);
+
+        assertEquals(callOptionId, TelemetryInterceptor.requestId(
+                CallOptions.DEFAULT.withOption(
+                        io.milvus.common.interceptor.ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                        callOptionId),
+                fallback));
+        assertEquals(threadId, TelemetryInterceptor.requestId(CallOptions.DEFAULT, fallback));
+        assertEquals("", TelemetryInterceptor.requestId(
+                CallOptions.DEFAULT.withOption(
+                        io.milvus.common.interceptor.ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                        ""),
+                fallback));
+        fallback.set("4BF92F3577B34DA6A3CE929D0E0E4736");
+        assertEquals("", TelemetryInterceptor.requestId(CallOptions.DEFAULT, fallback));
+    }
+
+    @Test
+    void truncatesSingleOversizedErrorReply() throws Exception {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        try {
+            char[] chars = new char[2 * 1024 * 1024];
+            Arrays.fill(chars, 'x');
+            manager.recordOperation("Query", "books", System.nanoTime(), new String(chars), "");
+            java.lang.reflect.Method method = ClientTelemetryManager.class
+                    .getDeclaredMethod("handleShowErrors", ClientCommand.class);
+            method.setAccessible(true);
+
+            CommandReply reply = (CommandReply) method.invoke(manager, ClientCommand.newBuilder()
+                    .setCommandId("errors")
+                    .setCommandType("show_errors")
+                    .build());
+
+            assertTrue(reply.getSuccess());
+            assertTrue(reply.getPayload().size() <= 1024 * 1024);
+        } finally {
+            manager.close();
+        }
+    }
+
+    private static ClientTelemetryManager manager() {
+        return new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+    }
+
+    private static ClientCommand command(
+            String id, String type, String payload, long createTime) {
+        return ClientCommand.newBuilder()
+                .setCommandId(id)
+                .setCommandType(type)
+                .setPayload(ByteString.copyFromUtf8(payload))
+                .setCreateTime(createTime)
+                .build();
+    }
+
+    private static ClientCommand collectionCommand(
+            String id, boolean enabled, String collection, long createTime) {
+        return command(id, "collection_metrics", String.format(
+                "{\"enabled\":%s,\"collections\":[\"%s\"]}", enabled, collection), createTime);
+    }
+
+    private static CommandReply processOne(
+            ClientTelemetryManager manager, ClientCommand command) throws Exception {
+        manager.processCommands(Collections.singletonList(command));
+        Field field = ClientTelemetryManager.class.getDeclaredField("pendingReplies");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<CommandReply> replies = (List<CommandReply>) field.get(manager);
+        synchronized (replies) {
+            return replies.get(replies.size() - 1);
+        }
+    }
+
+    private static Object invoke(Object target, String name) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(name);
+        method.setAccessible(true);
+        return method.invoke(target);
+    }
+
+    private static Object invoke(
+            Object target, String name, Class<?> parameterType, Object argument) throws Exception {
+        Method method = target.getClass().getDeclaredMethod(name, parameterType);
+        method.setAccessible(true);
+        return method.invoke(target, argument);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object getField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/telemetry/LogicalOperationTelemetryTest.java
+++ b/sdk-core/src/test/java/io/milvus/telemetry/LogicalOperationTelemetryTest.java
@@ -1,0 +1,468 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.grpc.CollectionSchema;
+import io.milvus.grpc.ClientCommand;
+import io.milvus.grpc.ClientInfo;
+import io.milvus.grpc.ConnectRequest;
+import io.milvus.grpc.ConnectResponse;
+import io.milvus.grpc.DataType;
+import io.milvus.grpc.DescribeCollectionRequest;
+import io.milvus.grpc.DescribeCollectionResponse;
+import io.milvus.grpc.FieldSchema;
+import io.milvus.grpc.FieldData;
+import io.milvus.grpc.LongArray;
+import io.milvus.grpc.KeyValuePair;
+import io.milvus.grpc.MilvusServiceGrpc;
+import io.milvus.grpc.QueryRequest;
+import io.milvus.grpc.QueryResults;
+import io.milvus.grpc.SearchRequest;
+import io.milvus.grpc.SearchResultData;
+import io.milvus.grpc.SearchResults;
+import io.milvus.orm.iterator.RpcStubWrapper;
+import io.milvus.grpc.ScalarField;
+import io.milvus.param.ConnectParam;
+import io.milvus.param.Constant;
+import io.milvus.param.MetricType;
+import io.milvus.param.R;
+import io.milvus.param.RetryParam;
+import io.milvus.param.dml.DeleteParam;
+import io.milvus.param.dml.HybridSearchParam;
+import io.milvus.param.dml.InsertParam;
+import io.milvus.param.dml.SearchParam;
+import io.milvus.param.dml.UpsertParam;
+import io.milvus.param.highlevel.dml.GetIdsParam;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.RetryConfig;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LogicalOperationTelemetryTest {
+    @Test
+    void v2TelemetryUsesStrictRequestIdAndCannotReplaceSuccessfulResult() throws Exception {
+        MilvusClientV2 client = new MilvusClientV2(null);
+        ClientTelemetryManager manager = mock(ClientTelemetryManager.class);
+        ThreadLocal<String> requestId = new ThreadLocal<>();
+        requestId.set("arbitrary-wire-id");
+        setField(client, "connectConfig", ConnectConfig.builder()
+                .uri("http://localhost:19530")
+                .clientRequestId(requestId)
+                .build());
+        setField(client, "telemetry", manager);
+        doThrow(new IllegalStateException("telemetry failure"))
+                .when(manager).recordOperation(
+                        eq("Search"), eq("books"), anyLong(), eq(""), eq(""));
+        Method logicalOperation = MilvusClientV2.class.getDeclaredMethod(
+                "recordLogicalOperation", String.class, String.class, Supplier.class);
+        logicalOperation.setAccessible(true);
+
+        Object result = logicalOperation.invoke(
+                client, "Search", "books", (Supplier<String>) () -> "business-result");
+
+        assertEquals("business-result", result);
+        verify(manager).recordOperation(
+                eq("Search"), eq("books"), anyLong(), eq(""), eq(""));
+        requestId.remove();
+    }
+
+    @Test
+    void v2IteratorStubSuppressesInternalPageTelemetry() throws Exception {
+        ManagedChannel channel = InProcessChannelBuilder.forName(
+                InProcessServerBuilder.generateName()).directExecutor().build();
+        MilvusClientV2 client = new MilvusClientV2(null);
+        try {
+            setField(client, "connectConfig", ConnectConfig.builder()
+                    .uri("http://localhost:19530")
+                    .build());
+            setField(client, "cacheEndpoint", "localhost:19530");
+            client.setBlockingStub(MilvusServiceGrpc.newBlockingStub(channel));
+            Method createIteratorRpcStub = MilvusClientV2.class.getDeclaredMethod(
+                    "createIteratorRpcStub", String.class);
+            createIteratorRpcStub.setAccessible(true);
+
+            RpcStubWrapper stub = (RpcStubWrapper) createIteratorRpcStub.invoke(client, "");
+
+            assertEquals(Boolean.TRUE, stub.get().getCallOptions().getOption(
+                    TelemetryInterceptor.LOGICAL_OPERATION_OPTION));
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+
+    @Test
+    void syncAndAsyncRetriesEachProduceOneLogicalMetric() throws Exception {
+        AtomicInteger syncAttempts = new AtomicInteger();
+        AtomicInteger asyncAttempts = new AtomicInteger();
+        String serverName = InProcessServerBuilder.generateName();
+        Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new MilvusServiceGrpc.MilvusServiceImplBase() {
+                    @Override
+                    public void search(
+                            SearchRequest request, StreamObserver<SearchResults> responseObserver) {
+                        AtomicInteger attempts = "sync".equals(request.getCollectionName())
+                                ? syncAttempts : asyncAttempts;
+                        if (attempts.incrementAndGet() == 1) {
+                            responseObserver.onError(io.grpc.Status.UNAVAILABLE.asRuntimeException());
+                            return;
+                        }
+                        responseObserver.onNext(successfulSearch());
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "default", null);
+        MilvusClientV2 client = new MilvusClientV2(null);
+        try {
+            setField(client, "telemetry", manager);
+            Channel intercepted = ClientInterceptors.intercept(
+                    channel, new TelemetryInterceptor(manager, null));
+            client.setBlockingStub(MilvusServiceGrpc.newBlockingStub(intercepted));
+            client.setFutureStub(MilvusServiceGrpc.newFutureStub(intercepted));
+            client.retryConfig(RetryConfig.builder()
+                    .maxRetryTimes(2)
+                    .initialBackOffMs(0)
+                    .maxBackOffMs(0)
+                    .build());
+
+            client.search(searchRequest("sync"));
+            invokeCreateSnapshot(manager);
+            assertEquals(2, syncAttempts.get());
+            assertEquals(1, searchRequestCount(manager));
+
+            client.searchAsync(searchRequest("async")).get(5, TimeUnit.SECONDS);
+            awaitRequestCount(manager, "Search", 2);
+            assertEquals(2, asyncAttempts.get());
+            assertEquals(2, searchRequestCount(manager));
+
+            assertThrows(RuntimeException.class, () -> client.insert(null));
+            assertThrows(RuntimeException.class, () -> client.upsert(null));
+            assertThrows(RuntimeException.class, () -> client.delete(null));
+            assertThrows(RuntimeException.class, () -> client.get(null));
+            assertThrows(RuntimeException.class, () -> client.query(null));
+            assertThrows(RuntimeException.class, () -> client.hybridSearch(null));
+            assertThrows(RuntimeException.class, () -> client.getAsync(null).join());
+            assertThrows(RuntimeException.class, () -> client.queryAsync(null).join());
+            assertThrows(RuntimeException.class, () -> client.hybridSearchAsync(null).join());
+        } finally {
+            client.close();
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void legacyRetryValidationAsyncCompletionAndSimpleGetAreLogicalOnce() throws Exception {
+        AtomicInteger retryAttempts = new AtomicInteger();
+        AtomicInteger queryAttempts = new AtomicInteger();
+        Server server = ServerBuilder.forPort(0)
+                .addService(new MilvusServiceGrpc.MilvusServiceImplBase() {
+                    @Override
+                    public void connect(ConnectRequest request, StreamObserver<ConnectResponse> observer) {
+                        observer.onNext(ConnectResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.newBuilder().setCode(0).build())
+                                .setIdentifier(1L)
+                                .build());
+                        observer.onCompleted();
+                    }
+
+                    @Override
+                    public void search(SearchRequest request, StreamObserver<SearchResults> observer) {
+                        if ("retry".equals(request.getCollectionName())
+                                && retryAttempts.incrementAndGet() == 1) {
+                            observer.onError(io.grpc.Status.UNAVAILABLE.asRuntimeException());
+                            return;
+                        }
+                        if ("async".equals(request.getCollectionName())) {
+                            try {
+                                Thread.sleep(25L);
+                            } catch (InterruptedException exception) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                        observer.onNext(successfulSearch());
+                        observer.onCompleted();
+                    }
+
+                    @Override
+                    public void describeCollection(
+                            DescribeCollectionRequest request,
+                            StreamObserver<DescribeCollectionResponse> observer) {
+                        observer.onNext(DescribeCollectionResponse.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.newBuilder().setCode(0).build())
+                                .setCollectionName(request.getCollectionName())
+                                .setSchema(CollectionSchema.newBuilder()
+                                        .addFields(FieldSchema.newBuilder()
+                                                .setName("id")
+                                                .setDataType(DataType.Int64)
+                                                .setIsPrimaryKey(true)
+                                                .build())
+                                        .addFields(FieldSchema.newBuilder()
+                                                .setName("vector")
+                                                .setDataType(DataType.FloatVector)
+                                                .addTypeParams(KeyValuePair.newBuilder()
+                                                        .setKey(Constant.VECTOR_DIM)
+                                                        .setValue("2")
+                                                        .build())
+                                                .build())
+                                        .build())
+                                .build());
+                        observer.onCompleted();
+                    }
+
+                    @Override
+                    public void query(QueryRequest request, StreamObserver<QueryResults> observer) {
+                        queryAttempts.incrementAndGet();
+                        observer.onNext(QueryResults.newBuilder()
+                                .setStatus(io.milvus.grpc.Status.newBuilder().setCode(0).build())
+                                .addFieldsData(FieldData.newBuilder()
+                                        .setFieldName("id")
+                                        .setType(DataType.Int64)
+                                        .setScalars(ScalarField.newBuilder()
+                                                .setLongData(LongArray.newBuilder().addData(1L).build())
+                                                .build())
+                                        .build())
+                                .build());
+                        observer.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        MilvusServiceClient owner = new MilvusServiceClient(ConnectParam.newBuilder()
+                .withHost("localhost")
+                .withPort(server.getPort())
+                .build());
+        MilvusServiceClient client = (MilvusServiceClient) owner.withRetry(RetryParam.newBuilder()
+                .withMaxRetryTimes(2)
+                .withInitialBackOffMs(1)
+                .withMaxBackOffMs(1)
+                .build());
+        ClientTelemetryManager manager = owner.getTelemetry();
+        try {
+            ClientInfo clientInfo = invokeBuildClientInfo(manager);
+            assertFalse(clientInfo.getReservedMap().containsKey("db_name"));
+            manager.processCommands(Collections.singletonList(ClientCommand.newBuilder()
+                    .setCommandId("legacy-config")
+                    .setCommandType("get_config")
+                    .setCreateTime(1)
+                    .build()));
+
+            R<SearchResults> retryResult = client.search(legacySearch("retry"));
+            assertEquals(R.Status.Success.getCode(), retryResult.getStatus());
+            invokeCreateSnapshot(manager);
+            assertEquals(2, retryAttempts.get());
+            assertEquals(1, requestCount(manager, "Search"));
+
+            R<SearchResults> invalidResult = client.search((SearchParam) null);
+            assertTrue(invalidResult.getStatus() != R.Status.Success.getCode());
+            invokeCreateSnapshot(manager);
+            assertEquals(2, requestCount(manager, "Search"));
+            assertEquals(1, errorCount(manager, "Search"));
+
+            R<SearchResults> asyncResult = client.searchAsync(legacySearch("async"))
+                    .get(5, TimeUnit.SECONDS);
+            assertEquals(R.Status.Success.getCode(), asyncResult.getStatus());
+            awaitRequestCount(manager, "Search", 3);
+            assertEquals(3, requestCount(manager, "Search"));
+            assertTrue(maxLatencyMs(manager, "Search") >= 10.0);
+
+            R<?> getResult = client.get(GetIdsParam.newBuilder()
+                    .withCollectionName("books")
+                    .withPrimaryIds(Collections.singletonList(1L))
+                    .withOutputFields(Collections.singletonList("id"))
+                    .build());
+            assertEquals(R.Status.Success.getCode(), getResult.getStatus(),
+                    String.valueOf(getResult.getException()));
+            invokeCreateSnapshot(manager);
+            assertEquals(1, queryAttempts.get());
+            assertEquals(1, requestCount(manager, "Query"));
+
+            assertNotEquals(R.Status.Success.getCode(),
+                    client.insert((InsertParam) null).getStatus());
+            assertNotEquals(R.Status.Success.getCode(),
+                    client.upsert((UpsertParam) null).getStatus());
+            assertNotEquals(R.Status.Success.getCode(),
+                    client.delete((DeleteParam) null).getStatus());
+            assertNotEquals(R.Status.Success.getCode(),
+                    client.hybridSearch((HybridSearchParam) null).getStatus());
+            assertThrows(NullPointerException.class,
+                    () -> client.insertAsync((InsertParam) null));
+            assertThrows(NullPointerException.class,
+                    () -> client.upsertAsync((UpsertParam) null));
+            assertThrows(NullPointerException.class,
+                    () -> client.hybridSearchAsync((HybridSearchParam) null));
+
+            MilvusClientV2 configuredClient = new MilvusClientV2(ConnectConfig.builder()
+                    .uri("http://localhost:" + server.getPort())
+                    .build());
+            try {
+                ClientTelemetryManager configuredManager = configuredClient.getTelemetry();
+                assertFalse(invokeBuildClientInfo(configuredManager)
+                        .getReservedMap().containsKey("db_name"));
+                configuredManager.processCommands(Collections.singletonList(ClientCommand.newBuilder()
+                        .setCommandId("v2-config")
+                        .setCommandType("get_config")
+                        .setCreateTime(1)
+                        .build()));
+                configuredClient.startTelemetry();
+            } finally {
+                configuredClient.close();
+            }
+
+            client.close(1);
+            assertTrue(manager.isClosed());
+        } finally {
+            owner.close(1);
+            server.shutdownNow();
+        }
+    }
+
+    private static SearchReq searchRequest(String collection) {
+        return SearchReq.builder()
+                .collectionName(collection)
+                .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                .limit(1)
+                .build();
+    }
+
+    private static SearchParam legacySearch(String collection) {
+        return SearchParam.newBuilder()
+                .withCollectionName(collection)
+                .withMetricType(MetricType.L2)
+                .withTopK(1)
+                .withVectors(Collections.singletonList(Arrays.asList(1.0f, 2.0f)))
+                .withVectorFieldName("vector")
+                .build();
+    }
+
+    private static SearchResults successfulSearch() {
+        return SearchResults.newBuilder()
+                .setStatus(io.milvus.grpc.Status.newBuilder().setCode(0).build())
+                .setResults(SearchResultData.newBuilder()
+                        .setNumQueries(1)
+                        .addTopks(0)
+                        .build())
+                .build();
+    }
+
+    private static long searchRequestCount(ClientTelemetryManager manager) {
+        return requestCount(manager, "Search");
+    }
+
+    private static void awaitRequestCount(
+            ClientTelemetryManager manager, String operationName, long expected) throws Exception {
+        long deadline = System.currentTimeMillis() + 1_000;
+        while (requestCount(manager, operationName) < expected
+                && System.currentTimeMillis() < deadline) {
+            invokeCreateSnapshot(manager);
+            // A future may complete just before its telemetry callback. Avoid a tight loop:
+            // more than 120 empty snapshots would evict the already-verified prior window.
+            Thread.sleep(10L);
+        }
+    }
+
+    private static long requestCount(ClientTelemetryManager manager, String operationName) {
+        long count = 0;
+        for (ClientTelemetryManager.MetricsSnapshot snapshot : manager.getMetricsSnapshots()) {
+            for (ClientTelemetryManager.OperationSnapshot operation : snapshot.metrics) {
+                if (operationName.equals(operation.operation)) {
+                    count += operation.global.request_count;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static long errorCount(ClientTelemetryManager manager, String operationName) {
+        long count = 0;
+        for (ClientTelemetryManager.MetricsSnapshot snapshot : manager.getMetricsSnapshots()) {
+            for (ClientTelemetryManager.OperationSnapshot operation : snapshot.metrics) {
+                if (operationName.equals(operation.operation)) {
+                    count += operation.global.error_count;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static double maxLatencyMs(ClientTelemetryManager manager, String operationName) {
+        double max = 0.0;
+        for (ClientTelemetryManager.MetricsSnapshot snapshot : manager.getMetricsSnapshots()) {
+            for (ClientTelemetryManager.OperationSnapshot operation : snapshot.metrics) {
+                if (operationName.equals(operation.operation)) {
+                    max = Math.max(max, operation.global.max_latency_ms);
+                }
+            }
+        }
+        return max;
+    }
+
+    private static void invokeCreateSnapshot(ClientTelemetryManager manager) throws Exception {
+        Method method = ClientTelemetryManager.class.getDeclaredMethod("createSnapshot");
+        method.setAccessible(true);
+        method.invoke(manager);
+    }
+
+    private static ClientInfo invokeBuildClientInfo(ClientTelemetryManager manager) throws Exception {
+        Method method = ClientTelemetryManager.class.getDeclaredMethod("buildClientInfo");
+        method.setAccessible(true);
+        return (ClientInfo) method.invoke(manager);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/telemetry/TelemetryInterceptorTest.java
+++ b/sdk-core/src/test/java/io/milvus/telemetry/TelemetryInterceptorTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.telemetry;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.grpc.MilvusServiceGrpc;
+import io.milvus.grpc.SearchRequest;
+import io.milvus.grpc.SearchResults;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+class TelemetryInterceptorTest {
+    @Test
+    void recordsBusinessAndTransportFailuresAtUnaryBoundary() throws Exception {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null);
+        CapturingChannel channel = new CapturingChannel();
+        TelemetryInterceptor interceptor = new TelemetryInterceptor(manager, null);
+        try {
+            ClientCall<SearchRequest, SearchResults> businessCall = interceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, channel);
+            businessCall.start(new ClientCall.Listener<SearchResults>() {}, new Metadata());
+            businessCall.sendMessage(SearchRequest.newBuilder().setCollectionName("books").build());
+            channel.listener.onMessage(SearchResults.newBuilder()
+                    .setStatus(io.milvus.grpc.Status.newBuilder()
+                            .setCode(1)
+                            .setReason("business failure")
+                            .build())
+                    .build());
+            channel.listener.onClose(Status.OK, new Metadata());
+
+            ClientCall<SearchRequest, SearchResults> transportCall = interceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, channel);
+            transportCall.start(new ClientCall.Listener<SearchResults>() {}, new Metadata());
+            transportCall.sendMessage(SearchRequest.newBuilder().setCollectionName("books").build());
+            channel.listener.onClose(Status.UNAVAILABLE.withDescription("offline"), new Metadata());
+
+            assertEquals(2, manager.getRecentErrors(10).size());
+            assertEquals("business failure", manager.getRecentErrors(10).get(1).error_msg);
+            assertEquals("books", manager.getRecentErrors(10).get(1).collection);
+            assertTrue(manager.getRecentErrors(10).get(0).error_msg.contains("UNAVAILABLE"));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void bypassesNonOperationsExplicitLogicalCallsAndNestedScopes() {
+        ClientTelemetryManager manager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null);
+        CapturingChannel channel = new CapturingChannel();
+        TelemetryInterceptor interceptor = new TelemetryInterceptor(manager, null);
+        try {
+            ClientCall<?, ?> nonOperation = interceptor.interceptCall(
+                    MilvusServiceGrpc.getConnectMethod(), CallOptions.DEFAULT, channel);
+            assertSame(channel.lastCall, nonOperation);
+
+            ClientCall<?, ?> explicitLogical = interceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(),
+                    CallOptions.DEFAULT.withOption(TelemetryInterceptor.LOGICAL_OPERATION_OPTION, true),
+                    channel);
+            assertSame(channel.lastCall, explicitLogical);
+
+            ClientTelemetryManager.LogicalOperationScope outer =
+                    manager.beginLogicalOperation();
+            ClientTelemetryManager.LogicalOperationScope inner =
+                    manager.beginLogicalOperation();
+            ClientCall<?, ?> nested = interceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, channel);
+            assertSame(channel.lastCall, nested);
+            inner.close();
+            outer.close();
+            outer.close();
+
+            ClientCall<?, ?> instrumented = interceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, channel);
+            assertFalse(channel.lastCall == instrumented);
+            assertEquals(4, channel.calls.get());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void logicalSuppressionIsScopedToTheOwningClient() throws Exception {
+        ClientTelemetryManager firstManager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null);
+        ClientTelemetryManager secondManager = new ClientTelemetryManager(
+                TelemetryConfig.defaults(), "", "test", () -> "", null);
+        CapturingChannel firstChannel = new CapturingChannel();
+        CapturingChannel secondChannel = new CapturingChannel();
+        TelemetryInterceptor firstInterceptor = new TelemetryInterceptor(firstManager, null);
+        TelemetryInterceptor secondInterceptor = new TelemetryInterceptor(secondManager, null);
+        try (ClientTelemetryManager.LogicalOperationScope ignored =
+                     firstManager.beginLogicalOperation()) {
+            ClientCall<?, ?> firstCall = firstInterceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, firstChannel);
+            assertSame(firstChannel.lastCall, firstCall);
+
+            ClientCall<?, ?> secondCall = secondInterceptor.interceptCall(
+                    MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, secondChannel);
+            assertFalse(secondChannel.lastCall == secondCall);
+
+            Field legacyDepth = MilvusServiceClient.class.getDeclaredField("logicalOperationDepth");
+            assertFalse(Modifier.isStatic(legacyDepth.getModifiers()));
+        } finally {
+            firstManager.close();
+            secondManager.close();
+        }
+    }
+
+    @Test
+    void telemetryFailureDoesNotSuppressBusinessClose() {
+        ClientTelemetryManager manager = mock(ClientTelemetryManager.class);
+        doThrow(new IllegalStateException("telemetry failure"))
+                .when(manager).recordOperation(
+                        anyString(), anyString(), anyLong(), anyString(), anyString());
+        CapturingChannel channel = new CapturingChannel();
+        TelemetryInterceptor interceptor = new TelemetryInterceptor(manager, null);
+        AtomicInteger closes = new AtomicInteger();
+        ClientCall<SearchRequest, SearchResults> call = interceptor.interceptCall(
+                MilvusServiceGrpc.getSearchMethod(), CallOptions.DEFAULT, channel);
+        call.start(new ClientCall.Listener<SearchResults>() {
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+                closes.incrementAndGet();
+            }
+        }, new Metadata());
+        call.sendMessage(SearchRequest.newBuilder().setCollectionName("books").build());
+
+        channel.listener.onClose(Status.OK, new Metadata());
+
+        assertEquals(1, closes.get());
+    }
+
+    @Test
+    void protobufExtractionFailsOpenForUnrelatedValues() throws Exception {
+        assertEquals("", invokeStatic("collectionName", "not-protobuf"));
+        assertEquals(true, invokeStatic("responseSucceeded", "not-protobuf"));
+        assertEquals("Milvus operation failed", invokeStatic("responseError", "not-protobuf"));
+        assertNull(invokeStatic("statusMessage", SearchRequest.getDefaultInstance()));
+
+        SearchRequest request = SearchRequest.newBuilder().setCollectionName("books").build();
+        assertEquals("books", invokeStatic("collectionName", request));
+    }
+
+    private static Object invokeStatic(String name, Object argument) throws Exception {
+        Method method = TelemetryInterceptor.class.getDeclaredMethod(name, Object.class);
+        method.setAccessible(true);
+        return method.invoke(null, argument);
+    }
+
+    private static final class CapturingChannel extends Channel {
+        private final AtomicInteger calls = new AtomicInteger();
+        private ClientCall<?, ?> lastCall;
+        private ClientCall.Listener listener;
+
+        @Override
+        public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+                MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+            calls.incrementAndGet();
+            ClientCall<RequestT, ResponseT> call = new ClientCall<RequestT, ResponseT>() {
+                @Override
+                public void start(Listener<ResponseT> responseListener, Metadata headers) {
+                    listener = responseListener;
+                }
+
+                @Override
+                public void request(int numMessages) {
+                }
+
+                @Override
+                public void cancel(String message, Throwable cause) {
+                }
+
+                @Override
+                public void halfClose() {
+                }
+
+                @Override
+                public void sendMessage(RequestT message) {
+                }
+            };
+            lastCall = call;
+            return call;
+        }
+
+        @Override
+        public String authority() {
+            return "test";
+        }
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
@@ -55,6 +55,7 @@ public class BaseTest {
         client_v2.setBlockingStub(blockingStub);
         client_v2.setFutureStub(futureStub);
         when(blockingStub.withDeadlineAfter(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(blockingStub);
+        when(blockingStub.withOption(any(), any())).thenReturn(blockingStub);
         when(futureStub.withDeadlineAfter(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(futureStub);
         when(futureStub.withOption(any(), any())).thenReturn(futureStub);
 

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -544,7 +544,8 @@ public class MilvusClientV2Test extends BaseTest {
 
         // io.milvus/v2/client
         config.setIgnoredMethods(Arrays.asList("clientRequestId", "getClientRequestId", "setClientRequestId",
-                "sslContext", "setSslContext", "getSslContext"));
+                "sslContext", "setSslContext", "getSslContext", "getTelemetryRuntimeState",
+                "telemetryRuntimeState", "telemetryConfig", "setDeferTelemetryStart"));
         VerifyClass(ConnectConfig.class.getName(), config);
         config.clearIgnoredMethods();
         VerifyClass(RetryConfig.class.getName(), config);

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2UseDatabaseTelemetryTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2UseDatabaseTelemetryTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.client;
+
+import io.grpc.ManagedChannel;
+import io.milvus.grpc.MilvusServiceGrpc;
+import io.milvus.telemetry.ClientTelemetryManager;
+import io.milvus.telemetry.TelemetryConfig;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class MilvusClientV2UseDatabaseTelemetryTest {
+    @Test
+    void candidateFailureLeavesActiveConnectionAndTelemetryUntouched() throws Exception {
+        ConnectConfig config = config("default");
+        ClientTelemetryManager oldManager = manager("client-id");
+        oldManager.start();
+        ManagedChannel oldChannel = mock(ManagedChannel.class);
+        TestClient client = new TestClient(candidateConfig -> {
+            throw new IllegalStateException("candidate failed");
+        });
+        installConnection(client, config, oldManager, oldChannel);
+
+        try {
+            assertThrows(IllegalStateException.class, () -> client.useDatabase("other"));
+            assertEquals("default", client.currentUsedDatabase());
+            assertSame(oldManager, client.getTelemetry());
+            assertTrue(oldManager.isReady());
+            assertFalse(oldManager.isClosed());
+            verify(oldChannel, never()).shutdownNow();
+        } finally {
+            oldManager.close();
+        }
+    }
+
+    @Test
+    void successfulCandidatePreservesTelemetryStateAndThenClosesOldConnection() throws Exception {
+        ConnectConfig config = config("default");
+        ClientTelemetryManager oldManager = manager("client-id");
+        oldManager.start();
+        ManagedChannel oldChannel = mock(ManagedChannel.class);
+        ManagedChannel newChannel = mock(ManagedChannel.class);
+        AtomicReference<ConnectConfig> seenConfig = new AtomicReference<>();
+        AtomicReference<ClientTelemetryManager> newManagerRef = new AtomicReference<>();
+        TestClient client = new TestClient(candidateConfig -> {
+            seenConfig.set(candidateConfig);
+            ClientTelemetryManager replacement = manager(candidateConfig.getTelemetryClientId());
+            newManagerRef.set(replacement);
+            MilvusClientV2 candidate = new MilvusClientV2(null);
+            installConnection(candidate, candidateConfig, replacement, newChannel);
+            return candidate;
+        });
+        installConnection(client, config, oldManager, oldChannel);
+
+        try {
+            client.useDatabase("other");
+
+            ClientTelemetryManager replacement = newManagerRef.get();
+            assertEquals("other", seenConfig.get().getDbName());
+            assertTrue(seenConfig.get().isDeferTelemetryStart());
+            assertEquals(oldManager.getClientId(), seenConfig.get().getTelemetryClientId());
+            assertEquals("other", client.currentUsedDatabase());
+            assertEquals("other", config.getDbName());
+            assertSame(replacement, client.getTelemetry());
+            assertEquals(oldManager.getClientId(), replacement.getClientId());
+            assertTrue(oldManager.isClosed());
+            assertTrue(replacement.isReady());
+            verify(oldChannel).shutdownNow();
+            verify(newChannel, never()).shutdownNow();
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    void failedStateHandoffRollsBackPublishedCandidateAndKeepsOldLifecycle() throws Exception {
+        ConnectConfig config = config("default");
+        ClientTelemetryManager oldManager = manager("client-id");
+        oldManager.start();
+        ManagedChannel oldChannel = mock(ManagedChannel.class);
+        ManagedChannel candidateChannel = mock(ManagedChannel.class);
+        AtomicReference<ClientTelemetryManager> candidateManagerRef = new AtomicReference<>();
+        TestClient client = new TestClient(candidateConfig -> {
+            ClientTelemetryManager candidateManager = manager("different-client-id");
+            candidateManagerRef.set(candidateManager);
+            MilvusClientV2 candidate = new MilvusClientV2(null);
+            installConnection(candidate, candidateConfig, candidateManager, candidateChannel);
+            return candidate;
+        });
+        installConnection(client, config, oldManager, oldChannel);
+
+        try {
+            assertThrows(IllegalArgumentException.class, () -> client.useDatabase("other"));
+            assertEquals("default", client.currentUsedDatabase());
+            assertSame(oldManager, client.getTelemetry());
+            assertTrue(oldManager.isReady());
+            assertFalse(oldManager.isClosed());
+            assertTrue(candidateManagerRef.get().isClosed());
+            verify(oldChannel, never()).shutdownNow();
+            verify(candidateChannel).shutdownNow();
+        } finally {
+            oldManager.close();
+        }
+    }
+
+    private static ConnectConfig config(String database) {
+        return ConnectConfig.builder()
+                .uri("http://localhost:19530")
+                .dbName(database)
+                .telemetryConfig(TelemetryConfig.builder()
+                        .heartbeatIntervalMs(TimeUnit.MINUTES.toMillis(10))
+                        .build())
+                .telemetryClientId("client-id")
+                .build();
+    }
+
+    private static ClientTelemetryManager manager(String clientId) {
+        return new ClientTelemetryManager(
+                TelemetryConfig.builder()
+                        .heartbeatIntervalMs(TimeUnit.MINUTES.toMillis(10))
+                        .build(),
+                "", "test", () -> "default", null, clientId);
+    }
+
+    private static void installConnection(
+            MilvusClientV2 client,
+            ConnectConfig config,
+            ClientTelemetryManager manager,
+            ManagedChannel channel) {
+        try {
+            setField(client, "connectConfig", config);
+            setField(client, "cacheEndpoint", "localhost:19530");
+            setField(client, "telemetry", manager);
+            setField(client, "channel", channel);
+            setField(client, "blockingStub", mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class));
+            setField(client, "futureStub", mock(MilvusServiceGrpc.MilvusServiceFutureStub.class));
+        } catch (ReflectiveOperationException exception) {
+            throw new AssertionError(exception);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value)
+            throws ReflectiveOperationException {
+        Field field = MilvusClientV2.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private interface CandidateFactory {
+        MilvusClientV2 create(ConnectConfig config);
+    }
+
+    private static final class TestClient extends MilvusClientV2 {
+        private final CandidateFactory candidateFactory;
+
+        private TestClient(CandidateFactory candidateFactory) {
+            super(null);
+            this.candidateFactory = candidateFactory;
+        }
+
+        @Override
+        MilvusClientV2 createDatabaseCandidate(ConnectConfig config) {
+            return candidateFactory.create(config);
+        }
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/client/globalcluster/GlobalStubTelemetryHandoffTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/globalcluster/GlobalStubTelemetryHandoffTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.client.globalcluster;
+
+import io.milvus.telemetry.ClientTelemetryManager;
+import io.milvus.telemetry.TelemetryConfig;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+class GlobalStubTelemetryHandoffTest {
+    @Test
+    void retargetPublishesCurrentAndFuturePrimaryToNewOwner() {
+        ClientTelemetryManager oldManager = manager("");
+        oldManager.start();
+        TestMilvusClient oldClient = new TestMilvusClient(oldManager);
+        ClientTelemetryManager newManager = manager(oldManager.getClientId());
+        TestMilvusClient newClient = new TestMilvusClient(newManager);
+        GlobalStub stub = testStub(oldClient, (endpoint, state, deferred) -> newClient);
+        AtomicReference<MilvusClientV2> published = new AtomicReference<>();
+
+        try {
+            stub.retargetPrimaryChange(published::set);
+            assertSame(oldClient, published.get());
+
+            stub.onTopologyChange(topology(2, "new-primary:19530"));
+            assertSame(newClient, published.get());
+        } finally {
+            newManager.close();
+            oldManager.close();
+        }
+    }
+
+    @Test
+    void replacementConstructionFailureKeepsOldTelemetryRunning() {
+        ClientTelemetryManager oldManager = manager("");
+        oldManager.start();
+        TestMilvusClient oldClient = new TestMilvusClient(oldManager);
+        GlobalStub stub = testStub(oldClient, (endpoint, state, deferred) -> {
+            throw new IllegalStateException("connect failed");
+        });
+
+        try {
+            assertThrows(IllegalStateException.class,
+                    () -> stub.onTopologyChange(topology(2, "new-primary:19530")));
+            assertSame(oldClient, stub.getPrimaryClient());
+            assertEquals("old-primary:19530", stub.getPrimaryEndpoint());
+            assertTrue(oldManager.isReady());
+            assertFalse(oldManager.isClosed());
+            assertFalse(oldClient.closed);
+        } finally {
+            oldManager.close();
+        }
+    }
+
+    @Test
+    void successfulReplacementPreservesStateClosesOldAndForwardsLateOperations() throws Exception {
+        ClientTelemetryManager oldManager = manager("");
+        oldManager.recordOperation("Search", "books", System.nanoTime(), "", "");
+        oldManager.start();
+        TestMilvusClient oldClient = new TestMilvusClient(oldManager);
+
+        ClientTelemetryManager newManager = manager(oldManager.getClientId());
+        TestMilvusClient newClient = new TestMilvusClient(newManager);
+        AtomicBoolean deferred = new AtomicBoolean();
+        GlobalStub stub = testStub(oldClient, (endpoint, state, deferTelemetryStart) -> {
+            assertEquals(oldManager.getClientId(), state.getClientId());
+            deferred.set(deferTelemetryStart);
+            return newClient;
+        });
+
+        try {
+            stub.onTopologyChange(topology(2, "new-primary:19530"));
+            assertTrue(deferred.get());
+            assertSame(newClient, stub.getPrimaryClient());
+            assertEquals("new-primary:19530", stub.getPrimaryEndpoint());
+            assertTrue(oldManager.isClosed());
+            assertTrue(newManager.isReady());
+            assertEquals(oldManager.getClientId(), newManager.getClientId());
+            assertTrue(oldClient.closed);
+
+            // A foreground request that captured the old manager before the switch must not vanish.
+            oldManager.recordOperation("Search", "books", System.nanoTime(), "", "");
+            invokeCreateSnapshot(newManager);
+            assertEquals(2, awaitRequestCount(newManager, "Search"));
+        } finally {
+            newManager.close();
+        }
+    }
+
+    @Test
+    void outerStubSwitchFailureRollsBackWithoutStoppingOldTelemetry() {
+        ClientTelemetryManager oldManager = manager("");
+        oldManager.start();
+        TestMilvusClient oldClient = new TestMilvusClient(oldManager);
+        ClientTelemetryManager newManager = manager(oldManager.getClientId());
+        TestMilvusClient newClient = new TestMilvusClient(newManager);
+        AtomicInteger callbacks = new AtomicInteger();
+        ConnectConfig config = ConnectConfig.builder().uri("http://global:19530").build();
+        GlobalStub stub = new GlobalStub("http://global:19530", config, client -> {
+            callbacks.incrementAndGet();
+            if (client == newClient) {
+                throw new IllegalStateException("outer switch failed");
+            }
+        }, topology(1, "old-primary:19530"), oldClient,
+                (endpoint, state, deferred) -> newClient);
+
+        try {
+            assertThrows(IllegalStateException.class,
+                    () -> stub.onTopologyChange(topology(2, "new-primary:19530")));
+            assertSame(oldClient, stub.getPrimaryClient());
+            assertEquals("old-primary:19530", stub.getPrimaryEndpoint());
+            assertEquals(2, callbacks.get());
+            assertFalse(oldManager.isClosed());
+            assertTrue(oldManager.isReady());
+            assertTrue(newManager.isClosed());
+            assertFalse(oldClient.closed);
+            assertTrue(newClient.closed);
+            // The failed outer switch must have cancelled retirement, so the old manager can
+            // enter and leave a later retirement normally instead of remaining fenced forever.
+            long retirementToken = oldManager.beginRuntimeStateRetirement();
+            oldManager.cancelRuntimeStateRetirement(retirementToken);
+        } finally {
+            oldManager.close();
+        }
+    }
+
+    private static GlobalStub testStub(MilvusClientV2 oldClient, GlobalStub.ClientFactory factory) {
+        ConnectConfig config = ConnectConfig.builder().uri("http://global:19530").build();
+        return new GlobalStub("http://global:19530", config, ignored -> { },
+                topology(1, "old-primary:19530"), oldClient, factory);
+    }
+
+    private static GlobalTopology topology(long version, String endpoint) {
+        return new GlobalTopology(version, Collections.singletonList(
+                new ClusterInfo("cluster", endpoint, ClusterCapability.WRITABLE)));
+    }
+
+    private static ClientTelemetryManager manager(String clientId) {
+        return new ClientTelemetryManager(TelemetryConfig.defaults(), "", "test",
+                () -> "default", null, clientId);
+    }
+
+    private static void invokeCreateSnapshot(ClientTelemetryManager manager) throws Exception {
+        Method method = ClientTelemetryManager.class.getDeclaredMethod("createSnapshot");
+        method.setAccessible(true);
+        method.invoke(manager);
+    }
+
+    private static long requestCount(ClientTelemetryManager manager, String operationName) {
+        long count = 0;
+        for (ClientTelemetryManager.MetricsSnapshot snapshot : manager.getMetricsSnapshots()) {
+            for (ClientTelemetryManager.OperationSnapshot operation : snapshot.metrics) {
+                if (operationName.equals(operation.operation)) {
+                    count += operation.global.request_count;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static long awaitRequestCount(
+            ClientTelemetryManager manager, String operationName) throws InterruptedException {
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+        long count;
+        do {
+            count = requestCount(manager, operationName);
+            if (count >= 2) {
+                return count;
+            }
+            Thread.sleep(1);
+        } while (System.nanoTime() < deadline);
+        return count;
+    }
+
+    private static final class TestMilvusClient extends MilvusClientV2 {
+        private final ClientTelemetryManager manager;
+        private boolean closed;
+
+        private TestMilvusClient(ClientTelemetryManager manager) {
+            super(null);
+            this.manager = manager;
+        }
+
+        @Override
+        public ClientTelemetryManager getTelemetry() {
+            return manager;
+        }
+
+        @Override
+        public void startTelemetry() {
+            manager.start();
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            manager.close();
+        }
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -359,24 +359,26 @@ class VectorTest extends BaseTest {
                 .build();
 
         CompletableFuture<QueryResp> synchronous = CompletableFuture.supplyAsync(() -> {
-            requestId.set("synchronous-request");
+            requestId.set("11111111111111111111111111111111");
             return client_v2.query(request);
         });
 
         try {
             Assertions.assertTrue(schemaLoadStarted.await(5, TimeUnit.SECONDS));
-            requestId.set("async-request");
+            requestId.set("async-query-request");
             CompletableFuture<QueryResp> asynchronous = client_v2.queryAsync(request);
 
-            requestId.set("unrelated-request");
+            requestId.set("33333333333333333333333333333333");
             releaseSchemaLoad.countDown();
 
             Assertions.assertNotNull(synchronous.get(1, TimeUnit.SECONDS));
             Assertions.assertNotNull(asynchronous.get(1, TimeUnit.SECONDS));
             verify(futureStub).withOption(
-                    ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "async-request");
+                    ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                    "async-query-request");
             verify(futureStub, never()).withOption(
-                    ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "synchronous-request");
+                    ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                    "11111111111111111111111111111111");
         } finally {
             releaseSchemaLoad.countDown();
             requestId.remove();
@@ -822,9 +824,9 @@ class VectorTest extends BaseTest {
                 .collectionName("query_original")
                 .filter("id > 0")
                 .build();
-        requestId.set("query-request");
+        requestId.set("44444444444444444444444444444444");
         CompletableFuture<QueryResp> queryFuture = client_v2.queryAsync(queryReq);
-        requestId.set("changed-after-query");
+        requestId.set("55555555555555555555555555555555");
         queryReq.setCollectionName("query_mutated");
         firstQuery.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
         queryFuture.get(1, TimeUnit.SECONDS);
@@ -833,7 +835,8 @@ class VectorTest extends BaseTest {
         queryCaptor.getAllValues().forEach(rpcRequest ->
                 Assertions.assertEquals("query_original", rpcRequest.getCollectionName()));
         verify(futureStub, times(2)).withOption(
-                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "query-request");
+                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                "44444444444444444444444444444444");
 
         clearInvocations(futureStub);
         SettableFuture<SearchResults> firstSearch = SettableFuture.create();
@@ -844,9 +847,9 @@ class VectorTest extends BaseTest {
                 .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
                 .limit(10)
                 .build();
-        requestId.set("search-request");
+        requestId.set("66666666666666666666666666666666");
         CompletableFuture<SearchResp> searchFuture = client_v2.searchAsync(searchReq);
-        requestId.set("changed-after-search");
+        requestId.set("77777777777777777777777777777777");
         searchReq.setCollectionName("search_mutated");
         firstSearch.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
         searchFuture.get(1, TimeUnit.SECONDS);
@@ -855,7 +858,8 @@ class VectorTest extends BaseTest {
         searchCaptor.getAllValues().forEach(rpcRequest ->
                 Assertions.assertEquals("search_original", rpcRequest.getCollectionName()));
         verify(futureStub, times(2)).withOption(
-                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "search-request");
+                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                "66666666666666666666666666666666");
 
         clearInvocations(futureStub);
         SettableFuture<SearchResults> firstHybridSearch = SettableFuture.create();
@@ -871,9 +875,9 @@ class VectorTest extends BaseTest {
                 .searchRequests(Collections.singletonList(annSearchReq))
                 .limit(10)
                 .build();
-        requestId.set("hybrid-request");
+        requestId.set("88888888888888888888888888888888");
         CompletableFuture<SearchResp> hybridFuture = client_v2.hybridSearchAsync(hybridSearchReq);
-        requestId.set("changed-after-hybrid");
+        requestId.set("99999999999999999999999999999999");
         hybridSearchReq.setCollectionName("hybrid_mutated");
         annSearchReq.setVectorFieldName("mutated_vector");
         firstHybridSearch.setException(io.grpc.Status.UNAVAILABLE.asRuntimeException());
@@ -886,7 +890,8 @@ class VectorTest extends BaseTest {
                     getParam(rpcRequest.getRequests(0).getSearchParamsList(), Constant.VECTOR_FIELD));
         });
         verify(futureStub, times(2)).withOption(
-                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION, "hybrid-request");
+                ClientRequestInterceptor.CLIENT_REQUEST_ID_OPTION,
+                "88888888888888888888888888888888");
         requestId.remove();
     }
 


### PR DESCRIPTION
Cherry-picks commit `68f9f22fc73f044e04956a2d570732436e212462` (68f9f22f) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

* feat: add client telemetry command support

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: preserve telemetry state across reconnects

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: sample telemetry operations evenly instead of in runs

Sampling kept a counter modulo 10000 and recorded an operation while the
remainder was under rate*10000, so the sampled operations formed one
contiguous run per cycle. A cycle is ten thousand operations while a
heartbeat window is tens or hundreds, so every window came out wholly
sampled or wholly dropped: at 3 QPS a rate of 0.25 gave fourteen minutes
of full metrics followed by forty-one reporting nothing from a client
that never stopped working. The long-run ratio was right; the ratio
inside a window, which is the only unit the telemetry API reports, never
was.

Accumulate the rate instead and sample on the operation that carries the
accumulator across a whole unit: 0.25 samples every fourth operation, and
any stretch of operations holds the configured ratio. A rate too small to
represent now still samples rarely rather than never -- the old threshold
truncated anything below 1e-4 to zero and then sampled nothing, so a
configured rate silently meant "off".

Matches the Go client, milvus-io/milvus#52615.

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: report telemetry every 10 seconds by default

The heartbeat interval is also the metrics window: each heartbeat carries
the operations since the last one, and the coordinator answers a
telemetry query from the window before the newest, so a caller reads
data between one and two intervals old. At the previous default of 30
seconds that is up to a minute behind, which reads as a stalled client
rather than as a lagging view.

Ten seconds puts the worst case at twenty. The cost is the coordinator
heartbeat rate, which scales with the number of connected clients rather
than with traffic; a deployment with enough clients for that to matter
can raise the interval, per client or fleet-wide, with a persistent
push_config.

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: align telemetry lifecycle with Go SDK

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* test: exclude telemetry handoff internals from bean checks

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* test: make async telemetry assertions race safe

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: address client telemetry review findings

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: keep telemetry control plane after dynamic disable

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: harden client telemetry lifecycle

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

* fix: aggregate telemetry latency history from samples

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>

---------

Signed-off-by: xiaofanluan <xiaofan.luan@zilliz.com>
