### PR TITLE
[cherry-pick] feat: support refreshable workload-identity credentials in BulkWriter (#2058)

### DIFF
--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/RemoteBulkWriter.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/RemoteBulkWriter.java
@@ -158,14 +158,7 @@ public class RemoteBulkWriter extends LocalBulkWriter {
 
         if (connectParam instanceof S3ConnectParam) {
             S3ConnectParam s3ConnectParam = (S3ConnectParam) connectParam;
-            storageClient = MinioStorageClient.getStorageClient(
-                    s3ConnectParam.getCloudName(),
-                    s3ConnectParam.getEndpoint(),
-                    s3ConnectParam.getAccessKey(),
-                    s3ConnectParam.getSecretKey(),
-                    s3ConnectParam.getSessionToken(),
-                    s3ConnectParam.getRegion(),
-                    s3ConnectParam.getHttpClient());
+            storageClient = MinioStorageClient.getStorageClient(s3ConnectParam);
         } else if (connectParam instanceof AzureConnectParam) {
             AzureConnectParam azureConnectParam = (AzureConnectParam) connectParam;
             storageClient = AzureStorageClient.getStorageClient(azureConnectParam.getConnStr(),

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/connect/GcpMetadataServerCredentialsProvider.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/connect/GcpMetadataServerCredentialsProvider.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.bulkwriter.connect;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.minio.credentials.Credentials;
+import io.minio.credentials.Provider;
+import io.minio.messages.ResponseDate;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A minio {@link Provider} that fetches OAuth2 access tokens from the GCE metadata
+ * server, for workloads running on GCP with a service-account-attached identity (GKE
+ * workload identity, GCE service account).
+ *
+ * <p>The GCS XML API authenticates with an {@code Authorization: Bearer} header instead
+ * of request signing, so the access token is carried in {@link Credentials#sessionToken()}
+ * (matching the established convention of passing the GCS bearer token as the session
+ * token); accessKey/secretKey hold a sentinel value and are never used.</p>
+ *
+ * <p>Tokens are cached and refetched shortly before the server-reported expiry, so a
+ * long-running writer never sends an expired token. If a refetch fails while the cached
+ * token is still valid, the cached token is served until it truly expires; the cached
+ * fast path is lock-free, since {@code fetch()} is invoked per storage request.</p>
+ */
+public class GcpMetadataServerCredentialsProvider implements Provider {
+    private static final String TOKEN_URL =
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+    // refetch this far ahead of the server-reported expiry to absorb clock skew and
+    // in-flight requests
+    private static final long REFRESH_MARGIN_MS = 60_000;
+    // minio Credentials rejects empty accessKey/secretKey; the bearer path never reads
+    // them, so a self-describing sentinel fills the slots
+    private static final String BEARER_ONLY = "gcp-bearer-only";
+
+    private final String tokenUrl;
+    private final OkHttpClient httpClient;
+
+    private volatile Credentials cachedCredentials;
+    private volatile long expiresAtMillis;
+
+    public GcpMetadataServerCredentialsProvider() {
+        this(TOKEN_URL, new OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .build());
+    }
+
+    // visible for testing
+    GcpMetadataServerCredentialsProvider(String tokenUrl, OkHttpClient httpClient) {
+        this.tokenUrl = tokenUrl;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public Credentials fetch() {
+        if (cachedCredentials != null && System.currentTimeMillis() < expiresAtMillis - REFRESH_MARGIN_MS) {
+            return cachedCredentials;
+        }
+        synchronized (this) {
+            long now = System.currentTimeMillis();
+            if (cachedCredentials != null && now < expiresAtMillis - REFRESH_MARGIN_MS) {
+                return cachedCredentials;
+            }
+            try {
+                return fetchToken();
+            } catch (IllegalStateException e) {
+                if (cachedCredentials != null && now < expiresAtMillis) {
+                    // the cached token is still valid; serve it while the metadata
+                    // server is unreachable instead of failing in-flight uploads
+                    return cachedCredentials;
+                }
+                throw e;
+            }
+        }
+    }
+
+    private Credentials fetchToken() {
+        Request request = new Request.Builder()
+                .url(tokenUrl)
+                .header("Metadata-Flavor", "Google")
+                .get()
+                .build();
+        String body;
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                throw tokenFetchFailure("http " + response.code(), null);
+            }
+            body = response.body().string();
+        } catch (IOException e) {
+            throw tokenFetchFailure(e.getMessage(), e);
+        }
+        try {
+            JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+            String token = json.get("access_token").getAsString();
+            long expiresInSeconds = json.get("expires_in").getAsLong();
+            cachedCredentials = new Credentials(BEARER_ONLY, BEARER_ONLY, token,
+                    new ResponseDate(ZonedDateTime.now().plusSeconds(expiresInSeconds)));
+            expiresAtMillis = System.currentTimeMillis() + expiresInSeconds * 1000;
+            return cachedCredentials;
+        } catch (RuntimeException e) {
+            // malformed JSON or missing access_token/expires_in fields
+            throw tokenFetchFailure("unparseable token response: " + e.getMessage(), e);
+        }
+    }
+
+    private static IllegalStateException tokenFetchFailure(String detail, Throwable cause) {
+        String message = "failed to fetch GCP access token from metadata server, " + detail
+                + "; no GCP service account identity is available in this environment";
+        return cause == null ? new IllegalStateException(message) : new IllegalStateException(message, cause);
+    }
+}

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/connect/S3ConnectParam.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/connect/S3ConnectParam.java
@@ -21,7 +21,9 @@ package io.milvus.bulkwriter.connect;
 
 import io.milvus.exception.ParamException;
 import io.milvus.param.ParamUtils;
+import io.minio.credentials.Provider;
 import okhttp3.OkHttpClient;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -36,6 +38,7 @@ public class S3ConnectParam extends StorageConnectParam {
     private final String region;
     private final OkHttpClient httpClient;
     private final String cloudName;
+    private final Provider credentialsProvider;
 
     private S3ConnectParam(@NotNull Builder builder) {
         this.bucketName = builder.bucketName;
@@ -46,6 +49,7 @@ public class S3ConnectParam extends StorageConnectParam {
         this.region = builder.region;
         this.httpClient = builder.httpClient;
         this.cloudName = builder.cloudName;
+        this.credentialsProvider = builder.credentialsProvider;
     }
 
     public String getBucketName() {
@@ -80,6 +84,16 @@ public class S3ConnectParam extends StorageConnectParam {
         return cloudName;
     }
 
+    /**
+     * An external credentials provider that refreshes credentials automatically while
+     * the writer is running. When set, it takes precedence over the static
+     * accessKey/secretKey/sessionToken fields. For GCP the bearer token is carried in
+     * {@code Credentials.sessionToken()} (see GcpMetadataServerCredentialsProvider).
+     */
+    public Provider getCredentialsProvider() {
+        return credentialsProvider;
+    }
+
     @Override
     public String toString() {
         return "S3ConnectParam{" +
@@ -109,6 +123,7 @@ public class S3ConnectParam extends StorageConnectParam {
         private String region;
         private OkHttpClient httpClient;
         private String cloudName;
+        private Provider credentialsProvider;
 
         private Builder() {
         }
@@ -172,6 +187,20 @@ public class S3ConnectParam extends StorageConnectParam {
         }
 
         /**
+         * Sets an external credentials provider. Use this for identity-based
+         * authentication that must refresh credentials while the writer is running
+         * (e.g. AWS web identity / IRSA, GCP workload identity). Mutually exclusive
+         * with the static accessKey/secretKey/sessionToken setters; enforced at
+         * {@link #build()}. For GCP the provider's {@code fetch()} may be invoked per
+         * HTTP request, so it must cache credentials internally (per the minio
+         * {@code Provider} contract).
+         */
+        public Builder withCredentialsProvider(@NotNull Provider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        /**
          * Verifies parameters and creates a new {@link S3ConnectParam} instance.
          *
          * @return {@link S3ConnectParam}
@@ -179,6 +208,11 @@ public class S3ConnectParam extends StorageConnectParam {
         public S3ConnectParam build() throws ParamException {
             ParamUtils.CheckNullEmptyString(endpoint, "endpoint");
             ParamUtils.CheckNullEmptyString(bucketName, "bucketName");
+            if (credentialsProvider != null && (StringUtils.isNotBlank(accessKey)
+                    || StringUtils.isNotBlank(secretKey) || StringUtils.isNotBlank(sessionToken))) {
+                throw new ParamException("credentialsProvider is mutually exclusive with the static"
+                        + " accessKey/secretKey/sessionToken fields");
+            }
 
             return new S3ConnectParam(this);
         }

--- a/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/storage/client/MinioStorageClient.java
+++ b/sdk-bulkwriter/src/main/java/io/milvus/bulkwriter/storage/client/MinioStorageClient.java
@@ -21,6 +21,7 @@ package io.milvus.bulkwriter.storage.client;
 
 import com.google.common.collect.Multimap;
 import io.milvus.bulkwriter.common.clientenum.CloudStorage;
+import io.milvus.bulkwriter.connect.S3ConnectParam;
 import io.milvus.bulkwriter.model.CompleteMultipartUploadOutputModel;
 import io.milvus.bulkwriter.storage.StorageClient;
 import io.milvus.exception.ParamException;
@@ -60,6 +61,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.amazonaws.services.s3.internal.Constants.MB;
 
@@ -87,6 +89,25 @@ public class MinioStorageClient extends MinioAsyncClient implements StorageClien
     }
 
     /**
+     * Creates a {@link MinioStorageClient} from a full {@link S3ConnectParam}. When the param
+     * carries an external credentials provider (e.g. AWS web identity or GCP workload identity),
+     * the provider is used so credentials refresh transparently while the writer is running;
+     * otherwise the static accessKey/secretKey/sessionToken are used as before.
+     *
+     * <p>For GCP the provider's {@code fetch()} is invoked per HTTP request (the bearer token
+     * is attached by an interceptor), so providers must cache credentials internally, as the
+     * minio {@link Provider} contract requires.
+     *
+     * @param connectParam the connection parameters
+     * @return the configured {@link MinioStorageClient}
+     */
+    public static MinioStorageClient getStorageClient(S3ConnectParam connectParam) {
+        return getStorageClient(connectParam.getCloudName(), connectParam.getEndpoint(),
+                connectParam.getAccessKey(), connectParam.getSecretKey(), connectParam.getSessionToken(),
+                connectParam.getRegion(), connectParam.getHttpClient(), connectParam.getCredentialsProvider());
+    }
+
+    /**
      * Creates a {@link MinioStorageClient} for the given cloud storage provider.
      *
      * @param cloudName the cloud storage name, used to detect GCP and Tencent Cloud behavior
@@ -107,15 +128,36 @@ public class MinioStorageClient extends MinioAsyncClient implements StorageClien
                                                       String sessionToken,
                                                       String region,
                                                       OkHttpClient httpClient) {
+        return getStorageClient(cloudName, endpoint, accessKey, secretKey, sessionToken, region,
+                httpClient, null);
+    }
+
+    // Shared implementation. When credentialsProvider is set it is used so credentials refresh
+    // transparently while the writer runs (for GCP the bearer token is read from
+    // Credentials.sessionToken() per request, so the provider must cache internally per the
+    // minio Provider contract); otherwise the static accessKey/secretKey/sessionToken apply.
+    private static MinioStorageClient getStorageClient(String cloudName,
+                                                      String endpoint,
+                                                      String accessKey,
+                                                      String secretKey,
+                                                      String sessionToken,
+                                                      String region,
+                                                      OkHttpClient httpClient,
+                                                      Provider credentialsProvider) {
         boolean closeHttpClient = httpClient == null;
         MinioAsyncClient.Builder minioClientBuilder = MinioAsyncClient.builder()
                 .endpoint(endpoint);
 
-        if (CloudStorage.isGcpCloud(cloudName) && StringUtils.isNotEmpty(sessionToken)) {
-            httpClient = buildAuthorizedClient(httpClient, sessionToken);
+        if (CloudStorage.isGcpCloud(cloudName)
+                && (credentialsProvider != null || StringUtils.isNotEmpty(sessionToken))) {
+            // the GCS XML API authenticates with a bearer header instead of signing; the
+            // bearer token rides in Credentials.sessionToken per the established convention
+            httpClient = buildAuthorizedClient(httpClient, gcpBearerTokenSource(credentialsProvider, sessionToken));
         } else {
-            Provider credentialsProvider = new StaticProvider(accessKey, secretKey, sessionToken);
-            minioClientBuilder.credentialsProvider(credentialsProvider);
+            Provider provider = credentialsProvider != null
+                    ? credentialsProvider
+                    : new StaticProvider(accessKey, secretKey, sessionToken);
+            minioClientBuilder.credentialsProvider(provider);
         }
 
         if (StringUtils.isNotEmpty(region)) {
@@ -134,11 +176,25 @@ public class MinioStorageClient extends MinioAsyncClient implements StorageClien
         return new MinioStorageClient(minioClient, closeHttpClient);
     }
 
-    private static OkHttpClient buildAuthorizedClient(OkHttpClient httpClient, String sessionToken) {
+    private static Supplier<String> gcpBearerTokenSource(Provider credentialsProvider, String sessionToken) {
+        if (credentialsProvider != null) {
+            return () -> {
+                String token = credentialsProvider.fetch().sessionToken();
+                if (StringUtils.isEmpty(token)) {
+                    throw new IllegalStateException("credentials provider returned no session token;"
+                            + " for GCP the bearer token must be carried in Credentials.sessionToken()");
+                }
+                return token;
+            };
+        }
+        return () -> sessionToken;
+    }
+
+    private static OkHttpClient buildAuthorizedClient(OkHttpClient httpClient, Supplier<String> tokenSupplier) {
         Interceptor authInterceptor = chain -> {
             Request original = chain.request();
             Request requestWithAuth = original.newBuilder()
-                    .header("Authorization", "Bearer " + sessionToken)
+                    .header("Authorization", "Bearer " + tokenSupplier.get())
                     .build();
             return chain.proceed(requestWithAuth);
         };

--- a/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/connect/GcpMetadataServerCredentialsProviderTest.java
+++ b/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/connect/GcpMetadataServerCredentialsProviderTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.bulkwriter.connect;
+
+import com.sun.net.httpserver.HttpServer;
+import io.minio.credentials.Credentials;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GcpMetadataServerCredentialsProviderTest {
+
+    private HttpServer server;
+    private final AtomicInteger hitCount = new AtomicInteger();
+    private volatile int expiresIn = 3600;
+    private volatile int httpStatus = 200;
+    private volatile String responseBody;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/token", exchange -> {
+            hitCount.incrementAndGet();
+            String body = responseBody != null ? responseBody
+                    : "{\"access_token\":\"token-" + hitCount.get() + "\","
+                    + "\"expires_in\":" + expiresIn + ",\"token_type\":\"Bearer\"}";
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(httpStatus, httpStatus == 200 ? bytes.length : -1);
+            if (httpStatus == 200) {
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private GcpMetadataServerCredentialsProvider newProvider() {
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/token";
+        return new GcpMetadataServerCredentialsProvider(url, new OkHttpClient());
+    }
+
+    @Test
+    void fetchesTokenFromMetadataServer() {
+        Credentials credentials = newProvider().fetch();
+        // the bearer token rides in sessionToken; accessKey/secretKey are sentinels
+        assertEquals("token-1", credentials.sessionToken());
+        assertFalse(credentials.isExpired());
+        assertEquals(1, hitCount.get());
+    }
+
+    @Test
+    void cachesTokenWhileValid() {
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        assertEquals("token-1", provider.fetch().sessionToken());
+        assertEquals("token-1", provider.fetch().sessionToken());
+        assertEquals(1, hitCount.get());
+    }
+
+    @Test
+    void refetchesWhenTokenNearExpiry() {
+        // expires_in below the refresh margin: every call must refetch
+        expiresIn = 30;
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        assertEquals("token-1", provider.fetch().sessionToken());
+        assertEquals("token-2", provider.fetch().sessionToken());
+        assertEquals(2, hitCount.get());
+    }
+
+    @Test
+    void failsFastWhenMetadataServerErrors() {
+        httpStatus = 500;
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        IllegalStateException e = assertThrows(IllegalStateException.class, provider::fetch);
+        assertTrue(e.getMessage().contains("http 500"));
+    }
+
+    @Test
+    void servesCachedTokenWhenRefetchFailsButTokenStillValid() {
+        // token lives 30s: inside the refresh margin, but far from truly expired
+        expiresIn = 30;
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        assertEquals("token-1", provider.fetch().sessionToken());
+
+        httpStatus = 500;
+        // refetch fails, but the cached token is still valid and must be served
+        assertEquals("token-1", provider.fetch().sessionToken());
+        assertEquals(2, hitCount.get());
+    }
+
+    @Test
+    void failsWhenTokenExpiredAndRefetchFails() {
+        // token expires immediately
+        expiresIn = 0;
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        provider.fetch();
+
+        httpStatus = 500;
+        IllegalStateException e = assertThrows(IllegalStateException.class, provider::fetch);
+        assertTrue(e.getMessage().contains("http 500"));
+    }
+
+    @Test
+    void failsFastWhenResponseIsNotJson() {
+        responseBody = "not-json";
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        IllegalStateException e = assertThrows(IllegalStateException.class, provider::fetch);
+        assertTrue(e.getMessage().contains("unparseable token response"));
+    }
+
+    @Test
+    void failsFastWhenTokenFieldMissing() {
+        responseBody = "{\"token_type\":\"Bearer\"}";
+        GcpMetadataServerCredentialsProvider provider = newProvider();
+        IllegalStateException e = assertThrows(IllegalStateException.class, provider::fetch);
+        assertTrue(e.getMessage().contains("unparseable token response"));
+    }
+}

--- a/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/storage/client/MinioStorageClientTest.java
+++ b/sdk-bulkwriter/src/test/java/io/milvus/bulkwriter/storage/client/MinioStorageClientTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.bulkwriter.storage.client;
+
+import com.sun.net.httpserver.HttpServer;
+import io.milvus.bulkwriter.connect.S3ConnectParam;
+import io.milvus.exception.ParamException;
+import io.minio.BucketExistsArgs;
+import io.minio.credentials.Credentials;
+import io.minio.credentials.Provider;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MinioStorageClientTest {
+
+    private HttpServer server;
+    private final AtomicReference<String> authorizationHeader = new AtomicReference<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            authorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            // no such bucket: drives bucketExists down the false path
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private String endpoint() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @Test
+    void buildsClientWithStaticKeys() throws Exception {
+        S3ConnectParam param = S3ConnectParam.newBuilder()
+                .withCloudName("aws")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withAccessKey("ak")
+                .withSecretKey("sk")
+                .withRegion("us-west-2")
+                .build();
+        MinioStorageClient client = MinioStorageClient.getStorageClient(param);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        // static keys take the signing path
+        assertSignedWithAccessKey("ak");
+    }
+
+    @Test
+    void buildsClientWithExternalCredentialsProvider() throws Exception {
+        Provider provider = () -> new Credentials("provider-ak", "provider-sk", "token", null);
+        S3ConnectParam param = S3ConnectParam.newBuilder()
+                .withCloudName("aws")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withRegion("us-west-2")
+                .withCredentialsProvider(provider)
+                .build();
+        MinioStorageClient client = MinioStorageClient.getStorageClient(param);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        // the external provider, not a StaticProvider, signed the request
+        assertSignedWithAccessKey("provider-ak");
+    }
+
+    @Test
+    void credentialsProviderRejectsStaticKeys() {
+        Provider provider = () -> new Credentials("ak", "sk", null, null);
+        S3ConnectParam.Builder base = S3ConnectParam.newBuilder()
+                .withCloudName("aws")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withCredentialsProvider(provider);
+
+        ParamException e = assertThrows(ParamException.class,
+                () -> base.withAccessKey("ak").build());
+        assertTrue(e.getMessage().contains("mutually exclusive"));
+        e = assertThrows(ParamException.class,
+                () -> base.withAccessKey(null).withSecretKey("sk").build());
+        assertTrue(e.getMessage().contains("mutually exclusive"));
+        e = assertThrows(ParamException.class,
+                () -> base.withSecretKey(null).withSessionToken("token").build());
+        assertTrue(e.getMessage().contains("mutually exclusive"));
+    }
+
+    @Test
+    void gcpProviderWithoutSessionTokenFailsLoudly() {
+        // a provider that carries no token in Credentials.sessionToken must fail with a
+        // clear error, not an opaque "Bearer null" 403 from the storage endpoint
+        Provider provider = () -> new Credentials("ak", "sk", null, null);
+        S3ConnectParam param = S3ConnectParam.newBuilder()
+                .withCloudName("gcp")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withRegion("us-west1")
+                .withCredentialsProvider(provider)
+                .build();
+        MinioStorageClient client = MinioStorageClient.getStorageClient(param);
+
+        Exception e = assertThrows(Exception.class,
+                () -> client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+        Throwable root = e;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertTrue(root.getMessage().contains("session token"), root.getMessage());
+    }
+
+    @Test
+    void sevenArgOverloadReusesProvidedHttpClient() throws Exception {
+        MinioStorageClient client = MinioStorageClient.getStorageClient(
+                "aws", endpoint(), "ak", "sk", null, "us-west-2", new OkHttpClient());
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        assertSignedWithAccessKey("ak");
+    }
+
+    @Test
+    void sevenArgOverloadSignsWithStaticKeys() throws Exception {
+        // regression: this overload has no bucketName and must not go through
+        // S3ConnectParam.build() validation (VolumeFileManager calls it)
+        MinioStorageClient client = MinioStorageClient.getStorageClient(
+                "aws", endpoint(), "ak", "sk", null, "us-west-2", null);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        assertSignedWithAccessKey("ak");
+    }
+
+    @Test
+    void sevenArgOverloadGcpStaticTokenSendsBearerHeader() throws Exception {
+        MinioStorageClient client = MinioStorageClient.getStorageClient(
+                "gcp", endpoint(), "ak", "sk", "static-token", "us-west1", null);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        assertEquals("Bearer static-token", authorizationHeader.get());
+    }
+
+    private void assertSignedWithAccessKey(String accessKey) {
+        String header = authorizationHeader.get();
+        assertNotNull(header, "expected a signed request");
+        assertTrue(header.startsWith("AWS4-HMAC-SHA256"), header);
+        assertTrue(header.contains("Credential=" + accessKey + "/"), header);
+    }
+
+    @Test
+    void gcpBearerHeaderComesFromProviderSessionToken() throws Exception {
+        AtomicInteger fetchCalls = new AtomicInteger();
+        // GCP convention: the bearer token rides in Credentials.sessionToken
+        Provider provider = () -> {
+            fetchCalls.incrementAndGet();
+            return new Credentials("unused", "unused", "fresh-token", null);
+        };
+        S3ConnectParam param = S3ConnectParam.newBuilder()
+                .withCloudName("gcp")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withRegion("us-west1")
+                .withCredentialsProvider(provider)
+                .build();
+        MinioStorageClient client = MinioStorageClient.getStorageClient(param);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        assertEquals("Bearer fresh-token", authorizationHeader.get());
+        assertTrue(fetchCalls.get() >= 1);
+    }
+
+    @Test
+    void gcpStaticSessionTokenStillWorks() throws Exception {
+        S3ConnectParam param = S3ConnectParam.newBuilder()
+                .withCloudName("gcp")
+                .withEndpoint(endpoint())
+                .withBucketName("bucket")
+                .withAccessKey("ak")
+                .withSecretKey("sk")
+                .withSessionToken("static-token")
+                .withRegion("us-west1")
+                .build();
+        MinioStorageClient client = MinioStorageClient.getStorageClient(param);
+
+        assertFalse(client.bucketExists(BucketExistsArgs.builder().bucket("bucket").build()).get());
+
+        assertEquals("Bearer static-token", authorizationHeader.get());
+    }
+}


### PR DESCRIPTION
Cherry-picks commit `39caf54415b45d435207aaeedf1aff4de939f9f3` (39caf544) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

RemoteBulkWriter hands static one-shot credentials to the storage client,
so any bulk write outliving the credential session (AWS STS session
duration, or the 1h GCP metadata-server token) fails mid-job with expired
credentials.

S3ConnectParam now accepts an external minio credentials.Provider that
refreshes credentials transparently while the writer runs: AWS web
identity rides minio's WebIdentityProvider, and the new
GcpMetadataServerCredentialsProvider carries the GCS bearer token in
Credentials.sessionToken (the existing convention) and refetches from the
metadata server before expiry. Static ak/sk/sessionToken behavior is
unchanged when no provider is set.

Signed-off-by: alohaha22 <shawn.work1229@outlook.com>
