### PR TITLE
[cherry-pick] Support query iterator cursor (#2045)

### DIFF
--- a/examples/src/main/java/io/milvus/v2/IteratorExample.java
+++ b/examples/src/main/java/io/milvus/v2/IteratorExample.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.milvus.orm.iterator.QueryIterator;
+import io.milvus.orm.iterator.QueryIteratorCursor;
 import io.milvus.orm.iterator.SearchIterator;
 import io.milvus.orm.iterator.SearchIteratorV2;
 import io.milvus.response.QueryResultsWrapper;
@@ -162,7 +163,7 @@ public class IteratorExample {
     }
 
     private static void queryIteratorWithTemplate(int batchSize) {
-        System.out.println("\n========== queryIterator() ==========");
+        System.out.println("\n========== queryIteratorWithTemplate() ==========");
         List<Long> ids = new ArrayList<>();
         for (long i = 500L; i < 600L; i++) {
             ids.add(i);
@@ -196,6 +197,67 @@ public class IteratorExample {
             }
         }
         System.out.printf("%d query results returned%n", counter);
+    }
+
+
+    // Query iterator with a resumable cursor
+    private static void queryIteratorWithCursor(int batchSize, int limit) {
+        System.out.println("\n========== queryIteratorWithCursor() with resumable cursor ==========");
+        String expr = ID_FIELD + " < 3000";
+
+        QueryIterator queryIterator = client.queryIterator(QueryIteratorReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .expr(expr)
+                .outputFields(Lists.newArrayList(ID_FIELD, AGE_FIELD))
+                .batchSize(batchSize)
+                .limit(limit)
+                .consistencyLevel(ConsistencyLevel.BOUNDED)
+                .build());
+
+        // Read four pages, then capture the cursor and close the iterator. With a batch size
+        // of 10, these pages contain 40 records in total.
+        System.out.println("QueryIterator first four pages results:");
+        int returnedBeforeCursor = 0;
+        for (int page = 0; page < 4; page++) {
+            List<QueryResultsWrapper.RowRecord> records = queryIterator.next();
+            for (QueryResultsWrapper.RowRecord record : records) {
+                System.out.println(record);
+                returnedBeforeCursor++;
+            }
+        }
+
+        QueryIteratorCursor cursor = queryIterator.getCursor();
+        queryIterator.close();
+        System.out.printf("%d query results returned before cursor capture, cursor=%s%n",
+                returnedBeforeCursor, cursor);
+
+        // resume pagination from the captured cursor in a brand new iterator. The limit is
+        // per-iterator, so subtract the rows already consumed to keep the combined total = limit.
+        QueryIterator resumed = client.queryIterator(QueryIteratorReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .expr(expr)
+                .outputFields(Lists.newArrayList(ID_FIELD, AGE_FIELD))
+                .batchSize(batchSize)
+                .limit(limit - returnedBeforeCursor)
+                .cursor(cursor)
+                .consistencyLevel(ConsistencyLevel.BOUNDED)
+                .build());
+
+        System.out.println("Resumed iterator results:");
+        int counter = 0;
+        while (true) {
+            List<QueryResultsWrapper.RowRecord> res = resumed.next();
+            if (res.isEmpty()) {
+                System.out.println("resumed query iteration finished, close");
+                resumed.close();
+                break;
+            }
+            for (QueryResultsWrapper.RowRecord record : res) {
+                System.out.println(record);
+                counter++;
+            }
+        }
+        System.out.printf("%d query results returned after resume%n", counter);
     }
 
 
@@ -275,7 +337,7 @@ public class IteratorExample {
     }
 
     private static void searchIteratorV2WithTemplate(int batchSize) {
-        System.out.println("\n========== searchIteratorV2() ==========");
+        System.out.println("\n========== searchIteratorV2WithTemplate() ==========");
         List<Long> ids = new ArrayList<>();
         for (long i = 500L; i < 600L; i++) {
             ids.add(i);
@@ -323,6 +385,7 @@ public class IteratorExample {
 
         queryIterator("userID < 3000", 1, 5, 10000);
         queryIteratorWithTemplate(80);
+        queryIteratorWithCursor(10, 100);
 
         searchIteratorV1("userAge > 50 &&userAge < 100", "{\"range_filter\": 15.0, \"radius\": 20.0}", 100, 500);
         searchIteratorV1("", "", 1, 3000);

--- a/sdk-core/src/main/java/io/milvus/orm/iterator/QueryIterator.java
+++ b/sdk-core/src/main/java/io/milvus/orm/iterator/QueryIterator.java
@@ -118,6 +118,12 @@ public class QueryIterator {
         this.vectorUtils.setEndpoint(blockingStub.getEndpoint());
         this.vectorUtils.setCurrentDbName(blockingStub.getDatabaseName());
 
+        if (queryIteratorReq.getCursor() != null) {
+            // resume from a previously captured cursor: reuse its session ts and pk/element
+            // position, and skip the setup-ts query and offset seek.
+            restoreFromCursor(queryIteratorReq.getCursor());
+            return;
+        }
         setupTsByRequest();
         seek();
     }
@@ -187,6 +193,35 @@ public class QueryIterator {
 
     public void close() {
         iteratorCache.releaseCache(cacheIdInUse);
+    }
+
+    /**
+     * Capture the current iterator position as a resumable cursor. The cursor holds the
+     * session timestamp, the last primary key returned, and (for element-filter iterators)
+     * the last matched element offset, so pagination can continue in a new iterator.
+     */
+    public QueryIteratorCursor getCursor() {
+        QueryIteratorCursor.QueryIteratorCursorBuilder builder = QueryIteratorCursor.builder()
+                .sessionTs(sessionTs)
+                .lastElementOffset(nextElementOffset == null ? null
+                        : ((Number) nextElementOffset).longValue());
+        if (nextId == null) {
+            return builder.build();
+        }
+        if (primaryField.getDataType() == DataType.VarChar) {
+            builder.strPk(String.valueOf(nextId));
+        } else {
+            builder.intPk(((Number) nextId).longValue());
+        }
+        return builder.build();
+    }
+
+    private void restoreFromCursor(QueryIteratorCursor cursor) {
+        this.sessionTs = cursor.getSessionTs();
+        this.nextId = cursor.getStrPk() != null ? cursor.getStrPk() : cursor.getIntPk();
+        this.nextElementOffset = cursor.getLastElementOffset();
+        this.cacheIdInUse = NO_CACHE_ID;
+        this.offset = 0;
     }
 
     private void updateCursor(List<QueryResultsWrapper.RowRecord> res) {

--- a/sdk-core/src/main/java/io/milvus/orm/iterator/QueryIteratorCursor.java
+++ b/sdk-core/src/main/java/io/milvus/orm/iterator/QueryIteratorCursor.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.orm.iterator;
+
+import io.milvus.exception.ParamException;
+import io.milvus.grpc.QueryCursor;
+
+/**
+ * A serializable snapshot of a {@link QueryIterator} position, used to resume
+ * pagination from where a previous iterator left off (pymilvus parity:
+ * {@code QueryIterator.get_cursor()} / {@code QueryIteratorCursor}).
+ *
+ * <p>The cursor captures the session timestamp of the original iterator, the last
+ * primary key returned, and (for element-filter iterators) the last matched element
+ * offset. Resume by passing it back through {@code QueryIteratorReq.cursor(...)}.
+ */
+public class QueryIteratorCursor {
+    private final long sessionTs;
+    private final Long intPk;
+    private final String strPk;
+    private final Long lastElementOffset;
+
+    private QueryIteratorCursor(QueryIteratorCursorBuilder builder) {
+        this.sessionTs = builder.sessionTs;
+        this.intPk = builder.intPk;
+        this.strPk = builder.strPk;
+        this.lastElementOffset = builder.lastElementOffset;
+    }
+
+    public static QueryIteratorCursorBuilder builder() {
+        return new QueryIteratorCursorBuilder();
+    }
+
+    public long getSessionTs() {
+        return sessionTs;
+    }
+
+    public Long getIntPk() {
+        return intPk;
+    }
+
+    public String getStrPk() {
+        return strPk;
+    }
+
+    public Long getLastElementOffset() {
+        return lastElementOffset;
+    }
+
+    /**
+     * Serialize this cursor to the gRPC {@code QueryCursor} message.
+     *
+     * <p>The gRPC {@code QueryCursor} message has no field for the last element offset, so
+     * serializing an element-filter cursor would silently drop the element position and cause
+     * the resumed iterator to skip rows. Reject such cursors to avoid the data loss.
+     *
+     * @throws ParamException if this cursor carries an element offset
+     */
+    public QueryCursor toProto() {
+        if (lastElementOffset != null) {
+            throw new ParamException("Cannot serialize an element-filter cursor to QueryCursor: "
+                    + "the gRPC message has no element-offset field, resuming would skip rows. "
+                    + "Resume in memory via QueryIteratorReq.cursor(...) instead.");
+        }
+        QueryCursor.Builder builder = QueryCursor.newBuilder().setSessionTs(sessionTs);
+        if (strPk != null) {
+            builder.setStrPk(strPk);
+        } else if (intPk != null) {
+            builder.setIntPk(intPk);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Reconstruct a cursor from a gRPC {@code QueryCursor} message, or {@code null}
+     * when the input is null.
+     */
+    public static QueryIteratorCursor fromProto(QueryCursor cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        QueryIteratorCursorBuilder builder = QueryIteratorCursor.builder()
+                .sessionTs(cursor.getSessionTs());
+        switch (cursor.getCursorPkCase()) {
+            case STR_PK:
+                builder.strPk(cursor.getStrPk());
+                break;
+            case INT_PK:
+                builder.intPk(cursor.getIntPk());
+                break;
+            default:
+                break;
+        }
+        return builder.build();
+    }
+
+    @Override
+    public String toString() {
+        return "QueryIteratorCursor{" +
+                "sessionTs=" + sessionTs +
+                ", intPk=" + intPk +
+                ", strPk='" + strPk + '\'' +
+                ", lastElementOffset=" + lastElementOffset +
+                '}';
+    }
+
+    public static class QueryIteratorCursorBuilder {
+        private long sessionTs;
+        private Long intPk;
+        private String strPk;
+        private Long lastElementOffset;
+
+        public QueryIteratorCursorBuilder sessionTs(long sessionTs) {
+            this.sessionTs = sessionTs;
+            return this;
+        }
+
+        public QueryIteratorCursorBuilder intPk(Long intPk) {
+            this.intPk = intPk;
+            return this;
+        }
+
+        public QueryIteratorCursorBuilder strPk(String strPk) {
+            this.strPk = strPk;
+            return this;
+        }
+
+        public QueryIteratorCursorBuilder lastElementOffset(Long lastElementOffset) {
+            this.lastElementOffset = lastElementOffset;
+            return this;
+        }
+
+        public QueryIteratorCursor build() {
+            return new QueryIteratorCursor(this);
+        }
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/QueryIteratorReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/QueryIteratorReq.java
@@ -1,6 +1,7 @@
 package io.milvus.v2.service.vector.request;
 
 import com.google.common.collect.Lists;
+import io.milvus.orm.iterator.QueryIteratorCursor;
 import io.milvus.v2.common.ConsistencyLevel;
 
 import java.util.HashMap;
@@ -37,6 +38,11 @@ public class QueryIteratorReq {
     //     Boolean, Long, Double, String, List<Boolean>, List<Long>, List<Double>, List<String>
     private Map<String, Object> filterTemplateValues;
 
+    // A previously captured cursor to resume pagination from (pymilvus parity).
+    // When set, the iterator continues from the cursor's session ts and pk/element
+    // position instead of starting over; offset is ignored in that case.
+    private QueryIteratorCursor cursor;
+
     private QueryIteratorReq(QueryIteratorReqBuilder builder) {
         this.databaseName = builder.databaseName;
         this.collectionName = builder.collectionName;
@@ -52,6 +58,7 @@ public class QueryIteratorReq {
         this.batchSize = builder.batchSize;
         this.reduceStopForBest = builder.reduceStopForBest;
         this.filterTemplateValues = builder.filterTemplateValues;
+        this.cursor = builder.cursor;
     }
 
     public static QueryIteratorReqBuilder builder() {
@@ -172,6 +179,14 @@ public class QueryIteratorReq {
         return filterTemplateValues;
     }
 
+    public QueryIteratorCursor getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(QueryIteratorCursor cursor) {
+        this.cursor = cursor;
+    }
+
     @Override
     public String toString() {
         return "QueryIteratorReq{" +
@@ -188,6 +203,7 @@ public class QueryIteratorReq {
                 ", timezone='" + timezone + '\'' +
                 ", batchSize=" + batchSize +
                 ", reduceStopForBest=" + reduceStopForBest +
+                ", cursor=" + cursor +
                 '}';
     }
 
@@ -206,6 +222,7 @@ public class QueryIteratorReq {
         private long batchSize = 1000L;
         private boolean reduceStopForBest = true;
         private Map<String, Object> filterTemplateValues = new HashMap<>();
+        private QueryIteratorCursor cursor;
 
         public QueryIteratorReqBuilder databaseName(String databaseName) {
             this.databaseName = databaseName;
@@ -279,6 +296,11 @@ public class QueryIteratorReq {
 
         public QueryIteratorReqBuilder filterTemplateValues(Map<String, Object> filterTemplateValues) {
             this.filterTemplateValues = filterTemplateValues;
+            return this;
+        }
+
+        public QueryIteratorReqBuilder cursor(QueryIteratorCursor cursor) {
+            this.cursor = cursor;
             return this;
         }
 

--- a/sdk-core/src/test/java/io/milvus/docker-compose-multi.yml
+++ b/sdk-core/src/test/java/io/milvus/docker-compose-multi.yml
@@ -31,7 +31,7 @@ services:
 
   standalone:
     container_name: milvus-javasdk-standalone-1
-    image: milvusdb/milvus:master-20260723-32a44262
+    image: milvusdb/milvus:master-20260825-dd1ee671
     user: "0:0"
     command: ["milvus", "run", "standalone"]
     security_opt:
@@ -83,7 +83,7 @@ services:
 
   standaloneslave:
     container_name: milvus-javasdk-standalone-2
-    image: milvusdb/milvus:master-20260723-32a44262
+    image: milvusdb/milvus:master-20260825-dd1ee671
     user: "0:0"
     command: ["milvus", "run", "standalone"]
     security_opt:

--- a/sdk-core/src/test/java/io/milvus/docker-compose.yml
+++ b/sdk-core/src/test/java/io/milvus/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   standalone:
     container_name: milvus-javasdk-standalone
-    image: milvusdb/milvus:master-20260723-32a44262
+    image: milvusdb/milvus:master-20260825-dd1ee671
     user: "0:0"
     command: ["milvus", "run", "standalone"]
     security_opt:

--- a/sdk-core/src/test/java/io/milvus/orm/iterator/IteratorTest.java
+++ b/sdk-core/src/test/java/io/milvus/orm/iterator/IteratorTest.java
@@ -33,6 +33,7 @@ import io.milvus.grpc.SearchRequest;
 import io.milvus.grpc.SearchResultData;
 import io.milvus.grpc.SearchResults;
 import io.milvus.grpc.Status;
+import io.milvus.exception.ParamException;
 import io.milvus.param.Constant;
 import io.milvus.response.QueryResultsWrapper;
 import io.milvus.v2.common.IndexParam;
@@ -50,6 +51,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -217,6 +221,291 @@ class IteratorTest {
         assertEquals("1", queryParam(request, Constant.QUERY_ITER_LAST_ELEMENT_OFFSET));
     }
 
+    @Test
+    void queryIteratorGetCursorCapturesPosition() {
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                queryResults(Arrays.asList(1L, 2L, 3L), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+
+        QueryIteratorCursor cursor = iterator.getCursor();
+        assertEquals(100L, cursor.getSessionTs());
+        assertEquals(Long.valueOf(3L), cursor.getIntPk());
+        assertNull(cursor.getStrPk());
+        assertNull(cursor.getLastElementOffset());
+
+        QueryIteratorCursor restored = QueryIteratorCursor.fromProto(cursor.toProto());
+        assertEquals(100L, restored.getSessionTs());
+        assertEquals(Long.valueOf(3L), restored.getIntPk());
+        assertNull(restored.getStrPk());
+    }
+
+    @Test
+    void queryIteratorGetCursorVarcharPk() {
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                varcharQueryResults(Collections.emptyList(), 100L),
+                varcharQueryResults(Arrays.asList("a", "b", "c"), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("pk"))
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                varcharPrimaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+
+        QueryIteratorCursor cursor = iterator.getCursor();
+        assertEquals("c", cursor.getStrPk());
+        assertNull(cursor.getIntPk());
+    }
+
+    @Test
+    void queryIteratorResumesVarcharPkFromCursor() {
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                varcharQueryResults(Collections.emptyList(), 100L),
+                varcharQueryResults(Arrays.asList("a", "b"), 100L),
+                varcharQueryResults(Collections.singletonList("c"), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("pk"))
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                varcharPrimaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+        QueryIteratorCursor cursor = iterator.getCursor();
+        assertEquals("b", cursor.getStrPk());
+
+        QueryIterator resumed = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("pk"))
+                        .batchSize(10)
+                        .cursor(cursor)
+                        .build(),
+                testStubWrapper(stub),
+                varcharPrimaryField(),
+                TEST_COLLECTION_ID);
+        assertEquals(Collections.singletonList("c"), strPks(resumed.next()));
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(stub, times(3)).query(captor.capture());
+        QueryRequest resumedRequest = captor.getAllValues().get(2);
+        assertEquals("pk > \"b\"", resumedRequest.getExpr());
+        assertEquals(100L, resumedRequest.getGuaranteeTimestamp());
+    }
+
+    @Test
+    void queryIteratorGetCursorElementFilterCapturesOffset() {
+        String filter = "element_filter(structA, $[int_val] >= 20000)";
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                elementQueryResults(7L, 0L, 1L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .expr(filter)
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+
+        QueryIteratorCursor cursor = iterator.getCursor();
+        assertEquals(Long.valueOf(7L), cursor.getIntPk());
+        assertEquals(Long.valueOf(1L), cursor.getLastElementOffset());
+    }
+
+    @Test
+    void queryIteratorResumesFromCursor() {
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                queryResults(Arrays.asList(1L, 2L), 100L),
+                queryResults(Collections.singletonList(3L), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+        QueryIteratorCursor cursor = iterator.getCursor();
+
+        QueryIterator resumed = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .batchSize(10)
+                        .cursor(cursor)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        assertEquals(Collections.singletonList(3L), ids(resumed.next()));
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(stub, times(3)).query(captor.capture());
+        QueryRequest resumedRequest = captor.getAllValues().get(2);
+        assertEquals("id > 2", resumedRequest.getExpr());
+        assertEquals(100L, resumedRequest.getGuaranteeTimestamp());
+    }
+
+    @Test
+    void queryIteratorResumesElementFilterFromCursor() {
+        String filter = "element_filter(structA, $[int_val] >= 20000)";
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                elementQueryResults(7L, 0L, 1L),
+                queryResults(Collections.emptyList(), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .expr(filter)
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+        QueryIteratorCursor cursor = iterator.getCursor();
+
+        QueryIterator resumed = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .expr(filter)
+                        .batchSize(10)
+                        .cursor(cursor)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        resumed.next();
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(stub, times(3)).query(captor.capture());
+        QueryRequest resumedRequest = captor.getAllValues().get(2);
+        assertEquals("id >= 7 and (" + filter + ")", resumedRequest.getExpr());
+        assertEquals("7", queryParam(resumedRequest, Constant.QUERY_ITER_LAST_PK));
+        assertEquals("1", queryParam(resumedRequest, Constant.QUERY_ITER_LAST_ELEMENT_OFFSET));
+    }
+
+    @Test
+    void queryIteratorElementFilterCursorRejectsProtoSerialization() {
+        String filter = "element_filter(structA, $[int_val] >= 20000)";
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                elementQueryResults(7L, 0L, 1L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .expr(filter)
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+
+        QueryIteratorCursor cursor = iterator.getCursor();
+        assertNotNull(cursor.getLastElementOffset());
+        assertThrows(ParamException.class, cursor::toProto);
+    }
+
+    @Test
+    void queryIteratorResumeIgnoresRequestOffset() {
+        MilvusServiceGrpc.MilvusServiceBlockingStub stub =
+                mock(MilvusServiceGrpc.MilvusServiceBlockingStub.class);
+        when(stub.query(any(QueryRequest.class))).thenReturn(
+                queryResults(Collections.emptyList(), 100L),
+                queryResults(Arrays.asList(1L, 2L), 100L),
+                queryResults(Collections.singletonList(3L), 100L));
+
+        QueryIterator iterator = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .batchSize(10)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        iterator.next();
+        QueryIteratorCursor cursor = iterator.getCursor();
+
+        QueryIterator resumed = new QueryIterator(
+                QueryIteratorReq.builder()
+                        .collectionName("test")
+                        .outputFields(Collections.singletonList("id"))
+                        .batchSize(10)
+                        .offset(5)
+                        .cursor(cursor)
+                        .build(),
+                testStubWrapper(stub),
+                primaryField(),
+                TEST_COLLECTION_ID);
+        assertEquals(Collections.singletonList(3L), ids(resumed.next()));
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(stub, times(3)).query(captor.capture());
+        QueryRequest resumedRequest = captor.getAllValues().get(2);
+        assertNull(queryParam(resumedRequest, Constant.OFFSET));
+    }
+
+    @Test
+    void queryIteratorReqToStringIncludesCursor() {
+        QueryIteratorCursor cursor = QueryIteratorCursor.builder()
+                .sessionTs(100L)
+                .intPk(3L)
+                .build();
+        QueryIteratorReq req = QueryIteratorReq.builder()
+                .collectionName("test")
+                .cursor(cursor)
+                .build();
+        assertTrue(req.toString().contains("cursor=" + cursor));
+    }
+
     private static QueryResults queryResults(List<Long> ids, long sessionTs) {
         QueryResults.Builder builder = QueryResults.newBuilder()
                 .setStatus(successStatus())
@@ -228,6 +517,24 @@ class IteratorTest {
                             .setType(DataType.Int64)
                             .setScalars(ScalarField.newBuilder()
                                     .setLongData(LongArray.newBuilder().addAllData(ids).build())
+                                    .build())
+                            .build());
+        }
+        return builder.build();
+    }
+
+    private static QueryResults varcharQueryResults(List<String> pks, long sessionTs) {
+        QueryResults.Builder builder = QueryResults.newBuilder()
+                .setStatus(successStatus())
+                .setSessionTs(sessionTs);
+        if (!pks.isEmpty()) {
+            builder.addOutputFields("pk")
+                    .addFieldsData(FieldData.newBuilder()
+                            .setFieldName("pk")
+                            .setType(DataType.VarChar)
+                            .setScalars(ScalarField.newBuilder()
+                                    .setStringData(io.milvus.grpc.StringArray.newBuilder()
+                                            .addAllData(pks).build())
                                     .build())
                             .build());
         }
@@ -297,12 +604,28 @@ class IteratorTest {
                 .build();
     }
 
+    private static CreateCollectionReq.FieldSchema varcharPrimaryField() {
+        return CreateCollectionReq.FieldSchema.builder()
+                .name("pk")
+                .dataType(io.milvus.v2.common.DataType.VarChar)
+                .isPrimaryKey(true)
+                .build();
+    }
+
     private static List<Long> ids(List<QueryResultsWrapper.RowRecord> records) {
         List<Long> ids = new ArrayList<>();
         for (QueryResultsWrapper.RowRecord record : records) {
             ids.add((Long) record.get("id"));
         }
         return ids;
+    }
+
+    private static List<String> strPks(List<QueryResultsWrapper.RowRecord> records) {
+        List<String> pks = new ArrayList<>();
+        for (QueryResultsWrapper.RowRecord record : records) {
+            pks.add((String) record.get("pk"));
+        }
+        return pks;
     }
 
     private static List<Long> offsets(List<QueryResultsWrapper.RowRecord> records) {


### PR DESCRIPTION
Cherry-picks commit `81e7e877332fa77a0910dea879b521d1a624a5a1` (81e7e877) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

* Support query iterator cursor

Signed-off-by: yhmo <yihua.mo@zilliz.com>

* Address review comments on query iterator cursor

- resume the example with limit - firstPage.size() so the combined total
  stays at limit (the limit is per-iterator)
- add queryIteratorResumesVarcharPkFromCursor to cover the quoted
  varchar pk > "..." resume expression

Signed-off-by: yhmo <yihua.mo@zilliz.com>

---------

Signed-off-by: yhmo <yihua.mo@zilliz.com>
