### PR TITLE
Align V2 API parity gaps with PyMilvus 2.6

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
+++ b/sdk-core/src/main/java/io/milvus/v2/common/IndexParam.java
@@ -19,6 +19,9 @@
 
 package io.milvus.v2.common;
 
+import io.milvus.v2.exception.ErrorCode;
+import io.milvus.v2.exception.MilvusClientException;
+
 import java.util.Map;
 
 public class IndexParam {
@@ -31,7 +34,7 @@ public class IndexParam {
     // Constructor for builder
     private IndexParam(IndexParamBuilder builder) {
         if (builder.fieldName == null) {
-            throw new NullPointerException("fieldName cannot be null");
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "fieldName cannot be null");
         }
         this.fieldName = builder.fieldName;
         this.indexName = builder.indexName;
@@ -68,7 +71,7 @@ public class IndexParam {
     // Setters
     public void setFieldName(String fieldName) {
         if (fieldName == null) {
-            throw new NullPointerException("fieldName cannot be null");
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "fieldName cannot be null");
         }
         this.fieldName = fieldName;
     }
@@ -110,7 +113,7 @@ public class IndexParam {
 
         public IndexParamBuilder fieldName(String fieldName) {
             if (fieldName == null) {
-                throw new NullPointerException("fieldName cannot be null");
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "fieldName cannot be null");
             }
             this.fieldName = fieldName;
             return this;

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -93,6 +93,14 @@ public class CollectionService extends BaseService {
                 .setShardsNum(request.getNumShards())
                 .setConsistencyLevelValue(request.getConsistencyLevel().getCode());
 
+        List<KeyValuePair> propertiesList = ParamUtils.AssembleKvPair(request.getProperties());
+        if (CollectionUtils.isNotEmpty(propertiesList)) {
+            propertiesList.forEach(builder::addProperties);
+        }
+        if (request.getNumPartitions() != null) {
+            builder.setNumPartitions(request.getNumPartitions());
+        }
+
         if (StringUtils.isNotEmpty(dbName)) {
             builder.setDbName(dbName);
         }

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
@@ -69,6 +69,25 @@ public class CreateCollectionReq {
             throw new IllegalArgumentException("Collection name cannot be null");
         }
 
+        // numeric bounds, keep consistent with PyMilvus
+        if (builder.dimension != null && builder.dimension <= 0) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "dimension must be a positive integer, got: " + builder.dimension);
+        }
+        if (builder.numPartitions != null && builder.numPartitions < 1) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "num_partitions must be greater than or equal to 1, got: " + builder.numPartitions);
+        }
+        if (builder.numShards != null && builder.numShards <= 0) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "num_shards must be a positive integer, got: " + builder.numShards);
+        }
+        if (builder.idType == DataType.VarChar && builder.maxLength != null
+                && (builder.maxLength < 1 || builder.maxLength > 65535)) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "max_length must be in the range [1, 65535], got: " + builder.maxLength);
+        }
+
         this.databaseName = builder.databaseName;
         this.collectionName = builder.collectionName;
         this.description = builder.description;
