### PR TITLE
[cherry-pick] Validate non-empty index params in createIndex (#2053)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
@@ -53,7 +53,11 @@ public class IndexService extends BaseService {
     public Void createIndex(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, CreateIndexReq request) {
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
-        for (IndexParam indexParam : request.getIndexParams()) {
+        List<IndexParam> indexParams = request.getIndexParams();
+        if (CollectionUtils.isEmpty(indexParams)) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Index params cannot be null or empty");
+        }
+        for (IndexParam indexParam : indexParams) {
             String fieldName = indexParam.getFieldName();
             String indexName = indexParam.getIndexName();
             String title = String.format("Create index for field: '%s' in collection: '%s' in database: '%s'",

--- a/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
@@ -21,6 +21,8 @@ package io.milvus.v2.service.index;
 
 import io.milvus.v2.BaseTest;
 import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.exception.ErrorCode;
+import io.milvus.v2.exception.MilvusClientException;
 import io.milvus.v2.service.index.request.CreateIndexReq;
 import io.milvus.v2.service.index.request.DescribeIndexReq;
 import io.milvus.v2.service.index.request.DropIndexReq;
@@ -33,8 +35,28 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class IndexTest extends BaseTest {
     Logger logger = LoggerFactory.getLogger(IndexTest.class);
+
+    @Test
+    void testCreateIndexValidatesIndexParams() {
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(CreateIndexReq.builder()
+                        .collectionName("test")
+                        .indexParams(new ArrayList<>())
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+
+        MilvusClientException nullException = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(CreateIndexReq.builder()
+                        .collectionName("test")
+                        .indexParams(null)
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, nullException.getErrorCode());
+    }
 
     @Test
     void testCreateIndex() {


### PR DESCRIPTION
Cherry-picks commit `e42b22c5550a450150a9a8a6baaf8bac8e1a84ba` (e42b22c5) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

Signed-off-by: yhmo <yihua.mo@zilliz.com>
