### PR TITLE
[cherry-pick] Support element-level query (#2042)

### DIFF
--- a/examples/src/main/java/io/milvus/v2/StructExample.java
+++ b/examples/src/main/java/io/milvus/v2/StructExample.java
@@ -443,6 +443,31 @@ public class StructExample {
         }
     }
 
+    private static void elementLevelQuery() {
+        System.out.println("===================================================");
+        String filter = String.format("element_filter(%s, $[%s] < 2000)", STRUCT_FIELD, FRAME_FIELD);
+        System.out.println("Element-level query with filter expression: " + filter);
+
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .filter(filter)
+                .limit(5)
+                .consistencyLevel(ConsistencyLevel.BOUNDED)
+                .outputFields(Arrays.asList(ID_FIELD, NAME_FIELD,
+                        String.format("%s[%s]", STRUCT_FIELD, FRAME_FIELD),
+                        String.format("%s[%s]", STRUCT_FIELD, DESC_FIELD)))
+                .build());
+        // the server evaluates the filter at element granularity and returns element_indices;
+        // the SDK expands one entity into one result per matched element, and each result carries
+        // elementOffset (the matched element's index within the struct-array field). The source
+        // entity index before expansion is intentionally not exposed: callers identify the source
+        // entity by its primary key in the entity map.
+        List<QueryResp.QueryResult> results = queryResp.getQueryResults();
+        for (QueryResp.QueryResult result : results) {
+            System.out.println(result + ", elementOffset=" + result.getElementOffset());
+        }
+    }
+
     private static JsonArray buildMetadataStructArray() {
         JsonArray metadata = new JsonArray();
 
@@ -540,6 +565,7 @@ public class StructExample {
 
             searchInt8VectorField(ID_FIELD + " == 999");
             elementLevelSearch();
+            elementLevelQuery();
 
             addCollectionStructField();
         } finally {

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/QueryResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/QueryResp.java
@@ -100,8 +100,24 @@ public class QueryResp {
     public static class QueryResult {
         private Map<String, Object> entity;
 
+        /**
+         * For struct-array element-level queries (via {@code element_filter}): the matched
+         * element's index within the array. Null for ordinary (non-element-level) queries.
+         *
+         * <p>The source entity index before row expansion is intentionally NOT exposed here:
+         * callers identify the source entity by its primary key in the {@code entity} map, so
+         * the original index carries no user-meaningful information.
+         *
+         * <p>Note on the V2 surface: {@code query()} exposes the matched offset as a typed
+         * accessor here, while {@code queryIterator()} embeds it as an {@code "offset"} key
+         * inside the entity map (see {@code Constant.OFFSET}). The entity map of this class
+         * intentionally does not contain an {@code "offset"} key.
+         */
+        private Long elementOffset;
+
         private QueryResult(QueryResultBuilder builder) {
             this.entity = builder.entity;
+            this.elementOffset = builder.elementOffset;
         }
 
         public static QueryResultBuilder builder() {
@@ -116,18 +132,33 @@ public class QueryResp {
             this.entity = entity;
         }
 
+        public Long getElementOffset() {
+            return elementOffset;
+        }
+
+        public void setElementOffset(Long elementOffset) {
+            this.elementOffset = elementOffset;
+        }
+
         @Override
         public String toString() {
             return "QueryResult{" +
                     "entity=" + entity +
+                    (elementOffset != null ? ", elementOffset=" + elementOffset : "") +
                     '}';
         }
 
         public static class QueryResultBuilder {
             private Map<String, Object> entity = new HashMap<>();
+            private Long elementOffset;
 
             public QueryResultBuilder entity(Map<String, Object> entity) {
                 this.entity = entity;
+                return this;
+            }
+
+            public QueryResultBuilder elementOffset(Long elementOffset) {
+                this.elementOffset = elementOffset;
                 return this;
             }
 

--- a/sdk-core/src/main/java/io/milvus/v2/utils/ConvertUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/ConvertUtils.java
@@ -85,12 +85,35 @@ public class ConvertUtils {
 
         // normal query
         QueryResultsWrapper queryResultsWrapper = new QueryResultsWrapper(response);
-        queryResultsWrapper.getRowRecords().forEach(rowRecord -> {
-            QueryResp.QueryResult queryResult = QueryResp.QueryResult.builder()
-                    .entity(rowRecord.getFieldValues())
-                    .build();
-            entities.add(queryResult);
-        });
+        List<QueryResultsWrapper.RowRecord> rowRecords = queryResultsWrapper.getRowRecords();
+        List<io.milvus.grpc.ElementIndices> elementIndices = response.getElementIndicesList();
+        if (elementIndices != null && !elementIndices.isEmpty()) {
+            if (elementIndices.size() != rowRecords.size()) {
+                throw new MilvusClientException(ErrorCode.SERVER_ERROR, String.format(
+                        "The element_indices count (%d) does not match the row count (%d)",
+                        elementIndices.size(), rowRecords.size()));
+            }
+            // struct-array element-level query: expand one entity into one result per matched element.
+            // The source entity index is intentionally not exposed on the result: callers identify
+            // the source entity by its primary key, so the index carries no user-meaningful info.
+            for (int i = 0; i < rowRecords.size(); i++) {
+                Map<String, Object> fieldValues = rowRecords.get(i).getFieldValues();
+                for (Long offset : elementIndices.get(i).getIndices().getDataList()) {
+                    QueryResp.QueryResult queryResult = QueryResp.QueryResult.builder()
+                            .entity(new HashMap<>(fieldValues))
+                            .elementOffset(offset)
+                            .build();
+                    entities.add(queryResult);
+                }
+            }
+        } else {
+            rowRecords.forEach(rowRecord -> {
+                QueryResp.QueryResult queryResult = QueryResp.QueryResult.builder()
+                        .entity(rowRecord.getFieldValues())
+                        .build();
+                entities.add(queryResult);
+            });
+        }
         return entities;
     }
 

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -250,6 +250,70 @@ class VectorTest extends BaseTest {
     }
 
     @Test
+    void testQueryElementLevelExpandsResultsWithOffset() {
+        QueryResults response = QueryResults.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0).build())
+                .addFieldsData(FieldData.newBuilder()
+                        .setFieldName("id")
+                        .setType(DataType.Int64)
+                        .setScalars(ScalarField.newBuilder()
+                                .setLongData(LongArray.newBuilder().addData(10L).addData(20L).build())
+                                .build())
+                        .build())
+                .addElementIndices(ElementIndices.newBuilder()
+                        .setIndices(LongArray.newBuilder().addData(0L).addData(2L).build())
+                        .build())
+                .addElementIndices(ElementIndices.newBuilder()
+                        .setIndices(LongArray.newBuilder().addData(1L).build())
+                        .build())
+                .build();
+        when(blockingStub.query(any())).thenReturn(response);
+
+        QueryResp resp = client_v2.query(QueryReq.builder()
+                .collectionName("book")
+                .filter("element_filter(clips, $[tag] == \"sports\")")
+                .build());
+
+        List<QueryResp.QueryResult> results = resp.getQueryResults();
+        Assertions.assertEquals(3, results.size());
+
+        Assertions.assertEquals(10L, results.get(0).getEntity().get("id"));
+        Assertions.assertEquals(0L, results.get(0).getElementOffset());
+
+        Assertions.assertEquals(10L, results.get(1).getEntity().get("id"));
+        Assertions.assertEquals(2L, results.get(1).getElementOffset());
+
+        Assertions.assertEquals(20L, results.get(2).getEntity().get("id"));
+        Assertions.assertEquals(1L, results.get(2).getElementOffset());
+    }
+
+    @Test
+    void testQueryElementLevelRejectsIndexCountMismatch() {
+        // element_indices count (1) does not match the row count (2): must fail, not silently drop
+        QueryResults response = QueryResults.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0).build())
+                .addFieldsData(FieldData.newBuilder()
+                        .setFieldName("id")
+                        .setType(DataType.Int64)
+                        .setScalars(ScalarField.newBuilder()
+                                .setLongData(LongArray.newBuilder().addData(10L).addData(20L).build())
+                                .build())
+                        .build())
+                .addElementIndices(ElementIndices.newBuilder()
+                        .setIndices(LongArray.newBuilder().addData(0L).build())
+                        .build())
+                .build();
+        when(blockingStub.query(any())).thenReturn(response);
+
+        MilvusClientException ex = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.query(QueryReq.builder()
+                        .collectionName("book")
+                        .filter("element_filter(clips, $[tag] == \"sports\")")
+                        .build()));
+        Assertions.assertEquals(ErrorCode.SERVER_ERROR, ex.getErrorCode());
+    }
+
+    @Test
     void testQueryAsync() throws Exception {
         QueryReq request = QueryReq.builder()
                 .collectionName("book")


### PR DESCRIPTION
Cherry-picks commit `9f16ab0b34f455aa65d093229b1112e308dec77a` (9f16ab0b) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

Signed-off-by: yhmo <yihua.mo@zilliz.com>
