### PR TITLE
Fix three PyMilvus parity gaps

### DIFF
--- a/examples/src/main/java/io/milvus/v2/AddFieldExample.java
+++ b/examples/src/main/java/io/milvus/v2/AddFieldExample.java
@@ -190,6 +190,9 @@ public class AddFieldExample {
                     .isNullable(true)
                     .build());
 
+            // Milvus 3.0 requires dataCoord.compaction.bumpSchemaVersion.enabled=true to add
+            // a function field to a collection that already contains segments.
+            //
             // Add a function-backed sparse field
             client.addFunctionField(AddFunctionFieldReq.builder()
                     .collectionName(COLLECTION_NAME)

--- a/examples/src/main/java/io/milvus/v2/FunctionChainExample.java
+++ b/examples/src/main/java/io/milvus/v2/FunctionChainExample.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v1.CommonUtils;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.utility.request.FlushReq;
+import io.milvus.v2.service.vector.request.FunctionChain;
+import io.milvus.v2.service.vector.request.FunctionChainArg;
+import io.milvus.v2.service.vector.request.FunctionChainExpr;
+import io.milvus.v2.service.vector.request.FunctionChainStage;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.response.InsertResp;
+import io.milvus.v2.service.vector.response.SearchResp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class FunctionChainExample {
+    private static final MilvusClientV2 client;
+
+    static {
+        client = new MilvusClientV2(ConnectConfig.builder()
+                .uri("http://localhost:19530")
+                .build());
+    }
+
+    private static final String COLLECTION_NAME = "java_sdk_example_function_chain_v2";
+    private static final String ID_FIELD = "id";
+    private static final String VECTOR_FIELD = "vector";
+    private static final Integer VECTOR_DIM = 128;
+
+    private static void buildCollection() {
+        // Drop collection if exists
+        client.dropCollection(DropCollectionReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .build());
+
+        // Create a collection with an int64 primary key and a float vector field
+        CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
+                .build();
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName(ID_FIELD)
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .autoID(false)
+                .build());
+        collectionSchema.addField(AddFieldReq.builder()
+                .fieldName(VECTOR_FIELD)
+                .dataType(DataType.FloatVector)
+                .dimension(VECTOR_DIM)
+                .build());
+
+        List<IndexParam> indexes = Collections.singletonList(IndexParam.builder()
+                .fieldName(VECTOR_FIELD)
+                .indexType(IndexParam.IndexType.FLAT)
+                .metricType(IndexParam.MetricType.COSINE)
+                .build());
+
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .collectionSchema(collectionSchema)
+                .indexParams(indexes)
+                .build());
+        System.out.printf("Collection '%s' created%n", COLLECTION_NAME);
+
+        // Load the collection before searching it
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .build());
+
+        // Insert rows for the function-chain search
+        long rowCount = 1000L;
+        List<JsonObject> rows = new ArrayList<>();
+        Gson gson = new Gson();
+        for (long i = 0L; i < rowCount; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty(ID_FIELD, i);
+            row.add(VECTOR_FIELD, gson.toJsonTree(CommonUtils.generateFloatVector(VECTOR_DIM)));
+            rows.add(row);
+        }
+
+        InsertResp insertResp = client.insert(InsertReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .data(rows)
+                .build());
+        System.out.printf("%d rows inserted%n", insertResp.getInsertCnt());
+
+        // Flush so the freshly inserted data is searchable
+        client.flush(FlushReq.builder()
+                .collectionNames(Collections.singletonList(COLLECTION_NAME))
+                .build());
+    }
+
+    private static void searchWithFunctionChain(int topK) {
+        // Round each search score to two decimal places, sort descending, and return topK rows.
+        FunctionChain functionChain = FunctionChain.builder()
+                .stage(FunctionChainStage.L2_RERANK)
+                .name("round_and_sort")
+                .map("$score", FunctionChainExpr.builder()
+                        .name("round_decimal")
+                        .arg(FunctionChainArg.col("$score"))
+                        .param("decimal", 2)
+                        .build())
+                .sort("$score", true, "")
+                .limit(topK)
+                .build();
+
+        SearchResp searchResp = client.search(SearchReq.builder()
+                .collectionName(COLLECTION_NAME)
+                .annsField(VECTOR_FIELD)
+                .data(Collections.singletonList(new FloatVec(
+                        CommonUtils.generateFloatVector(VECTOR_DIM, 1.0f))))
+                .outputFields(Collections.singletonList(ID_FIELD))
+                .limit(topK)
+                .addFunctionChain(functionChain)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+
+        System.out.println("\nFunction-chain search results:");
+        for (List<SearchResp.SearchResult> results : searchResp.getSearchResults()) {
+            for (SearchResp.SearchResult result : results) {
+                System.out.printf("ID: %s, Score: %f%n", result.getId(), result.getScore());
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        buildCollection();
+        searchWithFunctionChain(10);
+        client.close();
+    }
+}

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
@@ -588,6 +588,7 @@ public class CreateCollectionReq {
         private Long fieldId; // field id, only populated by describe_collection
         private Boolean isDynamic; // whether this field is the dynamic field
         private Boolean isFunctionOutput; // whether this field is a function output field
+        private List<Map<String, Object>> indexes = new ArrayList<>(); // only populated by describe_collection
 
         private FieldSchema(FieldSchemaBuilder builder) {
             this.name = builder.name;
@@ -776,6 +777,10 @@ public class CreateCollectionReq {
             return isFunctionOutput;
         }
 
+        public List<Map<String, Object>> getIndexes() {
+            return indexes;
+        }
+
         /**
          * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
          */
@@ -795,6 +800,13 @@ public class CreateCollectionReq {
          */
         public void setIsFunctionOutput(Boolean isFunctionOutput) {
             this.isFunctionOutput = isFunctionOutput;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setIndexes(List<Map<String, Object>> indexes) {
+            this.indexes = indexes;
         }
 
         @Override
@@ -819,6 +831,7 @@ public class CreateCollectionReq {
                     ", typeParams=" + typeParams +
                     ", multiAnalyzerParams=" + multiAnalyzerParams +
                     ", externalField='" + externalField + '\'' +
+                    ", indexes=" + indexes +
                     '}';
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/utility/OptimizeTask.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/utility/OptimizeTask.java
@@ -287,7 +287,7 @@ public class OptimizeTask {
      * @param targetSize size string like "512MB", "1GB", "1.5gb", or null
      * @return size in MB, or null if targetSize is null
      */
-    static Long parseTargetSize(String targetSize) {
+    public static Long parseTargetSize(String targetSize) {
         if (targetSize == null) {
             return null;
         }

--- a/sdk-core/src/main/java/io/milvus/v2/service/utility/UtilityService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/utility/UtilityService.java
@@ -208,8 +208,8 @@ public class UtilityService extends BaseService {
         if (StringUtils.isNotEmpty(dbName)) {
             builder.setDbName(dbName);
         }
-        if (request.getTargetSize() != null) {
-            builder.setTargetSize(request.getTargetSize());
+        if (request.getTargetSizeInMB() != null) {
+            builder.setTargetSize(request.getTargetSizeInMB());
         }
         ManualCompactionResponse response = blockingStub.manualCompaction(builder.build());
         rpcUtils.handleResponse(title, response.getStatus());

--- a/sdk-core/src/main/java/io/milvus/v2/service/utility/request/CompactReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/utility/request/CompactReq.java
@@ -19,12 +19,17 @@
 
 package io.milvus.v2.service.utility.request;
 
+import io.milvus.v2.exception.ErrorCode;
+import io.milvus.v2.exception.MilvusClientException;
+import io.milvus.v2.service.utility.OptimizeTask;
+
 public class CompactReq {
     private String databaseName;
     private String collectionName;
     private Boolean isClustering = Boolean.FALSE;
     private Boolean isL0 = Boolean.FALSE;
-    private Long targetSize; // in MB, null means server default
+    private Long targetSize; // value in targetSizeUnit, null means server default
+    private String targetSizeUnit = "mb";
 
     private CompactReq(CompactReqBuilder builder) {
         this.databaseName = builder.databaseName;
@@ -32,6 +37,7 @@ public class CompactReq {
         this.isClustering = builder.isClustering;
         this.isL0 = builder.isL0;
         this.targetSize = builder.targetSize;
+        this.targetSizeUnit = builder.targetSizeUnit;
     }
 
     public static CompactReqBuilder builder() {
@@ -78,6 +84,18 @@ public class CompactReq {
         this.targetSize = targetSize;
     }
 
+    public String getTargetSizeUnit() {
+        return targetSizeUnit;
+    }
+
+    public void setTargetSizeUnit(String targetSizeUnit) {
+        this.targetSizeUnit = targetSizeUnit;
+    }
+
+    public Long getTargetSizeInMB() {
+        return convertTargetSizeToMB(targetSize, targetSizeUnit);
+    }
+
     @Override
     public String toString() {
         return "CompactReq{" +
@@ -86,7 +104,28 @@ public class CompactReq {
                 ", isClustering=" + isClustering +
                 ", isL0=" + isL0 +
                 ", targetSize=" + targetSize +
+                ", targetSizeUnit='" + targetSizeUnit + '\'' +
                 '}';
+    }
+
+    private static Long convertTargetSizeToMB(Long targetSize, String targetSizeUnit) {
+        // null and 0 both mean "server default": the server reads an unset target_size as 0
+        // and skips force-merge, so mapping 0 to null preserves the wire behavior that existed
+        // before this change (0 was previously sent verbatim and treated as server default).
+        if (targetSize == null || targetSize == 0) {
+            return null;
+        }
+        if (targetSize < 0) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "targetSize must be a positive integer: " + targetSize);
+        }
+        if (targetSizeUnit == null) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "targetSizeUnit cannot be null when targetSize is set");
+        }
+        // Reuse the shared size-to-MB parser from OptimizeTask so the unit table and the
+        // 1MB floor live in a single place instead of two sibling parsers that can drift.
+        return OptimizeTask.parseTargetSize(targetSize + targetSizeUnit);
     }
 
     public static class CompactReqBuilder {
@@ -95,6 +134,7 @@ public class CompactReq {
         private Boolean isClustering = Boolean.FALSE;
         private Boolean isL0 = Boolean.FALSE;
         private Long targetSize;
+        private String targetSizeUnit = "mb";
 
         public CompactReqBuilder databaseName(String databaseName) {
             this.databaseName = databaseName;
@@ -118,6 +158,11 @@ public class CompactReq {
 
         public CompactReqBuilder targetSize(Long targetSize) {
             this.targetSize = targetSize;
+            return this;
+        }
+
+        public CompactReqBuilder targetSizeUnit(String targetSizeUnit) {
+            this.targetSizeUnit = targetSizeUnit;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -678,8 +678,21 @@ public class VectorService extends BaseService {
         // update the last write timestamp for SESSION consistency
         updateTsCache(dbName, collectionName, response.getTimestamp());
 
+        // Modern Milvus servers (>= 2.3.2) no longer return the deleted primary keys in the
+        // delete response, so primaryKeys will be empty against them. Only older servers
+        // echo the keys back, and a success response may omit the IDs field entirely.
+        List<Object> primaryKeys = new ArrayList<>();
+        if (response.hasIDs()) {
+            if (response.getIDs().hasIntId()) {
+                primaryKeys = new ArrayList<>(response.getIDs().getIntId().getDataList());
+            } else if (response.getIDs().hasStrId()) {
+                primaryKeys = new ArrayList<>(response.getIDs().getStrId().getDataList());
+            }
+        }
+
         return DeleteResp.builder()
                 .deleteCnt(response.getDeleteCnt())
+                .primaryKeys(primaryKeys)
                 .cost(getCost(response.getStatus()))
                 .build();
     }

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/DeleteResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/DeleteResp.java
@@ -19,12 +19,22 @@
 
 package io.milvus.v2.service.vector.response;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DeleteResp {
     private long deleteCnt;
+    /**
+     * Primary keys of the deleted entities. Note: Milvus servers >= 2.3.2 no longer echo the
+     * deleted primary keys in the delete response, so this list will be empty against a modern
+     * server. It is only populated when talking to an older server that returns the keys.
+     */
+    private List<Object> primaryKeys;
     private Long cost;
 
     private DeleteResp(DeleteRespBuilder builder) {
         this.deleteCnt = builder.deleteCnt;
+        this.primaryKeys = builder.primaryKeys;
         this.cost = builder.cost;
     }
 
@@ -40,6 +50,14 @@ public class DeleteResp {
         this.deleteCnt = deleteCnt;
     }
 
+    public List<Object> getPrimaryKeys() {
+        return primaryKeys;
+    }
+
+    public void setPrimaryKeys(List<Object> primaryKeys) {
+        this.primaryKeys = primaryKeys;
+    }
+
     public Long getCost() {
         return cost;
     }
@@ -52,16 +70,23 @@ public class DeleteResp {
     public String toString() {
         return "DeleteResp{" +
                 "deleteCnt=" + deleteCnt +
+                ", primaryKeys=" + primaryKeys +
                 ", cost=" + cost +
                 '}';
     }
 
     public static class DeleteRespBuilder {
         private long deleteCnt;
+        private List<Object> primaryKeys = new ArrayList<>();
         private Long cost;
 
         public DeleteRespBuilder deleteCnt(long deleteCnt) {
             this.deleteCnt = deleteCnt;
+            return this;
+        }
+
+        public DeleteRespBuilder primaryKeys(List<Object> primaryKeys) {
+            this.primaryKeys = primaryKeys;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
@@ -289,6 +289,30 @@ public class SchemaUtils {
             typeParams.put(keyValuePair.getKey(), keyValuePair.getValue());
         }
         schema.setTypeParams(typeParams);
+
+        Map<String, Object> indexParams = new HashMap<>();
+        for (KeyValuePair keyValuePair : fieldSchema.getIndexParamsList()) {
+            if (io.milvus.param.Constant.PARAMS.equals(keyValuePair.getKey())) {
+                try {
+                    indexParams.put(keyValuePair.getKey(), JsonUtils.fromJson(keyValuePair.getValue(),
+                            new TypeToken<Map<String, Object>>() {
+                            }.getType()));
+                } catch (Exception e) {
+                    /**
+                     * The kernel does not enforce validation on the input index `params`, so this conversion may throw an exception.
+                     * To prevent normal `descCollection` from malfunctioning, we wrap it here in a `try/catch` block.
+                     */
+                    logger.error("Failed to convert the index params value of {} , key:{}, value:{}", fieldSchema.getName(), keyValuePair.getKey(), keyValuePair.getValue());
+                }
+            } else {
+                indexParams.put(keyValuePair.getKey(), keyValuePair.getValue());
+            }
+        }
+        if (!indexParams.isEmpty()) {
+            schema.setIndexes(Collections.singletonList(indexParams));
+        } else {
+            schema.setIndexes(new ArrayList<>());
+        }
         return schema;
     }
 

--- a/sdk-core/src/test/java/io/milvus/v2/service/utility/CompactReqTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/utility/CompactReqTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.v2.service.utility;
+
+import io.milvus.v2.exception.MilvusClientException;
+import io.milvus.v2.service.utility.request.CompactReq;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CompactReqTest {
+    @Test
+    void targetSizeDefaultsToMegabytes() {
+        CompactReq request = CompactReq.builder()
+                .collectionName("test")
+                .targetSize(512L)
+                .build();
+
+        assertEquals(Long.valueOf(512L), request.getTargetSizeInMB());
+    }
+
+    @Test
+    void targetSizeSupportsBinarySizeUnits() {
+        assertEquals(Long.valueOf(1L), buildTargetSize(1048576L, "B").getTargetSizeInMB());
+        assertEquals(Long.valueOf(1L), buildTargetSize(1024L, "KB").getTargetSizeInMB());
+        assertEquals(Long.valueOf(1024L), buildTargetSize(1L, "GB").getTargetSizeInMB());
+        assertEquals(Long.valueOf(1024L * 1024L), buildTargetSize(1L, "TB").getTargetSizeInMB());
+        assertEquals(Long.valueOf(1024L * 1024L * 1024L), buildTargetSize(1L, "PB").getTargetSizeInMB());
+    }
+
+    @Test
+    void targetSizeAcceptsCaseAndWhitespace() {
+        assertEquals(Long.valueOf(2048L), buildTargetSize(2L, "gb").getTargetSizeInMB());
+        assertEquals(Long.valueOf(2048L), buildTargetSize(2L, " GB ").getTargetSizeInMB());
+    }
+
+    @Test
+    void nullTargetSizeUsesServerDefault() {
+        CompactReq request = CompactReq.builder()
+                .collectionName("test")
+                .build();
+
+        assertNull(request.getTargetSizeInMB());
+    }
+
+    @Test
+    void zeroTargetSizeUsesServerDefault() {
+        CompactReq request = CompactReq.builder()
+                .collectionName("test")
+                .targetSize(0L)
+                .build();
+
+        assertNull(request.getTargetSizeInMB());
+    }
+
+    @Test
+    void targetSizeRejectsInvalidValues() {
+        assertThrows(MilvusClientException.class, () -> buildTargetSize(-1L, "MB").getTargetSizeInMB());
+        assertThrows(MilvusClientException.class, () -> buildTargetSize(1023L, "KB").getTargetSizeInMB());
+        assertThrows(MilvusClientException.class, () -> buildTargetSize(1L, "XB").getTargetSizeInMB());
+        assertThrows(MilvusClientException.class, () -> CompactReq.builder()
+                .collectionName("test")
+                .targetSize(1L)
+                .targetSizeUnit(null)
+                .build()
+                .getTargetSizeInMB());
+    }
+
+    private CompactReq buildTargetSize(Long targetSize, String unit) {
+        return CompactReq.builder()
+                .collectionName("test")
+                .targetSize(targetSize)
+                .targetSizeUnit(unit)
+                .build();
+    }
+}

--- a/sdk-core/src/test/java/io/milvus/v2/service/utility/UtilityTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/utility/UtilityTest.java
@@ -21,6 +21,11 @@ package io.milvus.v2.service.utility;
 
 import com.google.gson.JsonObject;
 import io.milvus.common.utils.cache.CollectionTsCache;
+import io.milvus.grpc.DescribeCollectionRequest;
+import io.milvus.grpc.DescribeCollectionResponse;
+import io.milvus.grpc.ManualCompactionRequest;
+import io.milvus.grpc.ManualCompactionResponse;
+import io.milvus.grpc.Status;
 import io.milvus.v2.BaseTest;
 import io.milvus.v2.common.CompactionState;
 import io.milvus.v2.service.utility.request.*;
@@ -28,12 +33,16 @@ import io.milvus.v2.service.utility.response.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UtilityTest extends BaseTest {
     Logger logger = LoggerFactory.getLogger(UtilityTest.class);
@@ -130,6 +139,34 @@ class UtilityTest extends BaseTest {
                 .build();
         RefreshExternalCollectionResp resp = client_v2.refreshExternalCollection(req);
         assertEquals(12345L, resp.getJobId());
+    }
+
+    @Test
+    void testCompactConvertsTargetSizeUnitToMegabytes() {
+        Status success = Status.newBuilder().setCode(0).build();
+        when(blockingStub.describeCollection(any(DescribeCollectionRequest.class)))
+                .thenReturn(DescribeCollectionResponse.newBuilder()
+                        .setStatus(success)
+                        .setCollectionID(100L)
+                        .build());
+        when(blockingStub.manualCompaction(any(ManualCompactionRequest.class)))
+                .thenReturn(ManualCompactionResponse.newBuilder()
+                        .setStatus(success)
+                        .setCompactionID(200L)
+                        .build());
+
+        CompactReq request = CompactReq.builder()
+                .collectionName("test")
+                .targetSize(2L)
+                .targetSizeUnit("GB")
+                .build();
+        CompactResp response = client_v2.compact(request);
+
+        assertEquals(Long.valueOf(200L), response.getCompactionID());
+        ArgumentCaptor<ManualCompactionRequest> captor =
+                ArgumentCaptor.forClass(ManualCompactionRequest.class);
+        verify(blockingStub).manualCompaction(captor.capture());
+        assertEquals(2048L, captor.getValue().getTargetSize());
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -150,6 +150,11 @@ class VectorTest extends BaseTest {
     void testDeleteExposesCost() {
         MutationResult result = MutationResult.newBuilder()
                 .setDeleteCnt(2L)
+                .setIDs(IDs.newBuilder()
+                        .setIntId(LongArray.newBuilder()
+                                .addData(10L)
+                                .addData(20L)
+                                .build()))
                 .setStatus(Status.newBuilder().setCode(0)
                         .putExtraInfo("report_value", "456")
                         .build())
@@ -162,6 +167,7 @@ class VectorTest extends BaseTest {
                 .build());
 
         Assertions.assertEquals(2L, resp.getDeleteCnt());
+        Assertions.assertEquals(Arrays.asList(10L, 20L), resp.getPrimaryKeys());
         Assertions.assertEquals(456L, resp.getCost());
     }
 

--- a/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
@@ -301,6 +301,74 @@ public class SchemaUtilsTest {
     }
 
     @Test
+    void testConvertFromGrpcFieldSchemaPreservesIndexParams() {
+        FieldSchema rpcSchema = FieldSchema.newBuilder()
+                .setName("vector")
+                .setDataType(DataType.FloatVector)
+                .addIndexParams(KeyValuePair.newBuilder()
+                        .setKey("index_type")
+                        .setValue("HNSW")
+                        .build())
+                .addIndexParams(KeyValuePair.newBuilder()
+                        .setKey("metric_type")
+                        .setValue("L2")
+                        .build())
+                .addIndexParams(KeyValuePair.newBuilder()
+                        .setKey("params")
+                        .setValue("{\"M\":16,\"efConstruction\":200}")
+                        .build())
+                .build();
+
+        CreateCollectionReq.FieldSchema fieldSchema = SchemaUtils.convertFromGrpcFieldSchema(rpcSchema);
+
+        Assertions.assertNotNull(fieldSchema.getIndexes());
+        Assertions.assertEquals(1, fieldSchema.getIndexes().size());
+        Map<String, Object> index = fieldSchema.getIndexes().get(0);
+        Assertions.assertEquals("HNSW", index.get("index_type"));
+        Assertions.assertEquals("L2", index.get("metric_type"));
+        Map<?, ?> indexParams = (Map<?, ?>) index.get("params");
+        Assertions.assertEquals(16L, ((Number) indexParams.get("M")).longValue());
+        Assertions.assertEquals(200L, ((Number) indexParams.get("efConstruction")).longValue());
+    }
+
+    @Test
+    void testConvertFromGrpcFieldSchemaInitializesEmptyIndexes() {
+        FieldSchema rpcSchema = FieldSchema.newBuilder()
+                .setName("id")
+                .setDataType(DataType.Int64)
+                .build();
+
+        CreateCollectionReq.FieldSchema fieldSchema = SchemaUtils.convertFromGrpcFieldSchema(rpcSchema);
+
+        Assertions.assertNotNull(fieldSchema.getIndexes());
+        Assertions.assertTrue(fieldSchema.getIndexes().isEmpty());
+    }
+
+    @Test
+    void testConvertFromGrpcFieldSchemaSkipsMalformedIndexParams() {
+        FieldSchema rpcSchema = FieldSchema.newBuilder()
+                .setName("vector")
+                .setDataType(DataType.FloatVector)
+                .addIndexParams(KeyValuePair.newBuilder()
+                        .setKey("index_type")
+                        .setValue("HNSW")
+                        .build())
+                .addIndexParams(KeyValuePair.newBuilder()
+                        .setKey("params")
+                        .setValue("not-a-json-object")
+                        .build())
+                .build();
+
+        CreateCollectionReq.FieldSchema fieldSchema = SchemaUtils.convertFromGrpcFieldSchema(rpcSchema);
+
+        Assertions.assertNotNull(fieldSchema.getIndexes());
+        Assertions.assertEquals(1, fieldSchema.getIndexes().size());
+        Map<String, Object> index = fieldSchema.getIndexes().get(0);
+        Assertions.assertEquals("HNSW", index.get("index_type"));
+        Assertions.assertFalse(index.containsKey("params"));
+    }
+
+    @Test
     void testConvertFromGrpcFieldSchema() {
         CreateCollectionReq.CollectionSchema collectionSchema = buildSchema();
         List<CreateCollectionReq.FieldSchema> fieldSchemaList = collectionSchema.getFieldSchemaList();


### PR DESCRIPTION
  - Expose deleted primary keys in DeleteResp
  - Preserve field index params in DescribeCollectionResp
  - Support compact target size units
  - Add a V2 function chain example