@@ -529,6 +548,7 @@ public class CreateCollectionReq {
     }
 
     public static class FieldSchema {
+        private Long fieldId; // field id, only populated by describe_collection
         private String name;
         private String description = "";
         private DataType dataType;
@@ -538,6 +558,8 @@ public class CreateCollectionReq {
         private Boolean isPartitionKey = Boolean.FALSE;
         private Boolean isClusteringKey = Boolean.FALSE;
         private Boolean autoID = Boolean.FALSE;
+        private Boolean isDynamic; // whether this field is the dynamic field, only populated by describe_collection
+        private Boolean isFunctionOutput; // whether this field is a function output field, only populated by describe_collection
         private DataType elementType;
         private Integer maxCapacity;
         private Boolean isNullable = Boolean.FALSE; // only for scalar fields(not include Array fields)
@@ -572,6 +594,17 @@ public class CreateCollectionReq {
         }
 
         // Getters and Setters
+        public Long getFieldId() {
+            return fieldId;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setFieldId(Long fieldId) {
+            this.fieldId = fieldId;
+        }
+
         public String getName() {
             return name;
         }
@@ -642,6 +675,28 @@ public class CreateCollectionReq {
 
         public void setAutoID(Boolean autoID) {
             this.autoID = autoID;
+        }
+
+        public Boolean getIsDynamic() {
+            return isDynamic;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setIsDynamic(Boolean isDynamic) {
+            this.isDynamic = isDynamic;
+        }
+
+        public Boolean getIsFunctionOutput() {
+            return isFunctionOutput;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setIsFunctionOutput(Boolean isFunctionOutput) {
+            this.isFunctionOutput = isFunctionOutput;
         }
 
         public DataType getElementType() {
@@ -718,26 +773,36 @@ public class CreateCollectionReq {
 
         @Override
         public String toString() {
-            return "FieldSchema{" +
-                    "name='" + name + '\'' +
-                    ", description='" + description + '\'' +
-                    ", dataType=" + dataType +
-                    ", maxLength=" + maxLength +
-                    ", dimension=" + dimension +
-                    ", isPrimaryKey=" + isPrimaryKey +
-                    ", isPartitionKey=" + isPartitionKey +
-                    ", isClusteringKey=" + isClusteringKey +
-                    ", autoID=" + autoID +
-                    ", elementType=" + elementType +
-                    ", maxCapacity=" + maxCapacity +
-                    ", isNullable=" + isNullable +
-                    ", defaultValue=" + defaultValue +
-                    ", enableAnalyzer=" + enableAnalyzer +
-                    ", analyzerParams=" + analyzerParams +
-                    ", enableMatch=" + enableMatch +
-                    ", typeParams=" + typeParams +
-                    ", multiAnalyzerParams=" + multiAnalyzerParams +
-                    '}';
+            StringBuilder sb = new StringBuilder("FieldSchema{");
+            sb.append("name='").append(name).append('\'')
+                    .append(", description='").append(description).append('\'')
+                    .append(", dataType=").append(dataType)
+                    .append(", maxLength=").append(maxLength)
+                    .append(", dimension=").append(dimension)
+                    .append(", isPrimaryKey=").append(isPrimaryKey)
+                    .append(", isPartitionKey=").append(isPartitionKey)
+                    .append(", isClusteringKey=").append(isClusteringKey)
+                    .append(", autoID=").append(autoID)
+                    .append(", elementType=").append(elementType)
+                    .append(", maxCapacity=").append(maxCapacity)
+                    .append(", isNullable=").append(isNullable)
+                    .append(", defaultValue=").append(defaultValue)
+                    .append(", enableAnalyzer=").append(enableAnalyzer)
+                    .append(", analyzerParams=").append(analyzerParams)
+                    .append(", enableMatch=").append(enableMatch)
+                    .append(", typeParams=").append(typeParams)
+                    .append(", multiAnalyzerParams=").append(multiAnalyzerParams);
+            // server-assigned/derived attributes, populated only by describe_collection
+            if (fieldId != null) {
+                sb.append(", fieldId=").append(fieldId);
+            }
+            if (isDynamic != null) {
+                sb.append(", isDynamic=").append(isDynamic);
+            }
+            if (isFunctionOutput != null) {
+                sb.append(", isFunctionOutput=").append(isFunctionOutput);
+            }
+            return sb.append('}').toString();
         }
 
         public static FieldSchemaBuilder builder() {
@@ -864,11 +929,14 @@ public class CreateCollectionReq {
     }
 
     public static class Function {
+        private Long id; // function id, only populated by describe_collection
         private String name = "";
         private String description = "";
         private FunctionType functionType = FunctionType.UNKNOWN;
         private List<String> inputFieldNames = new ArrayList<>();
+        private List<Long> inputFieldIds = new ArrayList<>();
         private List<String> outputFieldNames = new ArrayList<>();
+        private List<Long> outputFieldIds = new ArrayList<>();
         private Map<String, String> params = new HashMap<>();
 
         protected Function(FunctionBuilder<?> builder) {
@@ -878,6 +946,17 @@ public class CreateCollectionReq {
             this.inputFieldNames = builder.inputFieldNames;
             this.outputFieldNames = builder.outputFieldNames;
             this.params = builder.params;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setId(Long id) {
+            this.id = id;
         }
 
         public String getName() {
@@ -912,12 +991,34 @@ public class CreateCollectionReq {
             this.inputFieldNames = inputFieldNames;
         }
 
+        public List<Long> getInputFieldIds() {
+            return inputFieldIds;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setInputFieldIds(List<Long> inputFieldIds) {
+            this.inputFieldIds = inputFieldIds;
+        }
+
         public List<String> getOutputFieldNames() {
             return outputFieldNames;
         }
 
         public void setOutputFieldNames(List<String> outputFieldNames) {
             this.outputFieldNames = outputFieldNames;
+        }
+
+        public List<Long> getOutputFieldIds() {
+            return outputFieldIds;
+        }
+
+        /**
+         * Server-assigned attribute, populated only by describe_collection; not used during create_collection.
+         */
+        public void setOutputFieldIds(List<Long> outputFieldIds) {
+            this.outputFieldIds = outputFieldIds;
         }
 
         public Map<String, String> getParams() {
@@ -930,14 +1031,24 @@ public class CreateCollectionReq {
 
         @Override
         public String toString() {
-            return "Function{" +
-                    "name='" + name + '\'' +
-                    ", description='" + description + '\'' +
-                    ", functionType=" + functionType +
-                    ", inputFieldNames=" + inputFieldNames +
-                    ", outputFieldNames=" + outputFieldNames +
-                    ", params=" + params +
-                    '}';
+            StringBuilder sb = new StringBuilder("Function{");
+            sb.append("name='").append(name).append('\'')
+                    .append(", description='").append(description).append('\'')
+                    .append(", functionType=").append(functionType)
+                    .append(", inputFieldNames=").append(inputFieldNames)
+                    .append(", outputFieldNames=").append(outputFieldNames)
+                    .append(", params=").append(params);
+            // server-assigned/derived attributes, populated only by describe_collection
+            if (id != null) {
+                sb.append(", id=").append(id);
+            }
+            if (!inputFieldIds.isEmpty()) {
+                sb.append(", inputFieldIds=").append(inputFieldIds);
+            }
+            if (!outputFieldIds.isEmpty()) {
+                sb.append(", outputFieldIds=").append(outputFieldIds);
+            }
+            return sb.append('}').toString();
         }
 
         public static FunctionBuilder<?> builder() {

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/response/DescribeCollectionResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/response/DescribeCollectionResp.java
@@ -41,8 +41,11 @@ public class DescribeCollectionResp {
     private CreateCollectionReq.CollectionSchema collectionSchema;
     private Long createTime;
     private Long createUtcTime;
+    private Long updateTimestamp;
     private ConsistencyLevel consistencyLevel;
+    private String consistencyLevelName;
     private Integer shardsNum;
+    private List<String> aliases;
     private final Map<String, String> properties;
 
     private DescribeCollectionResp(DescribeCollectionRespBuilder builder) {
@@ -59,8 +62,11 @@ public class DescribeCollectionResp {
         this.collectionSchema = builder.collectionSchema;
         this.createTime = builder.createTime;
         this.createUtcTime = builder.createUtcTime;
+        this.updateTimestamp = builder.updateTimestamp;
         this.consistencyLevel = builder.consistencyLevel;
+        this.consistencyLevelName = builder.consistencyLevelName;
         this.shardsNum = builder.shardsNum;
+        this.aliases = builder.aliases != null ? builder.aliases : new ArrayList<>();
         this.properties = builder.properties != null ? builder.properties : new HashMap<>();
     }
 
@@ -121,12 +127,24 @@ public class DescribeCollectionResp {
         return createUtcTime;
     }
 
+    public Long getUpdateTimestamp() {
+        return updateTimestamp;
+    }
+
     public ConsistencyLevel getConsistencyLevel() {
         return consistencyLevel;
     }
 
+    public String getConsistencyLevelName() {
+        return consistencyLevelName;
+    }
+
     public Integer getShardsNum() {
         return shardsNum;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
     }
 
     public Map<String, String> getProperties() {
@@ -186,12 +204,24 @@ public class DescribeCollectionResp {
         this.createUtcTime = createUtcTime;
     }
 
+    public void setUpdateTimestamp(Long updateTimestamp) {
+        this.updateTimestamp = updateTimestamp;
+    }
+
     public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
         this.consistencyLevel = consistencyLevel;
     }
 
+    public void setConsistencyLevelName(String consistencyLevelName) {
+        this.consistencyLevelName = consistencyLevelName;
+    }
+
     public void setShardsNum(Integer shardsNum) {
         this.shardsNum = shardsNum;
+    }
+
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
     }
 
     @Override
@@ -210,8 +240,11 @@ public class DescribeCollectionResp {
                 ", collectionSchema=" + collectionSchema +
                 ", createTime=" + createTime +
                 ", createUtcTime=" + createUtcTime +
+                ", updateTimestamp=" + updateTimestamp +
                 ", consistencyLevel=" + consistencyLevel +
+                ", consistencyLevelName='" + consistencyLevelName + '\'' +
                 ", shardsNum=" + shardsNum +
+                ", aliases=" + aliases +
                 ", properties=" + properties +
                 '}';
     }
@@ -230,8 +263,11 @@ public class DescribeCollectionResp {
         private CreateCollectionReq.CollectionSchema collectionSchema;
         private Long createTime;
         private Long createUtcTime;
+        private Long updateTimestamp;
         private ConsistencyLevel consistencyLevel;
+        private String consistencyLevelName;
         private Integer shardsNum;
+        private List<String> aliases;
         private Map<String, String> properties;
 
         public DescribeCollectionRespBuilder collectionName(String collectionName) {
@@ -299,13 +335,28 @@ public class DescribeCollectionResp {
             return this;
         }
 
+        public DescribeCollectionRespBuilder updateTimestamp(Long updateTimestamp) {
+            this.updateTimestamp = updateTimestamp;
+            return this;
+        }
+
         public DescribeCollectionRespBuilder consistencyLevel(ConsistencyLevel consistencyLevel) {
             this.consistencyLevel = consistencyLevel;
             return this;
         }
 
+        public DescribeCollectionRespBuilder consistencyLevelName(String consistencyLevelName) {
+            this.consistencyLevelName = consistencyLevelName;
+            return this;
+        }
+
         public DescribeCollectionRespBuilder shardsNum(Integer shardsNum) {
             this.shardsNum = shardsNum;
+            return this;
+        }
+
+        public DescribeCollectionRespBuilder aliases(List<String> aliases) {
+            this.aliases = aliases;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/index/IndexService.java
@@ -40,10 +40,17 @@ import java.util.stream.Collectors;
 public class IndexService extends BaseService {
 
     public Void createIndex(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, CreateIndexReq request) {
+        if (CollectionUtils.isEmpty(request.getIndexParams())) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "IndexParams is empty, no index can be created");
+        }
+
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
         for (IndexParam indexParam : request.getIndexParams()) {
             String fieldName = indexParam.getFieldName();
+            if (StringUtils.isEmpty(fieldName)) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Field name cannot be null or empty");
+            }
             String indexName = indexParam.getIndexName();
             String title = String.format("Create index for field: '%s' in collection: '%s' in database: '%s'",
                     fieldName, collectionName, dbName);
@@ -71,9 +78,16 @@ public class IndexService extends BaseService {
             Map<String, Object> extraParams = indexParam.getExtraParams();
             if (extraParams != null && !extraParams.isEmpty()) {
                 for (String key : extraParams.keySet()) {
+                    Object value = extraParams.get(key);
+                    // the dimension must be an integer, keep consistent with PyMilvus create_index_request
+                    // which requires isinstance(dim, int); floats and numeric strings are rejected
+                    if (Constant.VECTOR_DIM.equals(key) && !isLegalDimensionValue(value)) {
+                        throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                                "Dimension must be an integer, got: " + value);
+                    }
                     builder.addExtraParams(KeyValuePair.newBuilder()
                             .setKey(key)
-                            .setValue(extraParams.get(key).toString())
+                            .setValue(String.valueOf(value))
                             .build());
                 }
             }
@@ -115,6 +129,10 @@ public class IndexService extends BaseService {
         String indexName = request.getIndexName();
         String title = String.format("Alter properties of index: '%s' in collection: '%s' in database: '%s'",
                 indexName, collectionName, dbName);
+
+        if (request.getProperties() == null) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "properties should not be null");
+        }
 
         AlterIndexRequest.Builder builder = AlterIndexRequest.newBuilder()
                 .setCollectionName(collectionName)
@@ -200,6 +218,16 @@ public class IndexService extends BaseService {
                 .filter(desc -> fieldName == null || desc.getFieldName().equals(fieldName))
                 .map(IndexDescription::getIndexName)
                 .collect(Collectors.toList());
+    }
+
+    // mirrors PyMilvus create_index_request's isinstance(dim, int) check: only integral types are accepted,
+    // floats (e.g. 128.0), decimals and numeric strings (e.g. "128") are rejected
+    private static boolean isLegalDimensionValue(Object value) {
+        return value instanceof Integer
+                || value instanceof Long
+                || value instanceof Short
+                || value instanceof Byte
+                || value instanceof java.math.BigInteger;
     }
 
     private void WaitForIndexComplete(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, String dbName,

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -173,6 +173,7 @@ public class VectorService extends BaseService {
         return InsertResp.builder()
                 .InsertCnt(response.getInsertCnt())
                 .primaryKeys(ids)
+                .cost(getCost(response.getStatus()))
                 .build();
     }
 
@@ -242,6 +243,7 @@ public class VectorService extends BaseService {
         return UpsertResp.builder()
                 .upsertCnt(response.getUpsertCnt())
                 .primaryKeys(ids)
+                .cost(getCost(response.getStatus()))
                 .build();
     }
 
@@ -477,6 +479,25 @@ public class VectorService extends BaseService {
         }
     }
 
+    // decode the report value from the status.extra_info, returns 0 when it is absent or invalid
+    // (consistent with PyMilvus get_cost_from_status, which defaults to "0")
+    private Long getCost(io.milvus.grpc.Status status) {
+        java.util.Map<String, String> extraInfo = status.getExtraInfoMap();
+        if (extraInfo == null) {
+            return 0L;
+        }
+        String reportValue = extraInfo.get("report_value");
+        if (reportValue == null || reportValue.trim().isEmpty()) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(reportValue.trim());
+        } catch (NumberFormatException e) {
+            logger.warn("Failed to parse the report_value from status.extra_info: {}", reportValue);
+            return 0L;
+        }
+    }
+
     public QueryIterator queryIterator(RpcStubWrapper blockingStub,
                                        QueryIteratorReq request) {
         DescribeCollectionResponse descResp = getCollectionInfo(blockingStub.get(), request.getDatabaseName(),
@@ -523,6 +544,7 @@ public class VectorService extends BaseService {
         updateTsCache(dbName, collectionName, response.getTimestamp());
         return DeleteResp.builder()
                 .deleteCnt(response.getDeleteCnt())
+                .cost(getCost(response.getStatus()))
                 .build();
     }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/DeleteReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/DeleteReq.java
@@ -19,6 +19,8 @@
 
 package io.milvus.v2.service.vector.request;
 
+import io.milvus.v2.common.ConsistencyLevel;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,7 @@ public class DeleteReq {
     private String partitionName;
     private String filter;
     private List<Object> ids;
+    private ConsistencyLevel consistencyLevel;
 
     // Expression template, to improve expression parsing performance in complicated list
     // Assume user has a filter = "pk > 3 and city in ["beijing", "shanghai", ......]
@@ -47,6 +50,7 @@ public class DeleteReq {
         this.filter = builder.filter;
         this.ids = builder.ids;
         this.filterTemplateValues = builder.filterTemplateValues;
+        this.consistencyLevel = builder.consistencyLevel;
     }
 
     public static DeleteReqBuilder builder() {
@@ -101,6 +105,14 @@ public class DeleteReq {
         this.filterTemplateValues = filterTemplateValues;
     }
 
+    public ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+    }
+
     @Override
     public String toString() {
         return "DeleteReq{" +
@@ -109,6 +121,7 @@ public class DeleteReq {
                 ", partitionName='" + partitionName + '\'' +
                 ", filter='" + filter + '\'' +
                 ", ids=" + ids +
+                ", consistencyLevel=" + consistencyLevel +
 //                ", filterTemplateValues=" + filterTemplateValues +
                 '}';
     }
@@ -120,6 +133,7 @@ public class DeleteReq {
         private String filter;
         private List<Object> ids;
         private Map<String, Object> filterTemplateValues = new HashMap<>();
+        private ConsistencyLevel consistencyLevel;
 
         public DeleteReqBuilder databaseName(String databaseName) {
             this.databaseName = databaseName;
@@ -148,6 +162,11 @@ public class DeleteReq {
 
         public DeleteReqBuilder filterTemplateValues(Map<String, Object> filterTemplateValues) {
             this.filterTemplateValues = filterTemplateValues;
+            return this;
+        }
+
+        public DeleteReqBuilder consistencyLevel(ConsistencyLevel consistencyLevel) {
+            this.consistencyLevel = consistencyLevel;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/DeleteResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/DeleteResp.java
@@ -21,9 +21,11 @@ package io.milvus.v2.service.vector.response;
 
 public class DeleteResp {
     private long deleteCnt;
+    private Long cost;
 
     private DeleteResp(DeleteRespBuilder builder) {
         this.deleteCnt = builder.deleteCnt;
+        this.cost = builder.cost;
     }
 
     public static DeleteRespBuilder builder() {
@@ -38,18 +40,33 @@ public class DeleteResp {
         this.deleteCnt = deleteCnt;
     }
 
+    public Long getCost() {
+        return cost;
+    }
+
+    public void setCost(Long cost) {
+        this.cost = cost;
+    }
+
     @Override
     public String toString() {
         return "DeleteResp{" +
                 "deleteCnt=" + deleteCnt +
+                ", cost=" + cost +
                 '}';
     }
 
     public static class DeleteRespBuilder {
         private long deleteCnt;
+        private Long cost;
 
         public DeleteRespBuilder deleteCnt(long deleteCnt) {
             this.deleteCnt = deleteCnt;
+            return this;
+        }
+
+        public DeleteRespBuilder cost(Long cost) {
+            this.cost = cost;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/InsertResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/InsertResp.java
@@ -26,10 +26,12 @@ public class InsertResp {
     // TODO: the first character should be lower case, add a new member and deprecate the old member
     private long InsertCnt;
     private List<Object> primaryKeys;
+    private Long cost;
 
     private InsertResp(InsertRespBuilder builder) {
         this.InsertCnt = builder.InsertCnt;
         this.primaryKeys = builder.primaryKeys;
+        this.cost = builder.cost;
     }
 
     public static InsertRespBuilder builder() {
@@ -52,17 +54,27 @@ public class InsertResp {
         this.primaryKeys = primaryKeys;
     }
 
+    public Long getCost() {
+        return cost;
+    }
+
+    public void setCost(Long cost) {
+        this.cost = cost;
+    }
+
     @Override
     public String toString() {
         return "InsertResp{" +
                 "InsertCnt=" + InsertCnt +
                 ", primaryKeys=" + primaryKeys +
+                ", cost=" + cost +
                 '}';
     }
 
     public static class InsertRespBuilder {
         private long InsertCnt;
         private List<Object> primaryKeys = new ArrayList<>();
+        private Long cost;
 
         public InsertRespBuilder InsertCnt(long insertCnt) {
             InsertCnt = insertCnt;
@@ -71,6 +83,11 @@ public class InsertResp {
 
         public InsertRespBuilder primaryKeys(List<Object> primaryKeys) {
             this.primaryKeys = primaryKeys;
+            return this;
+        }
+
+        public InsertRespBuilder cost(Long cost) {
+            this.cost = cost;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/UpsertResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/UpsertResp.java
@@ -29,10 +29,12 @@ public class UpsertResp {
     // the new pk is not equal to the original pk, the original entity is deleted, and a new entity
     // is created with this new pk. Here we return this new pk to user.
     private List<Object> primaryKeys;
+    private Long cost;
 
     private UpsertResp(UpsertRespBuilder builder) {
         this.upsertCnt = builder.upsertCnt;
         this.primaryKeys = builder.primaryKeys;
+        this.cost = builder.cost;
     }
 
     // Getters and Setters
@@ -52,11 +54,20 @@ public class UpsertResp {
         this.primaryKeys = primaryKeys;
     }
 
+    public Long getCost() {
+        return cost;
+    }
+
+    public void setCost(Long cost) {
+        this.cost = cost;
+    }
+
     @Override
     public String toString() {
         return "UpsertResp{" +
                 "upsertCnt=" + upsertCnt +
                 ", primaryKeys=" + primaryKeys +
+                ", cost=" + cost +
                 '}';
     }
 
@@ -67,6 +78,7 @@ public class UpsertResp {
     public static class UpsertRespBuilder {
         private long upsertCnt;
         private List<Object> primaryKeys = new ArrayList<>(); // default value
+        private Long cost;
 
         private UpsertRespBuilder() {
         }
@@ -78,6 +90,11 @@ public class UpsertResp {
 
         public UpsertRespBuilder primaryKeys(List<Object> primaryKeys) {
             this.primaryKeys = primaryKeys;
+            return this;
+        }
+
+        public UpsertRespBuilder cost(Long cost) {
+            this.cost = cost;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/utils/ConvertUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/ConvertUtils.java
@@ -241,8 +241,11 @@ public class ConvertUtils {
                 .primaryFieldName(response.getSchema().getFieldsList().stream().filter(FieldSchema::getIsPrimaryKey).map(FieldSchema::getName).collect(java.util.stream.Collectors.toList()).get(0))
                 .createTime(response.getCreatedTimestamp())
                 .createUtcTime(response.getCreatedUtcTimestamp())
+                .updateTimestamp(response.getUpdateTimestamp())
                 .consistencyLevel(io.milvus.v2.common.ConsistencyLevel.valueOf(response.getConsistencyLevel().name().toUpperCase()))
+                .consistencyLevelName(response.getConsistencyLevel().name())
                 .shardsNum(response.getShardsNum())
+                .aliases(response.getAliasesList())
                 .properties(properties)
                 .build();
         return describeCollectionResp;

--- a/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
@@ -629,6 +629,9 @@ public class DataUtils {
                 .setCollectionName(request.getCollectionName())
                 .setPartitionName(request.getPartitionName())
                 .setExpr(request.getFilter());
+        if (request.getConsistencyLevel() != null) {
+            builder.setConsistencyLevelValue(request.getConsistencyLevel().getCode());
+        }
         if (request.getFilter() != null && !request.getFilter().isEmpty()) {
             Map<String, Object> filterTemplateValues = request.getFilterTemplateValues();
             filterTemplateValues.forEach((key, value) -> {

--- a/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/SchemaUtils.java
@@ -233,6 +233,10 @@ public class SchemaUtils {
                 .isNullable(fieldSchema.getNullable())
                 .defaultValue(ParamUtils.valueFieldToObject(fieldSchema.getDefaultValue(), fieldSchema.getDataType()))
                 .build();
+        // server-assigned/derived attributes, populated only by describe_collection
+        schema.setFieldId(fieldSchema.getFieldID());
+        schema.setIsDynamic(fieldSchema.getIsDynamic());
+        schema.setIsFunctionOutput(fieldSchema.getIsFunctionOutput());
 
         Map<String, String> typeParams = new HashMap<>();
         for (KeyValuePair keyValuePair : fieldSchema.getTypeParamsList()) {
@@ -303,7 +307,12 @@ public class SchemaUtils {
                 .outputFieldNames(functionSchema.getOutputFieldNamesList().stream().collect(Collectors.toList()));
         List<KeyValuePair> pairs = functionSchema.getParamsList();
         pairs.forEach((kv) -> builder.param(kv.getKey(), kv.getValue()));
-        return builder.build();
+        CreateCollectionReq.Function function = builder.build();
+        // server-assigned/derived attributes, populated only by describe_collection
+        function.setId(functionSchema.getId());
+        function.setInputFieldIds(functionSchema.getInputFieldIdsList().stream().collect(Collectors.toList()));
+        function.setOutputFieldIds(functionSchema.getOutputFieldIdsList().stream().collect(Collectors.toList()));
+        return function;
     }
 
     public static CreateCollectionReq.FieldSchema convertFieldReqToFieldSchema(AddFieldReq addFieldReq) {

--- a/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/BaseTest.java
@@ -156,6 +156,7 @@ public class BaseTest {
                 .build();
         when(blockingStub.search(any())).thenReturn(searchResults);
         when(futureStub.search(any())).thenReturn(Futures.immediateFuture(searchResults));
+        when(blockingStub.hybridSearch(any())).thenReturn(searchResults);
         when(futureStub.hybridSearch(any())).thenReturn(Futures.immediateFuture(searchResults));
 
         // partition api

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -325,6 +325,11 @@ public class MilvusClientV2Test extends BaseTest {
                 // some method accepts Object as input such as AddFieldReq.defaultValue
                 Long obj = random.nextLong();
                 randomValues.put(field.getName(), obj);
+            } else if (fieldType == CreateCollectionReq.Function.class
+                    || fieldType == CreateCollectionReq.FieldSchema.class) {
+                // server-assigned read-only models with getter-only fields; constructed
+                // internally by describe_collection, so do not recurse into their builders
+                randomValues.put(field.getName(), null);
             } else {
                 // recursive construct member by builder
                 Object obj = checkGetAndSet(fieldType, config);
@@ -448,7 +453,11 @@ public class MilvusClientV2Test extends BaseTest {
 
             Object temp = method.invoke(callIntance);
             System.out.println("check getter value for method: " + field.getName());
-            if (temp instanceof Boolean || temp instanceof String || temp instanceof Number ||
+            if (temp == null) {
+                // embedded server-assigned members (Function/FieldSchema) are constructed as null;
+                // verify the round-trip is null rather than hitting temp.getClass() below
+                Assertions.assertNull(randomValues.get(field.getName()));
+            } else if (temp instanceof Boolean || temp instanceof String || temp instanceof Number ||
                     temp instanceof List || temp instanceof Map || temp instanceof Enum) {
                 Assertions.assertEquals(temp, randomValues.get(field.getName()));
             } else if (!temp.getClass().isInterface() && !temp.getClass().isArray()) {
@@ -564,7 +573,14 @@ public class MilvusClientV2Test extends BaseTest {
         VerifyClass(CreateCollectionReq.class.getName(), config);
         config.clearIgnoredMethods();
         VerifyClass(CreateCollectionReq.CollectionSchema.class.getName(), config);
+        // Function's server-assigned fields (id/inputFieldIds/outputFieldIds) have getters and
+        // setters but no builder methods, so ignore them in the builder-member check and the
+        // getter round-trip check. (Embedded Function members are handled by randomCallMethod's
+        // recursion skip, independent of this list.)
+        config.setIgnoredMethods(Arrays.asList("id", "inputFieldIds", "outputFieldIds",
+                "getId", "getInputFieldIds", "getOutputFieldIds"));
         VerifyClass(CreateCollectionReq.Function.class.getName(), config);
+        config.clearIgnoredMethods();
         VerifyClass(CreateCollectionReq.StructFieldSchema.class.getName(), config);
         VerifyClass(DescribeCollectionReq.class.getName(), config);
         VerifyClass(DropCollectionFieldPropertiesReq.class.getName(), config);

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
@@ -26,7 +26,9 @@ import io.milvus.v2.common.IndexParam;
 import io.milvus.v2.exception.MilvusClientException;
 import io.milvus.v2.service.collection.request.*;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import io.milvus.v2.service.collection.response.DescribeReplicasResp;
 import io.milvus.v2.service.collection.response.GetCollectionStatsResp;
+import io.milvus.v2.service.collection.response.GetLoadStateResp;
 import io.milvus.v2.service.collection.response.ListCollectionsResp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -36,12 +38,15 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CollectionTest extends BaseTest {
     Logger logger = LoggerFactory.getLogger(CollectionTest.class);
@@ -288,6 +293,424 @@ class CollectionTest extends BaseTest {
         GetCollectionStatsResp resp = client_v2.getCollectionStats(req);
         Assertions.assertEquals(10L, resp.getNumOfEntities());
         Assertions.assertEquals("10", resp.getStats().get("row_count"));
+    }
+
+    @Test
+    void testCreateCollectionFastPathSetsProperties() {
+        CreateCollectionReq request = CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(2)
+                .numPartitions(4)
+                .property("collection.ttl.seconds", "100")
+                .build();
+        client_v2.createCollection(request);
+
+        ArgumentCaptor<io.milvus.grpc.CreateCollectionRequest> captor =
+                ArgumentCaptor.forClass(io.milvus.grpc.CreateCollectionRequest.class);
+        verify(blockingStub).createCollection(captor.capture());
+        io.milvus.grpc.CreateCollectionRequest rpcRequest = captor.getValue();
+        Assertions.assertEquals(4, rpcRequest.getNumPartitions());
+        boolean found = rpcRequest.getPropertiesList().stream()
+                .anyMatch(kv -> kv.getKey().equals("collection.ttl.seconds") && kv.getValue().equals("100"));
+        Assertions.assertTrue(found);
+    }
+
+    @Test
+    void testCreateCollectionNumericBoundsValidated() {
+        assertThrows(MilvusClientException.class, () -> CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(0)
+                .build());
+        assertThrows(MilvusClientException.class, () -> CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(2)
+                .numPartitions(0)
+                .build());
+        assertThrows(MilvusClientException.class, () -> CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(2)
+                .numShards(0)
+                .build());
+        assertThrows(MilvusClientException.class, () -> CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(2)
+                .idType(DataType.VarChar)
+                .maxLength(0)
+                .build());
+        assertThrows(MilvusClientException.class, () -> CreateCollectionReq.builder()
+                .collectionName("test")
+                .dimension(2)
+                .idType(DataType.VarChar)
+                .maxLength(65536)
+                .build());
+    }
+
+    @Test
+    void testDescribeCollectionSurfacesAliasesAndSchemaMetadata() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        io.milvus.grpc.CollectionSchema schema = io.milvus.grpc.CollectionSchema.newBuilder()
+                .setName("test")
+                .setEnableDynamicField(true)
+                .setVersion(3)
+                .addFields(io.milvus.grpc.FieldSchema.newBuilder()
+                        .setFieldID(100L)
+                        .setName("id")
+                        .setDataType(io.milvus.grpc.DataType.Int64)
+                        .setIsPrimaryKey(true)
+                        .build())
+                .addFields(io.milvus.grpc.FieldSchema.newBuilder()
+                        .setFieldID(101L)
+                        .setName("text")
+                        .setDataType(io.milvus.grpc.DataType.VarChar)
+                        .build())
+                .addFunctions(io.milvus.grpc.FunctionSchema.newBuilder()
+                        .setId(200L)
+                        .setName("bm25")
+                        .setType(io.milvus.grpc.FunctionType.BM25)
+                        .addInputFieldNames("text")
+                        .addInputFieldIds(101L)
+                        .addOutputFieldNames("sparse")
+                        .addOutputFieldIds(102L)
+                        .build())
+                .build();
+        io.milvus.grpc.DescribeCollectionResponse describeResponse = io.milvus.grpc.DescribeCollectionResponse.newBuilder()
+                .setStatus(successStatus)
+                .setCollectionName("test")
+                .setCollectionID(1L)
+                .setSchema(schema)
+                .setNumPartitions(2)
+                .addAliases("alias1")
+                .setConsistencyLevel(io.milvus.grpc.ConsistencyLevel.Bounded)
+                .setUpdateTimestamp(123456L)
+                .build();
+        when(blockingStub.describeCollection(any())).thenReturn(describeResponse);
+
+        DescribeCollectionResp resp = client_v2.describeCollection(DescribeCollectionReq.builder()
+                .collectionName("test")
+                .build());
+        Assertions.assertEquals(Collections.singletonList("alias1"), resp.getAliases());
+        Assertions.assertEquals("Bounded", resp.getConsistencyLevelName());
+        Assertions.assertEquals(123456L, resp.getUpdateTimestamp());
+
+        CreateCollectionReq.FieldSchema idField = resp.getCollectionSchema().getField("id");
+        Assertions.assertEquals(100L, idField.getFieldId());
+
+        CreateCollectionReq.Function function = resp.getCollectionSchema().getFunctionList().get(0);
+        Assertions.assertEquals(200L, function.getId());
+        Assertions.assertEquals(Collections.singletonList(101L), function.getInputFieldIds());
+        Assertions.assertEquals(Collections.singletonList(102L), function.getOutputFieldIds());
+    }
+
+    @Test
+    void testFieldSchemaServerAssignedAttributesDefaultNull() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("id")
+                .dataType(DataType.Int64)
+                .build();
+        // server-assigned attributes are null until populated by describe_collection
+        Assertions.assertNull(fieldSchema.getFieldId());
+        Assertions.assertNull(fieldSchema.getIsDynamic());
+        Assertions.assertNull(fieldSchema.getIsFunctionOutput());
+    }
+
+    @Test
+    void testFieldSchemaServerAssignedAttributesSetters() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("id")
+                .dataType(DataType.Int64)
+                .build();
+        fieldSchema.setFieldId(100L);
+        fieldSchema.setIsDynamic(Boolean.TRUE);
+        fieldSchema.setIsFunctionOutput(Boolean.TRUE);
+        Assertions.assertEquals(100L, fieldSchema.getFieldId());
+        Assertions.assertEquals(Boolean.TRUE, fieldSchema.getIsDynamic());
+        Assertions.assertEquals(Boolean.TRUE, fieldSchema.getIsFunctionOutput());
+    }
+
+    @Test
+    void testFieldSchemaToStringOmitsServerAssignedAttributesWhenNull() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("id")
+                .dataType(DataType.Int64)
+                .build();
+        String str = fieldSchema.toString();
+        Assertions.assertFalse(str.contains("fieldId="));
+        Assertions.assertFalse(str.contains("isDynamic="));
+        Assertions.assertFalse(str.contains("isFunctionOutput="));
+    }
+
+    @Test
+    void testFieldSchemaToStringIncludesServerAssignedAttributesWhenSet() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("id")
+                .dataType(DataType.Int64)
+                .build();
+        fieldSchema.setFieldId(100L);
+        fieldSchema.setIsDynamic(Boolean.TRUE);
+        fieldSchema.setIsFunctionOutput(Boolean.TRUE);
+        String str = fieldSchema.toString();
+        Assertions.assertTrue(str.contains("fieldId=100"));
+        Assertions.assertTrue(str.contains("isDynamic=true"));
+        Assertions.assertTrue(str.contains("isFunctionOutput=true"));
+    }
+
+    @Test
+    void testFunctionServerAssignedAttributesDefaultEmpty() {
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .build();
+        Assertions.assertNull(function.getId());
+        Assertions.assertTrue(function.getInputFieldIds().isEmpty());
+        Assertions.assertTrue(function.getOutputFieldIds().isEmpty());
+    }
+
+    @Test
+    void testFunctionServerAssignedAttributesSetters() {
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .build();
+        function.setId(200L);
+        function.setInputFieldIds(Collections.singletonList(101L));
+        function.setOutputFieldIds(Collections.singletonList(102L));
+        Assertions.assertEquals(200L, function.getId());
+        Assertions.assertEquals(Collections.singletonList(101L), function.getInputFieldIds());
+        Assertions.assertEquals(Collections.singletonList(102L), function.getOutputFieldIds());
+    }
+
+    @Test
+    void testFunctionToStringOmitsServerAssignedAttributesWhenEmpty() {
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .build();
+        String str = function.toString();
+        Assertions.assertFalse(str.contains("id="));
+        Assertions.assertFalse(str.contains("inputFieldIds="));
+        Assertions.assertFalse(str.contains("outputFieldIds="));
+    }
+
+    @Test
+    void testFunctionToStringIncludesServerAssignedAttributesWhenSet() {
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .build();
+        function.setId(200L);
+        function.setInputFieldIds(Collections.singletonList(101L));
+        function.setOutputFieldIds(Collections.singletonList(102L));
+        String str = function.toString();
+        Assertions.assertTrue(str.contains("id=200"));
+        Assertions.assertTrue(str.contains("inputFieldIds=[101]"));
+        Assertions.assertTrue(str.contains("outputFieldIds=[102]"));
+    }
+
+    @Test
+    void testDescribeCollectionRespSettersRoundTrip() {
+        DescribeCollectionResp resp = DescribeCollectionResp.builder()
+                .collectionName("test")
+                .build();
+        resp.setAliases(Collections.singletonList("alias1"));
+        resp.setConsistencyLevelName("Bounded");
+        resp.setUpdateTimestamp(123456L);
+        resp.setEnableDynamicField(Boolean.TRUE);
+        resp.setAutoID(Boolean.FALSE);
+        resp.setNumOfPartitions(2L);
+        resp.setShardsNum(1);
+        Assertions.assertEquals(Collections.singletonList("alias1"), resp.getAliases());
+        Assertions.assertEquals("Bounded", resp.getConsistencyLevelName());
+        Assertions.assertEquals(123456L, resp.getUpdateTimestamp());
+        Assertions.assertEquals(Boolean.TRUE, resp.getEnableDynamicField());
+        Assertions.assertEquals(Boolean.FALSE, resp.getAutoID());
+        Assertions.assertEquals(2L, resp.getNumOfPartitions());
+        Assertions.assertEquals(1, resp.getShardsNum());
+    }
+
+    @Test
+    void testDescribeCollectionRespRemainingSettersRoundTrip() {
+        DescribeCollectionResp resp = DescribeCollectionResp.builder().build();
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        resp.setCollectionName("coll");
+        resp.setCollectionID(1L);
+        resp.setDatabaseName("db");
+        resp.setDescription("desc");
+        resp.setFieldNames(Arrays.asList("id", "vector"));
+        resp.setVectorFieldNames(Collections.singletonList("vector"));
+        resp.setPrimaryFieldName("id");
+        resp.setCollectionSchema(schema);
+        resp.setConsistencyLevel(io.milvus.v2.common.ConsistencyLevel.BOUNDED);
+        resp.setCreateTime(10L);
+        resp.setCreateUtcTime(20L);
+        Assertions.assertEquals("coll", resp.getCollectionName());
+        Assertions.assertEquals(1L, resp.getCollectionID());
+        Assertions.assertEquals("db", resp.getDatabaseName());
+        Assertions.assertEquals("desc", resp.getDescription());
+        Assertions.assertEquals(Arrays.asList("id", "vector"), resp.getFieldNames());
+        Assertions.assertEquals(Collections.singletonList("vector"), resp.getVectorFieldNames());
+        Assertions.assertEquals("id", resp.getPrimaryFieldName());
+        Assertions.assertEquals(schema, resp.getCollectionSchema());
+        Assertions.assertEquals(io.milvus.v2.common.ConsistencyLevel.BOUNDED, resp.getConsistencyLevel());
+        Assertions.assertEquals(10L, resp.getCreateTime());
+        Assertions.assertEquals(20L, resp.getCreateUtcTime());
+    }
+
+    @Test
+    void testFunctionRegularSettersRoundTrip() {
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder().build();
+        function.setName("fn");
+        function.setDescription("desc");
+        function.setFunctionType(io.milvus.common.clientenum.FunctionType.BM25);
+        function.setInputFieldNames(Collections.singletonList("text"));
+        function.setOutputFieldNames(Collections.singletonList("sparse"));
+        Map<String, String> params = new HashMap<>();
+        params.put("k", "60");
+        function.setParams(params);
+        Assertions.assertEquals("fn", function.getName());
+        Assertions.assertEquals("desc", function.getDescription());
+        Assertions.assertEquals(io.milvus.common.clientenum.FunctionType.BM25, function.getFunctionType());
+        Assertions.assertEquals(Collections.singletonList("text"), function.getInputFieldNames());
+        Assertions.assertEquals(Collections.singletonList("sparse"), function.getOutputFieldNames());
+        Assertions.assertEquals("60", function.getParams().get("k"));
+    }
+
+    @Test
+    void testFieldSchemaRegularSettersRoundTrip() {
+        CreateCollectionReq.FieldSchema fieldSchema = CreateCollectionReq.FieldSchema.builder()
+                .name("id")
+                .dataType(DataType.Int64)
+                .build();
+        fieldSchema.setName("new_id");
+        fieldSchema.setDescription("desc");
+        fieldSchema.setIsPrimaryKey(Boolean.TRUE);
+        fieldSchema.setIsClusteringKey(Boolean.TRUE);
+        fieldSchema.setAutoID(Boolean.FALSE);
+        fieldSchema.setDefaultValue(5L);
+        Assertions.assertEquals("new_id", fieldSchema.getName());
+        Assertions.assertEquals("desc", fieldSchema.getDescription());
+        Assertions.assertEquals(Boolean.TRUE, fieldSchema.getIsPrimaryKey());
+        Assertions.assertEquals(Boolean.TRUE, fieldSchema.getIsClusteringKey());
+        Assertions.assertEquals(Boolean.FALSE, fieldSchema.getAutoID());
+        Assertions.assertEquals(5L, fieldSchema.getDefaultValue());
+    }
+
+    @Test
+    void testCreateSchemaStaticHelper() {
+        CreateCollectionReq.CollectionSchema schema = client_v2.createSchema();
+        Assertions.assertNotNull(schema);
+        Assertions.assertTrue(schema.getFieldSchemaList().isEmpty());
+        Assertions.assertFalse(schema.isEnableDynamicField());
+    }
+
+    @Test
+    void testAddCollectionField() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.addCollectionField(any())).thenReturn(successStatus);
+        AddCollectionFieldReq request = AddCollectionFieldReq.builder()
+                .collectionName("test")
+                .fieldName("extra")
+                .dataType(DataType.VarChar)
+                .maxLength(128)
+                .build();
+        client_v2.addCollectionField(request);
+        verify(blockingStub).addCollectionField(any());
+    }
+
+    @Test
+    void testAddCollectionFunction() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.addCollectionFunction(any())).thenReturn(successStatus);
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25_fn")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .inputFieldNames(Collections.singletonList("text"))
+                .outputFieldNames(Collections.singletonList("sparse"))
+                .build();
+        AddCollectionFunctionReq request = AddCollectionFunctionReq.builder()
+                .collectionName("test")
+                .function(function)
+                .build();
+        client_v2.addCollectionFunction(request);
+        verify(blockingStub).addCollectionFunction(any());
+    }
+
+    @Test
+    void testAlterCollectionFunction() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.alterCollectionFunction(any())).thenReturn(successStatus);
+        CreateCollectionReq.Function function = CreateCollectionReq.Function.builder()
+                .name("bm25_fn")
+                .functionType(io.milvus.common.clientenum.FunctionType.BM25)
+                .inputFieldNames(Collections.singletonList("text"))
+                .outputFieldNames(Collections.singletonList("sparse"))
+                .build();
+        AlterCollectionFunctionReq request = AlterCollectionFunctionReq.builder()
+                .collectionName("test")
+                .function(function)
+                .build();
+        client_v2.alterCollectionFunction(request);
+        verify(blockingStub).alterCollectionFunction(any());
+    }
+
+    @Test
+    void testDropCollectionFunction() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.dropCollectionFunction(any())).thenReturn(successStatus);
+        DropCollectionFunctionReq request = DropCollectionFunctionReq.builder()
+                .collectionName("test")
+                .functionName("bm25_fn")
+                .build();
+        client_v2.dropCollectionFunction(request);
+        verify(blockingStub).dropCollectionFunction(any());
+    }
+
+    @Test
+    void testDropCollectionFieldProperties() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.alterCollectionField(any())).thenReturn(successStatus);
+        DropCollectionFieldPropertiesReq request = DropCollectionFieldPropertiesReq.builder()
+                .collectionName("test")
+                .fieldName("extra")
+                .propertyKeys(Collections.singletonList("key"))
+                .build();
+        client_v2.dropCollectionFieldProperties(request);
+        verify(blockingStub).alterCollectionField(any());
+    }
+
+    @Test
+    void testRefreshLoad() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.loadCollection(any())).thenReturn(successStatus);
+        RefreshLoadReq request = RefreshLoadReq.builder()
+                .collectionName("test")
+                .sync(false)
+                .build();
+        client_v2.refreshLoad(request);
+        verify(blockingStub).loadCollection(any());
+    }
+
+    @Test
+    void testGetLoadStateV2() {
+        GetLoadStateReq request = GetLoadStateReq.builder()
+                .collectionName("test")
+                .build();
+        GetLoadStateResp resp = client_v2.getLoadStateV2(request);
+        Assertions.assertNotNull(resp);
+        Assertions.assertEquals(io.milvus.grpc.LoadState.LoadStateLoaded, resp.getState());
+    }
+
+    @Test
+    void testDescribeReplicas() {
+        io.milvus.grpc.Status successStatus = io.milvus.grpc.Status.newBuilder().setCode(0).build();
+        when(blockingStub.getReplicas(any())).thenReturn(io.milvus.grpc.GetReplicasResponse.newBuilder()
+                .setStatus(successStatus)
+                .build());
+        DescribeReplicasReq request = DescribeReplicasReq.builder()
+                .collectionName("test")
+                .build();
+        DescribeReplicasResp resp = client_v2.describeReplicas(request);
+        Assertions.assertNotNull(resp);
+        Assertions.assertTrue(resp.getReplicas().isEmpty());
     }
 
 }

--- a/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/index/IndexTest.java
@@ -19,19 +19,31 @@
 
 package io.milvus.v2.service.index;
 
+import io.milvus.grpc.CreateIndexRequest;
 import io.milvus.v2.BaseTest;
 import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.exception.MilvusClientException;
+import io.milvus.v2.service.index.request.AlterIndexPropertiesReq;
 import io.milvus.v2.service.index.request.CreateIndexReq;
 import io.milvus.v2.service.index.request.DescribeIndexReq;
 import io.milvus.v2.service.index.request.DropIndexReq;
 import io.milvus.v2.service.index.request.ListIndexesReq;
 import io.milvus.v2.service.index.response.DescribeIndexResp;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class IndexTest extends BaseTest {
     Logger logger = LoggerFactory.getLogger(IndexTest.class);
@@ -57,6 +69,135 @@ class IndexTest extends BaseTest {
                 .indexParams(indexParams)
                 .build();
         client_v2.createIndex(createIndexReq);
+    }
+
+    @Test
+    void testCreateIndexEmptyIndexParamsRejected() {
+        CreateIndexReq createIndexReq = CreateIndexReq.builder()
+                .collectionName("test")
+                .indexParams(Collections.emptyList())
+                .build();
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(createIndexReq));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        verify(blockingStub, never()).createIndex(any(CreateIndexRequest.class));
+    }
+
+    @Test
+    void testCreateIndexNullFieldNameRejected() {
+        // the null fieldName must be rejected with a checked error instead of a NullPointerException
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> IndexParam.builder().fieldName(null).build());
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+    }
+
+    @Test
+    void testCreateIndexDimMustBeInt() {
+        Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("dim", "abc");
+        IndexParam indexParam = IndexParam.builder()
+                .metricType(IndexParam.MetricType.COSINE)
+                .fieldName("vector")
+                .extraParams(extraParams)
+                .build();
+        CreateIndexReq createIndexReq = CreateIndexReq.builder()
+                .collectionName("test")
+                .indexParams(Collections.singletonList(indexParam))
+                .build();
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(createIndexReq));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        verify(blockingStub, never()).createIndex(any(CreateIndexRequest.class));
+    }
+
+    @Test
+    void testCreateIndexDimRejectsNumericStringAndDouble() {
+        // PyMilvus create_index_request requires isinstance(dim, int); numeric strings and floats are rejected
+        Map<String, Object> stringParams = new HashMap<>();
+        stringParams.put("dim", "128");
+        IndexParam stringDim = IndexParam.builder()
+                .metricType(IndexParam.MetricType.COSINE)
+                .fieldName("vector")
+                .extraParams(stringParams)
+                .build();
+        MilvusClientException stringException = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(CreateIndexReq.builder()
+                        .collectionName("test")
+                        .indexParams(Collections.singletonList(stringDim))
+                        .build()));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, stringException.getErrorCode());
+
+        Map<String, Object> doubleParams = new HashMap<>();
+        doubleParams.put("dim", 128.0);
+        IndexParam doubleDim = IndexParam.builder()
+                .metricType(IndexParam.MetricType.COSINE)
+                .fieldName("vector")
+                .extraParams(doubleParams)
+                .build();
+        MilvusClientException doubleException = assertThrows(MilvusClientException.class,
+                () -> client_v2.createIndex(CreateIndexReq.builder()
+                        .collectionName("test")
+                        .indexParams(Collections.singletonList(doubleDim))
+                        .build()));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, doubleException.getErrorCode());
+
+        verify(blockingStub, never()).createIndex(any(CreateIndexRequest.class));
+
+        // integral types are still accepted
+        Map<String, Object> intParams = new HashMap<>();
+        intParams.put("dim", 128);
+        IndexParam intDim = IndexParam.builder()
+                .metricType(IndexParam.MetricType.COSINE)
+                .fieldName("vector")
+                .extraParams(intParams)
+                .build();
+        client_v2.createIndex(CreateIndexReq.builder()
+                .collectionName("test")
+                .indexParams(Collections.singletonList(intDim))
+                .build());
+        verify(blockingStub).createIndex(any(CreateIndexRequest.class));
+    }
+
+    @Test
+    void testAlterIndexPropertiesNullPropertiesRejected() {
+        AlterIndexPropertiesReq request = AlterIndexPropertiesReq.builder()
+                .collectionName("test")
+                .indexName("vector_idx")
+                .properties(null)
+                .build();
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.alterIndexProperties(request));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        verify(blockingStub, never()).alterIndex(any());
+    }
+
+    @Test
+    void testIndexParamSettersRoundTrip() {
+        IndexParam indexParam = IndexParam.builder()
+                .fieldName("vector")
+                .build();
+        indexParam.setFieldName("vector2");
+        indexParam.setIndexName("idx");
+        indexParam.setIndexType(IndexParam.IndexType.HNSW);
+        indexParam.setMetricType(IndexParam.MetricType.IP);
+        Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("M", 16);
+        indexParam.setExtraParams(extraParams);
+        Assertions.assertEquals("vector2", indexParam.getFieldName());
+        Assertions.assertEquals("idx", indexParam.getIndexName());
+        Assertions.assertEquals(IndexParam.IndexType.HNSW, indexParam.getIndexType());
+        Assertions.assertEquals(IndexParam.MetricType.IP, indexParam.getMetricType());
+        Assertions.assertEquals(16, indexParam.getExtraParams().get("M"));
+    }
+
+    @Test
+    void testIndexParamNullFieldNameRejected() {
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> IndexParam.builder().fieldName(null).build());
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        exception = assertThrows(MilvusClientException.class,
+                () -> IndexParam.builder().fieldName("vector").build().setFieldName(null));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -30,6 +30,7 @@ import io.milvus.param.Constant;
 import io.milvus.v2.BaseTest;
 import io.milvus.v2.client.ConnectConfig;
 import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
 import io.milvus.v2.exception.ErrorCode;
 import io.milvus.v2.exception.MilvusClientException;
 import io.milvus.v2.service.vector.request.*;
@@ -548,6 +549,210 @@ class VectorTest extends BaseTest {
         Assertions.assertEquals(123L, response.getCost());
         verify(futureStub).hybridSearch(any(HybridSearchRequest.class));
         verify(blockingStub, never()).hybridSearch(any(HybridSearchRequest.class));
+    }
+
+    @Test
+    void testInsertCostDecodedFromStatusExtraInfo() {
+        Status status = Status.newBuilder()
+                .setCode(0)
+                .putExtraInfo("report_value", "456")
+                .build();
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(status)
+                .setInsertCnt(1L)
+                .build();
+        when(blockingStub.insert(any())).thenReturn(mutationResult);
+
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 0L);
+        row.add("vector", JsonUtils.toJsonTree(Arrays.asList(1.0f, 2.0f)));
+        InsertReq request = InsertReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(row))
+                .build();
+        InsertResp resp = client_v2.insert(request);
+        Assertions.assertEquals(456L, resp.getCost());
+    }
+
+    @Test
+    void testUpsertCostDecodedFromStatusExtraInfo() {
+        Status status = Status.newBuilder()
+                .setCode(0)
+                .putExtraInfo("report_value", "789")
+                .build();
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(status)
+                .setUpsertCnt(1L)
+                .build();
+        when(blockingStub.upsert(any())).thenReturn(mutationResult);
+
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 0L);
+        row.add("vector", JsonUtils.toJsonTree(Arrays.asList(1.0f, 2.0f)));
+        UpsertReq request = UpsertReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(row))
+                .build();
+        UpsertResp resp = client_v2.upsert(request);
+        Assertions.assertEquals(789L, resp.getCost());
+    }
+
+    @Test
+    void testDeleteCostDecodedFromStatusExtraInfo() {
+        Status status = Status.newBuilder()
+                .setCode(0)
+                .putExtraInfo("report_value", "321")
+                .build();
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(status)
+                .setDeleteCnt(1L)
+                .build();
+        when(blockingStub.delete(any())).thenReturn(mutationResult);
+
+        DeleteReq request = DeleteReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .build();
+        DeleteResp resp = client_v2.delete(request);
+        Assertions.assertEquals(321L, resp.getCost());
+    }
+
+    @Test
+    void testInsertCostDefaultsToZeroForInvalidReportValue() {
+        Status status = Status.newBuilder()
+                .setCode(0)
+                .putExtraInfo("report_value", "not-a-number")
+                .build();
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(status)
+                .setInsertCnt(1L)
+                .build();
+        when(blockingStub.insert(any())).thenReturn(mutationResult);
+
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 0L);
+        row.add("vector", JsonUtils.toJsonTree(Arrays.asList(1.0f, 2.0f)));
+        InsertReq request = InsertReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(row))
+                .build();
+        InsertResp resp = client_v2.insert(request);
+        Assertions.assertEquals(0L, resp.getCost());
+    }
+
+    @Test
+    void testInsertCostDefaultsToZeroWhenReportValueAbsent() {
+        // the status carries no extra_info at all: cost must default to 0
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0).build())
+                .setInsertCnt(1L)
+                .build();
+        when(blockingStub.insert(any())).thenReturn(mutationResult);
+
+        JsonObject row = new JsonObject();
+        row.addProperty("id", 0L);
+        row.add("vector", JsonUtils.toJsonTree(Arrays.asList(1.0f, 2.0f)));
+        InsertReq request = InsertReq.builder()
+                .collectionName("test")
+                .data(Collections.singletonList(row))
+                .build();
+        InsertResp resp = client_v2.insert(request);
+        Assertions.assertEquals(0L, resp.getCost());
+    }
+
+    @Test
+    void testDeleteCostDefaultsToZeroWhenReportValueAbsent() {
+        MutationResult mutationResult = MutationResult.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0).build())
+                .setDeleteCnt(1L)
+                .build();
+        when(blockingStub.delete(any())).thenReturn(mutationResult);
+
+        DeleteReq request = DeleteReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .build();
+        DeleteResp resp = client_v2.delete(request);
+        Assertions.assertEquals(0L, resp.getCost());
+    }
+
+    @Test
+    void testDeleteReqConsistencyLevelRoundTrip() {
+        DeleteReq request = DeleteReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .consistencyLevel(ConsistencyLevel.SESSION)
+                .build();
+        Assertions.assertEquals(ConsistencyLevel.SESSION, request.getConsistencyLevel());
+        request.setConsistencyLevel(ConsistencyLevel.BOUNDED);
+        Assertions.assertEquals(ConsistencyLevel.BOUNDED, request.getConsistencyLevel());
+        request.setFilterTemplateValues(Collections.emptyMap());
+        request.setDatabaseName("db");
+        request.setCollectionName("coll");
+        request.setPartitionName("p");
+        request.setIds(Collections.singletonList(1L));
+        Assertions.assertEquals("db", request.getDatabaseName());
+        Assertions.assertEquals("coll", request.getCollectionName());
+        Assertions.assertEquals("p", request.getPartitionName());
+        Assertions.assertEquals(Collections.singletonList(1L), request.getIds());
+    }
+
+    @Test
+    void testInsertRespSettersRoundTrip() {
+        InsertResp resp = InsertResp.builder().build();
+        resp.setInsertCnt(5L);
+        resp.setPrimaryKeys(Arrays.asList(1L, 2L));
+        resp.setCost(10L);
+        Assertions.assertEquals(5L, resp.getInsertCnt());
+        Assertions.assertEquals(Arrays.asList(1L, 2L), resp.getPrimaryKeys());
+        Assertions.assertEquals(10L, resp.getCost());
+    }
+
+    @Test
+    void testUpsertRespSettersRoundTrip() {
+        UpsertResp resp = UpsertResp.builder().build();
+        resp.setUpsertCnt(5L);
+        resp.setPrimaryKeys(Arrays.asList(1L, 2L));
+        resp.setCost(10L);
+        Assertions.assertEquals(5L, resp.getUpsertCnt());
+        Assertions.assertEquals(Arrays.asList(1L, 2L), resp.getPrimaryKeys());
+        Assertions.assertEquals(10L, resp.getCost());
+    }
+
+    @Test
+    void testDeleteRespSettersRoundTrip() {
+        DeleteResp resp = DeleteResp.builder().build();
+        resp.setDeleteCnt(5L);
+        resp.setCost(10L);
+        Assertions.assertEquals(5L, resp.getDeleteCnt());
+        Assertions.assertEquals(10L, resp.getCost());
+    }
+
+    @Test
+    void testDeleteConsistencyLevelSetOnWire() {
+        DeleteReq request = DeleteReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build();
+        client_v2.delete(request);
+
+        ArgumentCaptor<DeleteRequest> captor = ArgumentCaptor.forClass(DeleteRequest.class);
+        verify(blockingStub).delete(captor.capture());
+        Assertions.assertEquals(ConsistencyLevel.STRONG.getCode(), captor.getValue().getConsistencyLevelValue());
+    }
+
+    @Test
+    void testQueryWithoutConsistencyUsesDefaultConsistency() {
+        QueryReq request = QueryReq.builder()
+                .collectionName("test")
+                .filter("id > 0")
+                .build();
+        client_v2.query(request);
+
+        ArgumentCaptor<QueryRequest> captor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(blockingStub).query(captor.capture());
+        Assertions.assertTrue(captor.getValue().getUseDefaultConsistency());
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/SchemaUtilsTest.java
@@ -299,4 +299,73 @@ public class SchemaUtilsTest {
             }
         }
     }
+
+    @Test
+    void testConvertFromGrpcFunctionPopulatesServerAssignedAttributes() {
+        FunctionSchema functionSchema = FunctionSchema.newBuilder()
+                .setId(200L)
+                .setName("bm25")
+                .setDescription("xxx")
+                .setType(FunctionType.BM25)
+                .addInputFieldNames("text")
+                .addInputFieldIds(101L)
+                .addOutputFieldNames("sparse")
+                .addOutputFieldIds(102L)
+                .build();
+
+        CreateCollectionReq.Function function = SchemaUtils.convertFromGrpcFunction(functionSchema);
+        Assertions.assertEquals(200L, function.getId());
+        Assertions.assertEquals(Collections.singletonList(101L), function.getInputFieldIds());
+        Assertions.assertEquals(Collections.singletonList(102L), function.getOutputFieldIds());
+        Assertions.assertEquals("bm25", function.getName());
+        Assertions.assertEquals("xxx", function.getDescription());
+        Assertions.assertEquals(io.milvus.common.clientenum.FunctionType.BM25, function.getFunctionType());
+    }
+
+    @Test
+    void testConvertFromGrpcFunctionDefaultsServerAssignedAttributes() {
+        FunctionSchema functionSchema = FunctionSchema.newBuilder()
+                .setName("bm25")
+                .setType(FunctionType.BM25)
+                .build();
+
+        CreateCollectionReq.Function function = SchemaUtils.convertFromGrpcFunction(functionSchema);
+        Assertions.assertEquals(0L, function.getId());
+        Assertions.assertTrue(function.getInputFieldIds().isEmpty());
+        Assertions.assertTrue(function.getOutputFieldIds().isEmpty());
+    }
+
+    @Test
+    void testConvertFromGrpcFieldSchemaPopulatesServerAssignedAttributes() {
+        FieldSchema fieldSchema = FieldSchema.newBuilder()
+                .setFieldID(100L)
+                .setName("text")
+                .setDescription("desc")
+                .setDataType(DataType.VarChar)
+                .setIsDynamic(true)
+                .setIsFunctionOutput(true)
+                .addTypeParams(KeyValuePair.newBuilder().setKey("max_length").setValue("100").build())
+                .build();
+
+        CreateCollectionReq.FieldSchema converted = SchemaUtils.convertFromGrpcFieldSchema(fieldSchema);
+        Assertions.assertEquals(100L, converted.getFieldId());
+        Assertions.assertEquals(Boolean.TRUE, converted.getIsDynamic());
+        Assertions.assertEquals(Boolean.TRUE, converted.getIsFunctionOutput());
+        Assertions.assertEquals("text", converted.getName());
+        Assertions.assertEquals(100, converted.getMaxLength());
+    }
+
+    @Test
+    void testConvertFromGrpcFieldSchemaDefaultsServerAssignedAttributes() {
+        FieldSchema fieldSchema = FieldSchema.newBuilder()
+                .setName("id")
+                .setDataType(DataType.Int64)
+                .setIsPrimaryKey(true)
+                .build();
+
+        CreateCollectionReq.FieldSchema converted = SchemaUtils.convertFromGrpcFieldSchema(fieldSchema);
+        Assertions.assertEquals(0L, converted.getFieldId());
+        Assertions.assertEquals(Boolean.FALSE, converted.getIsDynamic());
+        Assertions.assertEquals(Boolean.FALSE, converted.getIsFunctionOutput());
+    }
 }

--- a/sdk-core/src/test/java/io/milvus/v2/utils/VectorUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/VectorUtilsTest.java
@@ -91,4 +91,39 @@ class VectorUtilsTest {
 
         assertEquals(0, request.getFunctionScore().getFunctions(0).getParamsCount());
     }
+
+    @Test
+    void queryUsesDefaultConsistencyWhenConsistencyLevelNull() {
+        QueryRequest request = new VectorUtils().ConvertToGrpcQueryRequest(QueryReq.builder()
+                .collectionName("coll")
+                .filter("id > 0")
+                .build());
+        assertEquals(true, request.getUseDefaultConsistency());
+        assertEquals(1L, request.getGuaranteeTimestamp());
+    }
+
+    @Test
+    void querySetsConsistencyLevelWhenProvided() {
+        QueryRequest request = new VectorUtils().ConvertToGrpcQueryRequest(QueryReq.builder()
+                .collectionName("coll")
+                .filter("id > 0")
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        assertEquals(false, request.getUseDefaultConsistency());
+        assertEquals(ConsistencyLevel.STRONG.getCode(), request.getConsistencyLevelValue());
+        assertEquals(0L, request.getGuaranteeTimestamp());
+    }
+
+    @Test
+    void querySessionConsistencyUsesCachedTimestamp() {
+        CollectionTsCache.getInstance().set("host-a:19530", "db", "coll", 200L);
+        VectorUtils utils = new VectorUtils();
+        utils.setEndpoint("host-a:19530");
+        utils.setCurrentDbName("db");
+        QueryRequest request = utils.ConvertToGrpcQueryRequest(QueryReq.builder()
+                .collectionName("coll")
+                .consistencyLevel(ConsistencyLevel.SESSION)
+                .build());
+        assertEquals(200L, request.getGuaranteeTimestamp());
+    }
 }


### PR DESCRIPTION
- decode cost from status.extra_info for insert/upsert/delete
- send num_partitions/properties on fast-path createCollection
- reject null index fieldName and empty index_params with checked errors
- support guaranteeTimestamp override for query/hybridSearch
- surface describeCollection aliases/consistencyLevelName/enableNamespace/ schemaVersion/updateTimestamp and field/function id metadata
- enforce createCollection numeric bounds; guard alterIndexProperties null properties; set delete consistency level