### PR TITLE
Align GetResp/QueryResp metadata and delete consistency with pymilvus

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -125,6 +125,14 @@ public class CollectionService extends BaseService {
             builder.setDbName(dbName);
         }
 
+        List<KeyValuePair> propertiesList = ParamUtils.AssembleKvPair(request.getProperties());
+        if (CollectionUtils.isNotEmpty(propertiesList)) {
+            propertiesList.forEach(builder::addProperties);
+        }
+        if (request.getNumPartitions() != null) {
+            builder.setNumPartitions(request.getNumPartitions());
+        }
+
         Status status = blockingStub.createCollection(builder.build());
         rpcUtils.handleResponse(title, status);
         invalidateSchemaCache(dbName, collectionName);
@@ -880,7 +888,7 @@ public class CollectionService extends BaseService {
         Map<String, String> stats = new HashMap<>();
         response.getStatsList().forEach(stat -> stats.put(stat.getKey(), stat.getValue()));
         GetCollectionStatsResp getCollectionStatsResp = GetCollectionStatsResp.builder()
-                .numOfEntities(response.getStatsList().stream().filter(stat -> stat.getKey().equals("row_count")).map(stat -> Long.parseLong(stat.getValue())).findFirst().get())
+                .numOfEntities(response.getStatsList().stream().filter(stat -> stat.getKey().equals("row_count")).map(stat -> Long.parseLong(stat.getValue())).findFirst().orElse(0L))
                 .stats(stats)
                 .build();
         return getCollectionStatsResp;

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -398,11 +398,78 @@ public class VectorService extends BaseService {
     private QueryResp convertQueryResponse(String title, QueryResults response) {
         rpcUtils.handleResponse(title, response.getStatus());
 
-        return QueryResp.builder()
+        QueryResp.QueryRespBuilder respBuilder = QueryResp.builder()
                 .queryResults(convertUtils.getEntities(response))
                 .sessionTs(response.getSessionTs())
-                .cost(getCost(response.getStatus()))
-                .build();
+                .cost(getCost(response.getStatus()));
+        fillQueryRespFromExtraInfo(respBuilder, response.getStatus().getExtraInfoMap());
+        return respBuilder.build();
+    }
+
+    private void fillQueryRespFromExtraInfo(QueryResp.QueryRespBuilder respBuilder, java.util.Map<String, String> extraInfo) {
+        ScanMetrics metrics = parseScanMetrics(extraInfo);
+        if (metrics.scannedRemoteBytes != null) {
+            respBuilder.scannedRemoteBytes(metrics.scannedRemoteBytes);
+        }
+        if (metrics.scannedTotalBytes != null) {
+            respBuilder.scannedTotalBytes(metrics.scannedTotalBytes);
+        }
+        if (metrics.cacheHitRatio != null) {
+            respBuilder.cacheHitRatio(metrics.cacheHitRatio);
+        }
+    }
+
+    private void fillSearchRespFromExtraInfo(SearchResp.SearchRespBuilder respBuilder, java.util.Map<String, String> extraInfo) {
+        ScanMetrics metrics = parseScanMetrics(extraInfo);
+        if (metrics.scannedRemoteBytes != null) {
+            respBuilder.scannedRemoteBytes(metrics.scannedRemoteBytes);
+        }
+        if (metrics.scannedTotalBytes != null) {
+            respBuilder.scannedTotalBytes(metrics.scannedTotalBytes);
+        }
+        if (metrics.cacheHitRatio != null) {
+            respBuilder.cacheHitRatio(metrics.cacheHitRatio);
+        }
+    }
+
+    private ScanMetrics parseScanMetrics(java.util.Map<String, String> extraInfo) {
+        ScanMetrics metrics = new ScanMetrics();
+        metrics.scannedRemoteBytes = parseLongMetric(extraInfo, "scanned_remote_bytes");
+        metrics.scannedTotalBytes = parseLongMetric(extraInfo, "scanned_total_bytes");
+        metrics.cacheHitRatio = parseFloatMetric(extraInfo, "cache_hit_ratio");
+        return metrics;
+    }
+
+    private Long parseLongMetric(java.util.Map<String, String> extraInfo, String key) {
+        String rawValue = extraInfo.get(key);
+        if (rawValue == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(rawValue);
+        } catch (NumberFormatException e) {
+            logger.warn("Failed to parse {} as long: {}", key, rawValue);
+            return null;
+        }
+    }
+
+    private Float parseFloatMetric(java.util.Map<String, String> extraInfo, String key) {
+        String rawValue = extraInfo.get(key);
+        if (rawValue == null) {
+            return null;
+        }
+        try {
+            return Float.parseFloat(rawValue);
+        } catch (NumberFormatException e) {
+            logger.warn("Failed to parse {} as float: {}", key, rawValue);
+            return null;
+        }
+    }
+
+    private static class ScanMetrics {
+        private Long scannedRemoteBytes;
+        private Long scannedTotalBytes;
+        private Float cacheHitRatio;
     }
 
     private long getCost(Status status) {
@@ -724,18 +791,6 @@ public class VectorService extends BaseService {
         return target;
     }
 
-    private void fillSearchRespFromExtraInfo(SearchResp.SearchRespBuilder respBuilder, java.util.Map<String, String> extraInfo) {
-        if (extraInfo.containsKey("scanned_remote_bytes")) {
-            respBuilder.scannedRemoteBytes(Long.parseLong(extraInfo.get("scanned_remote_bytes")));
-        }
-        if (extraInfo.containsKey("scanned_total_bytes")) {
-            respBuilder.scannedTotalBytes(Long.parseLong(extraInfo.get("scanned_total_bytes")));
-        }
-        if (extraInfo.containsKey("cache_hit_ratio")) {
-            respBuilder.cacheHitRatio(Float.parseFloat(extraInfo.get("cache_hit_ratio")));
-        }
-    }
-
     /**
      * Creates a query iterator over the entities of the specified collection.
      *
@@ -933,13 +988,18 @@ public class VectorService extends BaseService {
         // An empty id list is a no-op: return an empty result without issuing the RPC
         // (aligned with pymilvus, which short-circuits empty ids to []).
         if (CollectionUtils.isEmpty(request.getIds())) {
-            return GetResp.builder().getResults(new ArrayList<>()).build();
+            return GetResp.builder().queryResults(new ArrayList<>()).cost(0L).build();
         }
         // call query to get the result
         QueryResp queryResp = query(blockingStub, toQueryReq(request), clusterId);
 
         return GetResp.builder()
-                .getResults(queryResp.getQueryResults())
+                .queryResults(queryResp.getQueryResults())
+                .sessionTs(queryResp.getSessionTs())
+                .cost(queryResp.getCost())
+                .scannedRemoteBytes(queryResp.getScannedRemoteBytes())
+                .scannedTotalBytes(queryResp.getScannedTotalBytes())
+                .cacheHitRatio(queryResp.getCacheHitRatio())
                 .build();
     }
 
@@ -962,7 +1022,7 @@ public class VectorService extends BaseService {
         // An empty id list is a no-op: return an empty result without issuing the RPC
         // (aligned with pymilvus, which short-circuits empty ids to []).
         if (CollectionUtils.isEmpty(request.getIds())) {
-            return CompletableFuture.completedFuture(GetResp.builder().getResults(new ArrayList<>()).build());
+            return CompletableFuture.completedFuture(GetResp.builder().queryResults(new ArrayList<>()).cost(0L).build());
         }
         final QueryReq queryReq;
         try {
@@ -974,7 +1034,12 @@ public class VectorService extends BaseService {
         return transformFuture(
                 queryAsync(futureStubSupplier, queryReq, clusterId, retryUtils),
                 queryResp -> GetResp.builder()
-                        .getResults(queryResp.getQueryResults())
+                        .queryResults(queryResp.getQueryResults())
+                        .sessionTs(queryResp.getSessionTs())
+                        .cost(queryResp.getCost())
+                        .scannedRemoteBytes(queryResp.getScannedRemoteBytes())
+                        .scannedTotalBytes(queryResp.getScannedTotalBytes())
+                        .cacheHitRatio(queryResp.getCacheHitRatio())
                         .build());
     }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/request/DeleteReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/request/DeleteReq.java
@@ -19,6 +19,8 @@
 
 package io.milvus.v2.service.vector.request;
 
+import io.milvus.v2.common.ConsistencyLevel;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,7 @@ public class DeleteReq {
     // Valid value of this map can be:
     //     Boolean, Long, Double, String, List<Boolean>, List<Long>, List<Double>, List<String>
     private Map<String, Object> filterTemplateValues;
+    private ConsistencyLevel consistencyLevel;
 
     private DeleteReq(DeleteReqBuilder builder) {
         this.databaseName = builder.databaseName;
@@ -50,6 +53,7 @@ public class DeleteReq {
         this.filter = builder.filter;
         this.ids = builder.ids;
         this.filterTemplateValues = builder.filterTemplateValues;
+        this.consistencyLevel = builder.consistencyLevel;
     }
 
     /**
@@ -169,6 +173,24 @@ public class DeleteReq {
         this.filterTemplateValues = filterTemplateValues;
     }
 
+    /**
+     * Returns the consistency level for the delete operation.
+     *
+     * @return the consistency level, or {@code null} for the server default
+     */
+    public ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    /**
+     * Sets the consistency level for the delete operation.
+     *
+     * @param consistencyLevel the consistency level, or {@code null} for the server default
+     */
+    public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+    }
+
     @Override
     public String toString() {
         return "DeleteReq{" +
@@ -177,6 +199,7 @@ public class DeleteReq {
                 ", partitionName='" + partitionName + '\'' +
                 ", filter='" + filter + '\'' +
                 ", ids=" + ids +
+                ", consistencyLevel=" + consistencyLevel +
 //                ", filterTemplateValues=" + filterTemplateValues +
                 '}';
     }
@@ -188,6 +211,7 @@ public class DeleteReq {
         private String filter;
         private List<Object> ids;
         private Map<String, Object> filterTemplateValues = new HashMap<>();
+        private ConsistencyLevel consistencyLevel;
 
         /**
          * Sets the database name.
@@ -252,6 +276,17 @@ public class DeleteReq {
          */
         public DeleteReqBuilder filterTemplateValues(Map<String, Object> filterTemplateValues) {
             this.filterTemplateValues = filterTemplateValues;
+            return this;
+        }
+
+        /**
+         * Sets the consistency level for the delete operation.
+         *
+         * @param consistencyLevel the consistency level, or {@code null} for the server default
+         * @return this builder
+         */
+        public DeleteReqBuilder consistencyLevel(ConsistencyLevel consistencyLevel) {
+            this.consistencyLevel = consistencyLevel;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/GetResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/GetResp.java
@@ -23,12 +23,15 @@ import java.util.List;
 
 /**
  * Response returned by the {@code get} API.
+ *
+ * <p>{@code get} is a query-by-primary-keys convenience over {@code query}, so this class
+ * inherits all members from {@link QueryResp}. The result entities are accessed through the
+ * inherited {@link #getQueryResults()}; {@link #getGetResults()} is kept as a deprecated alias.
  */
-public class GetResp {
-    private List<QueryResp.QueryResult> getResults;
+public class GetResp extends QueryResp {
 
-    private GetResp(GetRespBuilder builder) {
-        this.getResults = builder.getResults;
+    private GetResp(QueryRespBuilder builder) {
+        super(builder);
     }
 
     /**
@@ -44,46 +47,76 @@ public class GetResp {
      * Returns the retrieved entities.
      *
      * @return the retrieved entities
+     * @deprecated use {@link #getQueryResults()} instead
      */
-    public List<QueryResp.QueryResult> getGetResults() {
-        return getResults;
+    @Deprecated
+    public List<QueryResult> getGetResults() {
+        return getQueryResults();
     }
 
     /**
      * Sets the retrieved entities.
      *
      * @param getResults the retrieved entities
+     * @deprecated use {@link #setQueryResults(List)} instead
      */
-    public void setGetResults(List<QueryResp.QueryResult> getResults) {
-        this.getResults = getResults;
+    @Deprecated
+    public void setGetResults(List<QueryResult> getResults) {
+        setQueryResults(getResults);
     }
 
-    @Override
-    public String toString() {
-        return "GetResp{" +
-                "getResults=" + getResults +
-                '}';
-    }
-
-    public static class GetRespBuilder {
-        private List<QueryResp.QueryResult> getResults;
+    public static class GetRespBuilder extends QueryRespBuilder {
 
         /**
          * Sets the retrieved entities.
          *
          * @param getResults the retrieved entities
          * @return this builder
+         * @deprecated use {@link #queryResults(List)} instead
          */
-        public GetRespBuilder getResults(List<QueryResp.QueryResult> getResults) {
-            this.getResults = getResults;
+        @Deprecated
+        public GetRespBuilder getResults(List<QueryResult> getResults) {
+            queryResults(getResults);
             return this;
         }
 
-        /**
-         * Builds the {@link GetResp}.
-         *
-         * @return the response
-         */
+        @Override
+        public GetRespBuilder queryResults(List<QueryResult> queryResults) {
+            super.queryResults(queryResults);
+            return this;
+        }
+
+        @Override
+        public GetRespBuilder sessionTs(long sessionTs) {
+            super.sessionTs(sessionTs);
+            return this;
+        }
+
+        @Override
+        public GetRespBuilder cost(Long cost) {
+            super.cost(cost);
+            return this;
+        }
+
+        @Override
+        public GetRespBuilder scannedRemoteBytes(Long scannedRemoteBytes) {
+            super.scannedRemoteBytes(scannedRemoteBytes);
+            return this;
+        }
+
+        @Override
+        public GetRespBuilder scannedTotalBytes(Long scannedTotalBytes) {
+            super.scannedTotalBytes(scannedTotalBytes);
+            return this;
+        }
+
+        @Override
+        public GetRespBuilder cacheHitRatio(Float cacheHitRatio) {
+            super.cacheHitRatio(cacheHitRatio);
+            return this;
+        }
+
+        @Override
         public GetResp build() {
             return new GetResp(this);
         }

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/response/QueryResp.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/response/QueryResp.java
@@ -31,11 +31,17 @@ public class QueryResp {
     private List<QueryResult> queryResults;
     private long sessionTs; // default eventually ts
     private Long cost;
+    private Long scannedRemoteBytes;
+    private Long scannedTotalBytes;
+    private Float cacheHitRatio;
 
-    private QueryResp(QueryRespBuilder builder) {
+    protected QueryResp(QueryRespBuilder builder) {
         this.queryResults = builder.queryResults;
         this.sessionTs = builder.sessionTs;
         this.cost = builder.cost;
+        this.scannedRemoteBytes = builder.scannedRemoteBytes;
+        this.scannedTotalBytes = builder.scannedTotalBytes;
+        this.cacheHitRatio = builder.cacheHitRatio;
     }
 
     /**
@@ -101,12 +107,69 @@ public class QueryResp {
         this.cost = cost;
     }
 
+    /**
+     * Returns the number of bytes scanned remotely during the query.
+     *
+     * @return the scanned remote bytes, or {@code null} if not reported by the server
+     */
+    public Long getScannedRemoteBytes() {
+        return scannedRemoteBytes;
+    }
+
+    /**
+     * Sets the number of bytes scanned remotely during the query.
+     *
+     * @param scannedRemoteBytes the scanned remote bytes
+     */
+    public void setScannedRemoteBytes(Long scannedRemoteBytes) {
+        this.scannedRemoteBytes = scannedRemoteBytes;
+    }
+
+    /**
+     * Returns the total number of bytes scanned during the query.
+     *
+     * @return the scanned total bytes, or {@code null} if not reported by the server
+     */
+    public Long getScannedTotalBytes() {
+        return scannedTotalBytes;
+    }
+
+    /**
+     * Sets the total number of bytes scanned during the query.
+     *
+     * @param scannedTotalBytes the scanned total bytes
+     */
+    public void setScannedTotalBytes(Long scannedTotalBytes) {
+        this.scannedTotalBytes = scannedTotalBytes;
+    }
+
+    /**
+     * Returns the cache hit ratio of the query.
+     *
+     * @return the cache hit ratio, or {@code null} if not reported by the server
+     */
+    public Float getCacheHitRatio() {
+        return cacheHitRatio;
+    }
+
+    /**
+     * Sets the cache hit ratio of the query.
+     *
+     * @param cacheHitRatio the cache hit ratio
+     */
+    public void setCacheHitRatio(Float cacheHitRatio) {
+        this.cacheHitRatio = cacheHitRatio;
+    }
+
     @Override
     public String toString() {
-        return "QueryResp{" +
+        return getClass().getSimpleName() + "{" +
                 "queryResults=" + queryResults +
                 ", sessionTs=" + sessionTs +
                 ", cost=" + cost +
+                ", scannedRemoteBytes=" + scannedRemoteBytes +
+                ", scannedTotalBytes=" + scannedTotalBytes +
+                ", cacheHitRatio=" + cacheHitRatio +
                 '}';
     }
 
@@ -114,6 +177,9 @@ public class QueryResp {
         private List<QueryResult> queryResults = new ArrayList<>();
         private long sessionTs = 1L; // default eventually ts
         private Long cost;
+        private Long scannedRemoteBytes;
+        private Long scannedTotalBytes;
+        private Float cacheHitRatio;
 
         /**
          * Sets the queried entities.
@@ -145,6 +211,39 @@ public class QueryResp {
          */
         public QueryRespBuilder cost(Long cost) {
             this.cost = cost;
+            return this;
+        }
+
+        /**
+         * Sets the number of bytes scanned remotely during the query.
+         *
+         * @param scannedRemoteBytes the scanned remote bytes
+         * @return this builder
+         */
+        public QueryRespBuilder scannedRemoteBytes(Long scannedRemoteBytes) {
+            this.scannedRemoteBytes = scannedRemoteBytes;
+            return this;
+        }
+
+        /**
+         * Sets the total number of bytes scanned during the query.
+         *
+         * @param scannedTotalBytes the scanned total bytes
+         * @return this builder
+         */
+        public QueryRespBuilder scannedTotalBytes(Long scannedTotalBytes) {
+            this.scannedTotalBytes = scannedTotalBytes;
+            return this;
+        }
+
+        /**
+         * Sets the cache hit ratio of the query.
+         *
+         * @param cacheHitRatio the cache hit ratio
+         * @return this builder
+         */
+        public QueryRespBuilder cacheHitRatio(Float cacheHitRatio) {
+            this.cacheHitRatio = cacheHitRatio;
             return this;
         }
 

--- a/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/DataUtils.java
@@ -676,6 +676,9 @@ public class DataUtils {
         if (StringUtils.isNotEmpty(dbName)) {
             builder.setDbName(dbName);
         }
+        if (request.getConsistencyLevel() != null) {
+            builder.setConsistencyLevelValue(request.getConsistencyLevel().getCode());
+        }
         return builder.build();
     }
 

--- a/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
+++ b/sdk-core/src/test/java/io/milvus/v2/client/MilvusClientV2Test.java
@@ -773,7 +773,6 @@ public class MilvusClientV2Test extends BaseTest {
         VerifyClass(UpsertReq.class.getName(), config);
 
         VerifyClass(DeleteResp.class.getName(), config);
-        VerifyClass(GetResp.class.getName(), config);
         VerifyClass(InsertResp.class.getName(), config);
         VerifyClass(QueryResp.class.getName(), config);
         VerifyClass(QueryResp.QueryResult.class.getName(), config);

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
@@ -22,6 +22,7 @@ package io.milvus.v2.service.collection;
 import io.milvus.grpc.AddCollectionFieldRequest;
 import io.milvus.grpc.AddCollectionStructFieldRequest;
 import io.milvus.grpc.FieldSchema;
+import io.milvus.grpc.GetCollectionStatisticsResponse;
 import io.milvus.grpc.KeyValuePair;
 import io.milvus.grpc.StructArrayFieldSchema;
 import io.milvus.exception.ParamException;
@@ -91,6 +92,28 @@ class CollectionTest extends BaseTest {
                 .dimension(2)
                 .build();
         client_v2.createCollection(req);
+    }
+
+    @Test
+    void testCreateCollectionFastPathPropagatesPropertiesAndNumPartitions() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("key1", "value1");
+        CreateCollectionReq req = CreateCollectionReq.builder()
+                .collectionName("test2")
+                .dimension(2)
+                .properties(properties)
+                .numPartitions(5)
+                .build();
+        client_v2.createCollection(req);
+
+        ArgumentCaptor<io.milvus.grpc.CreateCollectionRequest> captor =
+                ArgumentCaptor.forClass(io.milvus.grpc.CreateCollectionRequest.class);
+        verify(blockingStub).createCollection(captor.capture());
+        io.milvus.grpc.CreateCollectionRequest rpcRequest = captor.getValue();
+
+        Assertions.assertEquals(5, rpcRequest.getNumPartitions());
+        Assertions.assertTrue(rpcRequest.getPropertiesList().stream()
+                .anyMatch(kv -> kv.getKey().equals("key1") && kv.getValue().equals("value1")));
     }
 
     @Test
@@ -1045,6 +1068,22 @@ class CollectionTest extends BaseTest {
         GetCollectionStatsResp resp = client_v2.getCollectionStats(req);
         Assertions.assertEquals(10L, resp.getNumOfEntities());
         Assertions.assertEquals("10", resp.getStats().get("row_count"));
+    }
+
+    @Test
+    void testGetCollectionStatsMissingRowCountReturnsZero() {
+        when(blockingStub.getCollectionStatistics(any())).thenReturn(
+                GetCollectionStatisticsResponse.newBuilder()
+                        .addStats(KeyValuePair.newBuilder().setKey("other_stat").setValue("1").build())
+                        .setStatus(io.milvus.grpc.Status.newBuilder().setCode(0).build())
+                        .build());
+
+        GetCollectionStatsReq req = GetCollectionStatsReq.builder()
+                .collectionName("test")
+                .build();
+        GetCollectionStatsResp resp = client_v2.getCollectionStats(req);
+        Assertions.assertEquals(0L, resp.getNumOfEntities());
+        Assertions.assertTrue(resp.getStats().containsKey("other_stat"));
     }
 
 }

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -1095,6 +1095,58 @@ class VectorTest extends BaseTest {
     }
 
     @Test
+    void testGetInheritsQueryRespMetadata() {
+        QueryResults queryResults = QueryResults.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0)
+                        .putExtraInfo("report_value", "123")
+                        .putExtraInfo("scanned_remote_bytes", "456")
+                        .putExtraInfo("scanned_total_bytes", "789")
+                        .putExtraInfo("cache_hit_ratio", "0.5")
+                        .build())
+                .setSessionTs(888L)
+                .build();
+        when(blockingStub.query(any(QueryRequest.class))).thenReturn(queryResults);
+
+        GetReq request = GetReq.builder()
+                .collectionName("book")
+                .ids(Collections.singletonList(1L))
+                .build();
+        GetResp resp = client_v2.get(request);
+
+        Assertions.assertTrue(resp instanceof QueryResp);
+        Assertions.assertEquals(888L, resp.getSessionTs());
+        Assertions.assertEquals(123L, resp.getCost());
+        Assertions.assertEquals(456L, resp.getScannedRemoteBytes());
+        Assertions.assertEquals(789L, resp.getScannedTotalBytes());
+        Assertions.assertEquals(0.5f, resp.getCacheHitRatio());
+        Assertions.assertSame(resp.getGetResults(), resp.getQueryResults());
+    }
+
+    @Test
+    void testGetIgnoresMalformedScanMetrics() {
+        QueryResults queryResults = QueryResults.newBuilder()
+                .setStatus(Status.newBuilder().setCode(0)
+                        .putExtraInfo("report_value", "123")
+                        .putExtraInfo("scanned_remote_bytes", "not-a-number")
+                        .putExtraInfo("cache_hit_ratio", "oops")
+                        .build())
+                .setSessionTs(1L)
+                .build();
+        when(blockingStub.query(any(QueryRequest.class))).thenReturn(queryResults);
+
+        GetReq request = GetReq.builder()
+                .collectionName("book")
+                .ids(Collections.singletonList(1L))
+                .build();
+        GetResp resp = client_v2.get(request);
+
+        Assertions.assertEquals(123L, resp.getCost());
+        Assertions.assertNull(resp.getScannedRemoteBytes());
+        Assertions.assertNull(resp.getScannedTotalBytes());
+        Assertions.assertNull(resp.getCacheHitRatio());
+    }
+
+    @Test
     void testSearchRejectsNonPositiveLimitAndOutOfRangeRoundDecimal() {
         MilvusClientException negativeLimit = Assertions.assertThrows(MilvusClientException.class,
                 () -> client_v2.search(SearchReq.builder().collectionName("book")

--- a/sdk-core/src/test/java/io/milvus/v2/utils/DataUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/DataUtilsTest.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonObject;
 import io.milvus.common.utils.JsonUtils;
 import io.milvus.grpc.*;
 import io.milvus.param.Constant;
+import io.milvus.v2.common.ConsistencyLevel;
 import io.milvus.v2.common.DataType;
 import io.milvus.v2.exception.DataNotMatchException;
 import io.milvus.v2.exception.ErrorCode;
@@ -468,6 +469,7 @@ class DataUtilsTest {
                 .partitionName("partition")
                 .filter("id > {min_id} and tag in {tags}")
                 .filterTemplateValues(templateValues)
+                .consistencyLevel(ConsistencyLevel.STRONG)
                 .build());
 
         Assertions.assertEquals("db", request.getDbName());
@@ -476,6 +478,18 @@ class DataUtilsTest {
         Assertions.assertEquals("id > {min_id} and tag in {tags}", request.getExpr());
         Assertions.assertEquals(new HashSet<>(Arrays.asList("min_id", "tags")),
                 request.getExprTemplateValuesMap().keySet());
+        Assertions.assertEquals(io.milvus.grpc.ConsistencyLevel.Strong_VALUE, request.getConsistencyLevelValue());
+    }
+
+    @Test
+    void testConvertGrpcDeleteRequestWithoutConsistencyLevel() {
+        DeleteRequest request = new DataUtils().ConvertToGrpcDeleteRequest(DeleteReq.builder()
+                .databaseName("db")
+                .collectionName("collection")
+                .filter("id > 0")
+                .build());
+
+        Assertions.assertEquals(0, request.getConsistencyLevelValue());
     }
 
     @Test


### PR DESCRIPTION
Align V2 responses and delete/create-collection behavior with pymilvus.

- GetResp now extends QueryResp so get()/getAsync() expose sessionTs, cost,
  scanned_remote_bytes, scanned_total_bytes and cache_hit_ratio, matching
  query responses; empty-ids short-circuits set cost 0L. getGetResults() and
  GetRespBuilder.getResults() are kept as deprecated aliases.
- QueryResp gained scanned_remote_bytes / scanned_total_bytes / cache_hit_ratio
  members populated from Status.extra_info with number-format guards.
- DeleteReq gained a consistencyLevel member wired to
  DeleteRequest.consistency_level.
- createCollection fast path now propagates properties and numPartitions
  (previously silently dropped).
- getCollectionStats returns 0 instead of throwing when row_count is absent.
