### PR TITLE
[cherry-pick] Align pymilvus client-side validation gaps (#2057)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/cdc/CDCService.java
@@ -34,8 +34,10 @@ import io.milvus.grpc.WALName;
 import io.milvus.v2.exception.ErrorCode;
 import io.milvus.v2.exception.MilvusClientException;
 import io.milvus.v2.service.BaseService;
+import io.milvus.v2.service.cdc.request.CrossClusterTopology;
 import io.milvus.v2.service.cdc.request.DumpMessagesReq;
 import io.milvus.v2.service.cdc.request.GetReplicateInfoReq;
+import io.milvus.v2.service.cdc.request.MilvusCluster;
 import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
 import io.milvus.v2.service.cdc.request.UpdateReplicateConfigurationReq;
 import io.milvus.v2.service.cdc.response.DumpMessageInfo;
@@ -43,7 +45,10 @@ import io.milvus.v2.service.cdc.response.DumpMessagesResp;
 import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
 import io.milvus.v2.service.cdc.response.GetReplicateInfoResp;
 import io.milvus.v2.service.cdc.response.UpdateReplicateConfigurationResp;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -107,8 +112,29 @@ public class CDCService extends BaseService {
      * @return the update replicate configuration response
      */
     public UpdateReplicateConfigurationResp updateReplicateConfiguration(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, UpdateReplicateConfigurationReq requestParam) {
+        ReplicateConfiguration configuration = requestParam.getReplicateConfiguration();
+        if (configuration == null || CollectionUtils.isEmpty(configuration.getClusters())) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "replicate configuration must contain at least one cluster");
+        }
+        for (MilvusCluster cluster : configuration.getClusters()) {
+            if (StringUtils.isEmpty(cluster.getClusterId())) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "clusterId cannot be null or empty");
+            }
+            if (StringUtils.isEmpty(cluster.getUri())) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "connection uri cannot be null or empty");
+            }
+        }
+        List<CrossClusterTopology> topologies = configuration.getCrossClusterTopologies();
+        if (topologies != null) {
+            for (CrossClusterTopology topology : topologies) {
+                if (StringUtils.isEmpty(topology.getSourceClusterId()) || StringUtils.isEmpty(topology.getTargetClusterId())) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "cross cluster topology requires both source_cluster_id and target_cluster_id");
+                }
+            }
+        }
         UpdateReplicateConfigurationRequest request = UpdateReplicateConfigurationRequest.newBuilder()
-                .setReplicateConfiguration(requestParam.getReplicateConfiguration().toGRPC())
+                .setReplicateConfiguration(configuration.toGRPC())
                 .setForcePromote(requestParam.isForcePromote())
                 .build();
 

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/CollectionService.java
@@ -70,12 +70,21 @@ public class CollectionService extends BaseService {
     public Void createCollection(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, CreateCollectionReq request) {
         if (request.getCollectionSchema() != null) {
             //create collections with schema
+            request.getCollectionSchema().verify();
             createCollectionWithSchema(blockingStub, request);
             return null;
         }
 
         if (request.getDimension() == null) {
             throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Dimension is undefined.");
+        }
+        io.milvus.v2.common.DataType idType = request.getIdType();
+        if (idType == null) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Primary key type is required");
+        }
+        if (idType != io.milvus.v2.common.DataType.Int64 && idType != io.milvus.v2.common.DataType.VarChar) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "Primary key type must be Int64 or VarChar, got: " + idType.name());
         }
 
         String dbName = request.getDatabaseName();

--- a/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/collection/request/CreateCollectionReq.java
@@ -22,6 +22,7 @@ package io.milvus.v2.service.collection.request;
 import com.google.gson.JsonObject;
 import io.milvus.common.clientenum.FunctionType;
 import io.milvus.exception.ParamException;
+import org.apache.commons.lang3.StringUtils;
 import io.milvus.v2.common.ConsistencyLevel;
 import io.milvus.v2.common.DataType;
 import io.milvus.v2.common.IndexParam;
@@ -904,6 +905,104 @@ public class CreateCollectionReq {
          */
         public static CollectionSchemaBuilder builder() {
             return new CollectionSchemaBuilder();
+        }
+
+        /**
+         * Validates the schema and detects obvious problems, mirroring pymilvus
+         * {@code CollectionSchema.verify()}:
+         * exactly one primary key whose type is Int64 or VarChar; a partition key that is not
+         * the primary key and whose type is Int64 or VarChar; a clustering key whose type is in
+         * {Int8, Int16, Int32, Int64, Float, Double, VarChar, FloatVector}; and auto-id allowed
+         * only on the primary key. External collections skip primary/partition/clustering key
+         * validation.
+         *
+         * @throws MilvusClientException if the schema is invalid
+         */
+        public void verify() {
+            if (StringUtils.isNotEmpty(externalSource)) {
+                return;
+            }
+            if (fieldSchemaList == null) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Schema fields cannot be null");
+            }
+
+            CreateCollectionReq.FieldSchema primaryField = null;
+            CreateCollectionReq.FieldSchema partitionKeyField = null;
+            CreateCollectionReq.FieldSchema clusteringKeyField = null;
+            for (CreateCollectionReq.FieldSchema field : fieldSchemaList) {
+                if (Boolean.TRUE.equals(field.getIsPrimaryKey())) {
+                    if (primaryField != null) {
+                        throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                                "There are more than one primary key, field name = " + primaryField.getName()
+                                        + ", " + field.getName());
+                    }
+                    primaryField = field;
+                }
+                if (Boolean.TRUE.equals(field.getIsPartitionKey())) {
+                    if (partitionKeyField != null) {
+                        throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                                "There are more than one partition key, field name = " + partitionKeyField.getName()
+                                        + ", " + field.getName());
+                    }
+                    partitionKeyField = field;
+                }
+                if (Boolean.TRUE.equals(field.getIsClusteringKey())) {
+                    if (clusteringKeyField != null) {
+                        throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                                "There are more than one clustering key, field name = " + clusteringKeyField.getName()
+                                        + ", " + field.getName());
+                    }
+                    clusteringKeyField = field;
+                }
+                if (Boolean.TRUE.equals(field.getAutoID()) && !Boolean.TRUE.equals(field.getIsPrimaryKey())) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "auto_id is only allowed on primary key field, field name = " + field.getName());
+                }
+            }
+
+            if (primaryField == null) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Primary key field is required");
+            }
+            DataType primaryType = primaryField.getDataType();
+            if (primaryType == null) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                        "Primary key field data type is required, field name = " + primaryField.getName());
+            }
+            if (primaryType != DataType.Int64 && primaryType != DataType.VarChar) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                        "Primary key data type must be Int64 or VarChar, got: " + primaryType.name());
+            }
+
+            if (partitionKeyField != null) {
+                if (partitionKeyField.getName().equals(primaryField.getName())) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "Partition key field cannot be the primary key field: " + partitionKeyField.getName());
+                }
+                DataType partitionType = partitionKeyField.getDataType();
+                if (partitionType == null) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "Partition key field data type is required, field name = " + partitionKeyField.getName());
+                }
+                if (partitionType != DataType.Int64 && partitionType != DataType.VarChar) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "Partition key data type must be Int64 or VarChar, got: " + partitionType.name());
+                }
+            }
+
+            if (clusteringKeyField != null) {
+                DataType clusteringType = clusteringKeyField.getDataType();
+                if (clusteringType == null) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "Clustering key field data type is required, field name = " + clusteringKeyField.getName());
+                }
+                if (clusteringType != DataType.Int8 && clusteringType != DataType.Int16
+                        && clusteringType != DataType.Int32 && clusteringType != DataType.Int64
+                        && clusteringType != DataType.Float && clusteringType != DataType.Double
+                        && clusteringType != DataType.VarChar && clusteringType != DataType.FloatVector) {
+                    throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                            "Unsupported clustering key data type: " + clusteringType.name());
+                }
+            }
         }
 
         public static class CollectionSchemaBuilder {

--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -35,6 +35,8 @@ import io.milvus.param.Constant;
 import io.milvus.v2.exception.DataNotMatchException;
 import io.milvus.v2.exception.ErrorCode;
 import io.milvus.v2.exception.MilvusClientException;
+
+import static io.milvus.param.Constant.MAX_BATCH_SIZE;
 import io.milvus.v2.service.BaseService;
 import io.milvus.v2.service.collection.request.CreateCollectionReq;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
@@ -731,6 +733,10 @@ public class VectorService extends BaseService {
      */
     public QueryIterator queryIterator(RpcStubWrapper blockingStub,
                                        QueryIteratorReq request, String clusterId) {
+        if (request.getBatchSize() < 1 || request.getBatchSize() > MAX_BATCH_SIZE) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "batch_size must be in [1, " + MAX_BATCH_SIZE + "], got: " + request.getBatchSize());
+        }
         DescribeCollectionResponse descResp = getCollectionInfo(blockingStub.get(), request.getDatabaseName(),
                 request.getCollectionName(), false);
         DescribeCollectionResp respR = convertUtils.convertDescCollectionResp(descResp);
@@ -809,6 +815,7 @@ public class VectorService extends BaseService {
         if (request.getFilter() != null && request.getIds() != null) {
             throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "filter and ids can't be set at the same time");
         }
+        validateDeleteIds(request.getIds());
 
         if (request.getFilter() == null) {
             DescribeCollectionResponse descResp = getCollectionInfo(blockingStub, dbName, collectionName, false);
@@ -836,10 +843,39 @@ public class VectorService extends BaseService {
         }
 
         return DeleteResp.builder()
-                .deleteCnt(response.getDeleteCnt())
+                 .deleteCnt(response.getDeleteCnt())
                 .primaryKeys(primaryKeys)
                 .cost(getCost(response.getStatus()))
                 .build();
+    }
+
+    /**
+     * Validates that every delete id is a flat scalar primary key (integer or string).
+     * Nested lists are rejected because {@code getExprById} renders them via
+     * {@code List.toString()}, producing an invalid expression. An empty id list is
+     * also rejected, matching pymilvus {@code is_legal_ids}.
+     *
+     * @param ids the ids to validate
+     */
+    private static void validateDeleteIds(List<Object> ids) {
+        if (ids == null) {
+            return;
+        }
+        if (ids.isEmpty()) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "Delete ids must not be empty");
+        }
+        for (Object id : ids) {
+            if (id instanceof List) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                        "Delete ids must be a flat list of integers or strings; nested lists are not allowed");
+            }
+            if (!(id instanceof Long) && !(id instanceof Integer) && !(id instanceof Short)
+                    && !(id instanceof Byte) && !(id instanceof String)) {
+                throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                        "Delete ids must be integers or strings, got: " + (id == null ? "null" : id.getClass().getName()));
+            }
+        }
     }
 
     /**
@@ -868,6 +904,11 @@ public class VectorService extends BaseService {
         String collectionName = request.getCollectionName();
         String title = String.format("Get entities of collection: '%s' in database: '%s'", collectionName, dbName);
         logger.debug(title);
+        // An empty id list is a no-op: return an empty result without issuing the RPC
+        // (aligned with pymilvus, which short-circuits empty ids to []).
+        if (CollectionUtils.isEmpty(request.getIds())) {
+            return GetResp.builder().getResults(new ArrayList<>()).build();
+        }
         // call query to get the result
         QueryResp queryResp = query(blockingStub, toQueryReq(request), clusterId);
 
@@ -892,6 +933,11 @@ public class VectorService extends BaseService {
         String collectionName = request.getCollectionName();
         String title = String.format("Get entities of collection: '%s' in database: '%s'", collectionName, dbName);
         logger.debug(title);
+        // An empty id list is a no-op: return an empty result without issuing the RPC
+        // (aligned with pymilvus, which short-circuits empty ids to []).
+        if (CollectionUtils.isEmpty(request.getIds())) {
+            return CompletableFuture.completedFuture(GetResp.builder().getResults(new ArrayList<>()).build());
+        }
         final QueryReq queryReq;
         try {
             queryReq = toQueryReq(request);

--- a/sdk-core/src/main/java/io/milvus/v2/utils/VectorUtils.java
+++ b/sdk-core/src/main/java/io/milvus/v2/utils/VectorUtils.java
@@ -305,6 +305,14 @@ public class VectorUtils {
      * @return the gRPC search request
      */
     public SearchRequest ConvertToGrpcSearchRequest(SearchReq request) {
+        if (request.getLimit() <= 0) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "Search limit must be a positive integer, got: " + request.getLimit());
+        }
+        if (request.getRoundDecimal() <= -2 || request.getRoundDecimal() >= 7) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "round_decimal must be in (-2, 7), got: " + request.getRoundDecimal());
+        }
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
         SearchRequest.Builder builder = SearchRequest.newBuilder()
@@ -728,6 +736,14 @@ public class VectorUtils {
      *                               score are set
      */
     public HybridSearchRequest ConvertToGrpcHybridSearchRequest(HybridSearchReq request) {
+        if (request.getLimit() <= 0) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "Search limit must be a positive integer, got: " + request.getLimit());
+        }
+        if (request.getRoundDecimal() <= -2 || request.getRoundDecimal() >= 7) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS,
+                    "round_decimal must be in (-2, 7), got: " + request.getRoundDecimal());
+        }
         String dbName = request.getDatabaseName();
         String collectionName = request.getCollectionName();
         HybridSearchRequest.Builder builder = HybridSearchRequest.newBuilder()

--- a/sdk-core/src/test/java/io/milvus/v2/service/cdc/CDCServiceTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/cdc/CDCServiceTest.java
@@ -22,16 +22,21 @@ package io.milvus.v2.service.cdc;
 import io.milvus.grpc.DumpMessagesRequest;
 import io.milvus.grpc.DumpMessagesResponse;
 import io.milvus.grpc.Status;
+import io.milvus.grpc.UpdateReplicateConfigurationRequest;
 import io.milvus.grpc.WALName;
 import io.milvus.v2.BaseTest;
 import io.milvus.v2.exception.ErrorCode;
 import io.milvus.v2.exception.MilvusClientException;
+import io.milvus.v2.service.cdc.request.CrossClusterTopology;
 import io.milvus.v2.service.cdc.request.DumpMessagesReq;
 import io.milvus.v2.service.cdc.request.GetReplicateInfoReq;
+import io.milvus.v2.service.cdc.request.MilvusCluster;
 import io.milvus.v2.service.cdc.request.ReplicateConfiguration;
+import io.milvus.v2.service.cdc.request.UpdateReplicateConfigurationReq;
 import io.milvus.v2.service.cdc.response.DumpMessageInfo;
 import io.milvus.v2.service.cdc.response.DumpMessagesResp;
 import io.milvus.v2.service.cdc.response.GetReplicateConfigurationResp;
+import io.milvus.v2.service.cdc.response.UpdateReplicateConfigurationResp;
 import io.milvus.v2.service.cdc.response.GetReplicateInfoResp;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -107,6 +112,65 @@ public class CDCServiceTest extends BaseTest {
         assertEquals(1, replicateConfiguration.getCrossClusterTopologies().size());
         assertEquals("source_cluster", replicateConfiguration.getCrossClusterTopologies().get(0).getSourceClusterId());
         assertEquals("target_cluster", replicateConfiguration.getCrossClusterTopologies().get(0).getTargetClusterId());
+    }
+
+    @Test
+    void testUpdateReplicateConfigurationValidation() {
+        MilvusClientException nullConfig = assertThrows(MilvusClientException.class,
+                () -> client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder().build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, nullConfig.getErrorCode());
+
+        MilvusClientException emptyClusters = assertThrows(MilvusClientException.class,
+                () -> client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder()
+                        .replicateConfiguration(ReplicateConfiguration.builder().clusters(new ArrayList<>()).build())
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, emptyClusters.getErrorCode());
+
+        MilvusClientException missingClusterId = assertThrows(MilvusClientException.class,
+                () -> client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder()
+                        .replicateConfiguration(ReplicateConfiguration.builder()
+                                .clusters(Arrays.asList(MilvusCluster.builder().uri("http://source.example.com:19530").build()))
+                                .build())
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, missingClusterId.getErrorCode());
+
+        MilvusClientException missingUri = assertThrows(MilvusClientException.class,
+                () -> client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder()
+                        .replicateConfiguration(ReplicateConfiguration.builder()
+                                .clusters(Arrays.asList(MilvusCluster.builder().clusterId("source_cluster").build()))
+                                .build())
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, missingUri.getErrorCode());
+
+        MilvusClientException missingTopologyTarget = assertThrows(MilvusClientException.class,
+                () -> client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder()
+                        .replicateConfiguration(ReplicateConfiguration.builder()
+                                .clusters(Arrays.asList(MilvusCluster.builder().clusterId("source_cluster").uri("http://source.example.com:19530").build()))
+                                .crossClusterTopologies(Arrays.asList(CrossClusterTopology.builder().sourceClusterId("source_cluster").build()))
+                                .build())
+                        .build()));
+        assertEquals(ErrorCode.INVALID_PARAMS, missingTopologyTarget.getErrorCode());
+    }
+
+    @Test
+    void testUpdateReplicateConfigurationSuccess() {
+        UpdateReplicateConfigurationResp resp = client_v2.updateReplicateConfiguration(UpdateReplicateConfigurationReq.builder()
+                .replicateConfiguration(ReplicateConfiguration.builder()
+                        .clusters(Arrays.asList(
+                                MilvusCluster.builder().clusterId("source_cluster").uri("http://source.example.com:19530").build(),
+                                MilvusCluster.builder().clusterId("target_cluster").uri("http://target.example.com:19530").build()))
+                        .crossClusterTopologies(Arrays.asList(CrossClusterTopology.builder()
+                                .sourceClusterId("source_cluster")
+                                .targetClusterId("target_cluster")
+                                .build()))
+                        .build())
+                .build());
+
+        assertNotNull(resp);
+        ArgumentCaptor<UpdateReplicateConfigurationRequest> captor = ArgumentCaptor.forClass(UpdateReplicateConfigurationRequest.class);
+        verify(blockingStub).updateReplicateConfiguration(captor.capture());
+        assertEquals(2, captor.getValue().getReplicateConfiguration().getClustersCount());
+        assertEquals("source_cluster", captor.getValue().getReplicateConfiguration().getCrossClusterTopology(0).getSourceClusterId());
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionServiceSchemaCacheTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionServiceSchemaCacheTest.java
@@ -26,6 +26,8 @@ import io.milvus.grpc.MilvusServiceGrpc;
 import io.milvus.grpc.SearchRequest;
 import io.milvus.grpc.Status;
 import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.AddFieldReq;
 import io.milvus.v2.service.collection.request.AlterCollectionFieldReq;
 import io.milvus.v2.service.collection.request.AlterCollectionPropertiesReq;
 import io.milvus.v2.service.collection.request.CreateCollectionReq;
@@ -139,10 +141,13 @@ class CollectionServiceSchemaCacheTest {
 
         SchemaCache.getInstance().set(ENDPOINT, DATABASE, COLLECTION, cached);
         CollectionTsCache.getInstance().set(ENDPOINT, DATABASE, COLLECTION, 200L);
+        CreateCollectionReq.CollectionSchema schema =
+                CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
         service.createCollection(stub, CreateCollectionReq.builder()
                 .databaseName(DATABASE)
                 .collectionName(COLLECTION)
-                .collectionSchema(CreateCollectionReq.CollectionSchema.builder().build())
+                .collectionSchema(schema)
                 .build());
         assertNull(SchemaCache.getInstance().get(ENDPOINT, DATABASE, COLLECTION));
         assertEquals(200L, CollectionTsCache.getInstance().get(ENDPOINT, DATABASE, COLLECTION));

--- a/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/collection/CollectionTest.java
@@ -106,7 +106,7 @@ class CollectionTest extends BaseTest {
                 .enableDynamicField(true)
                 .build();
         collectionSchema
-                .addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).build())
+                .addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build())
                 .addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(2).build());
 
         req = CreateCollectionReq.builder()
@@ -137,7 +137,7 @@ class CollectionTest extends BaseTest {
         CreateCollectionReq.CollectionSchema collectionSchema = CreateCollectionReq.CollectionSchema.builder()
                 .build();
         collectionSchema
-                .addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).build())
+                .addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build())
                 .addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(2).build())
                 .addField(AddFieldReq.builder().fieldName("description").dataType(DataType.VarChar).maxLength(64).build());
 
@@ -168,6 +168,183 @@ class CollectionTest extends BaseTest {
                 .property("prop", "val")
                 .build();
         assertEquals("val", req.getProperties().get("prop"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsMissingPrimaryKey() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(2).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("Primary key"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsMultiplePrimaryKeys() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id1").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("id2").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("more than one primary key"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsUnsupportedPrimaryKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Float).isPrimaryKey(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Int64 or VarChar"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsPartitionKeyEqualToPrimaryKey() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).isPartitionKey(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("cannot be the primary key"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsMultiplePartitionKeys() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("p1").dataType(DataType.Int64).isPartitionKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("p2").dataType(DataType.Int64).isPartitionKey(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("more than one partition key"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsMultipleClusteringKeys() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("c1").dataType(DataType.Int64).isClusteringKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("c2").dataType(DataType.Int64).isClusteringKey(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("more than one clustering key"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsAutoIdOnNonPrimaryKey() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build());
+        schema.addField(AddFieldReq.builder().fieldName("other").dataType(DataType.Int64).autoID(Boolean.TRUE).build());
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("auto_id"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifySkipsExternalCollection() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.setExternalSource("s3://bucket/path");
+        schema.addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(2).build());
+
+        Assertions.assertDoesNotThrow(schema::verify);
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsNullFieldSchemaList() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(null)
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("Schema fields cannot be null"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsNullPrimaryKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(Collections.singletonList(
+                        CreateCollectionReq.FieldSchema.builder().name("id").isPrimaryKey(Boolean.TRUE).build()))
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Primary key field data type is required"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsNullPartitionKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(Arrays.asList(
+                        CreateCollectionReq.FieldSchema.builder().name("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build(),
+                        CreateCollectionReq.FieldSchema.builder().name("pk").isPartitionKey(Boolean.TRUE).build()))
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Partition key field data type is required"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsUnsupportedPartitionKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(Arrays.asList(
+                        CreateCollectionReq.FieldSchema.builder().name("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build(),
+                        CreateCollectionReq.FieldSchema.builder().name("pk").dataType(DataType.Float).isPartitionKey(Boolean.TRUE).build()))
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Partition key data type must be Int64 or VarChar"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsNullClusteringKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(Arrays.asList(
+                        CreateCollectionReq.FieldSchema.builder().name("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build(),
+                        CreateCollectionReq.FieldSchema.builder().name("ck").isClusteringKey(Boolean.TRUE).build()))
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Clustering key field data type is required"));
+    }
+
+    @Test
+    void testCollectionSchemaVerifyRejectsUnsupportedClusteringKeyType() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder()
+                .fieldSchemaList(Arrays.asList(
+                        CreateCollectionReq.FieldSchema.builder().name("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).build(),
+                        CreateCollectionReq.FieldSchema.builder().name("ck").dataType(DataType.Bool).isClusteringKey(Boolean.TRUE).build()))
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class, schema::verify);
+        Assertions.assertTrue(exception.getMessage().contains("Unsupported clustering key data type"));
+    }
+
+    @Test
+    void testCreateCollectionRejectsNullIdType() {
+        CreateCollectionReq req = CreateCollectionReq.builder()
+                .collectionName("test2")
+                .dimension(2)
+                .build();
+        req.setIdType(null);
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.createCollection(req));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("Primary key type is required"));
+    }
+
+    @Test
+    void testCreateCollectionRejectsUnsupportedIdType() {
+        CreateCollectionReq req = CreateCollectionReq.builder()
+                .collectionName("test2")
+                .dimension(2)
+                .idType(DataType.Float)
+                .build();
+
+        MilvusClientException exception = assertThrows(MilvusClientException.class,
+                () -> client_v2.createCollection(req));
+        Assertions.assertEquals(io.milvus.v2.exception.ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("Primary key type must be Int64 or VarChar"));
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -1027,6 +1027,121 @@ class VectorTest extends BaseTest {
     }
 
     @Test
+    void testGetWithEmptyIdsReturnsEmptyWithoutRpc() {
+        GetReq request = GetReq.builder()
+                .collectionName("book")
+                .ids(Collections.emptyList())
+                .build();
+
+        GetResp resp = client_v2.get(request);
+
+        Assertions.assertNotNull(resp.getGetResults());
+        Assertions.assertTrue(resp.getGetResults().isEmpty());
+        verify(blockingStub, never()).query(any(QueryRequest.class));
+    }
+
+    @Test
+    void testSearchRejectsNonPositiveLimitAndOutOfRangeRoundDecimal() {
+        MilvusClientException negativeLimit = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.search(SearchReq.builder().collectionName("book")
+                        .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                        .limit(-1).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, negativeLimit.getErrorCode());
+
+        MilvusClientException zeroLimit = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.search(SearchReq.builder().collectionName("book")
+                        .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                        .limit(0).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, zeroLimit.getErrorCode());
+
+        MilvusClientException outOfRange = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.search(SearchReq.builder().collectionName("book")
+                        .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                        .limit(10)
+                        .roundDecimal(7).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, outOfRange.getErrorCode());
+        Assertions.assertTrue(outOfRange.getMessage().contains("round_decimal"));
+
+        MilvusClientException negativeRoundDecimal = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.search(SearchReq.builder().collectionName("book")
+                        .data(Collections.singletonList(new FloatVec(Arrays.asList(1.0f, 2.0f))))
+                        .limit(10)
+                        .roundDecimal(-3).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, negativeRoundDecimal.getErrorCode());
+        Assertions.assertTrue(negativeRoundDecimal.getMessage().contains("round_decimal"));
+    }
+
+    @Test
+    void testHybridSearchRejectsInvalidLimitAndRoundDecimal() {
+        MilvusClientException negativeLimit = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.hybridSearch(HybridSearchReq.builder().collectionName("book").limit(-1).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, negativeLimit.getErrorCode());
+
+        MilvusClientException zeroLimit = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.hybridSearch(HybridSearchReq.builder().collectionName("book").limit(0).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, zeroLimit.getErrorCode());
+
+        MilvusClientException outOfRange = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.hybridSearch(HybridSearchReq.builder().collectionName("book")
+                        .limit(10)
+                        .roundDecimal(7).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, outOfRange.getErrorCode());
+        Assertions.assertTrue(outOfRange.getMessage().contains("round_decimal"));
+    }
+
+    @Test
+    void testDeleteRejectsInvalidIdType() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.delete(DeleteReq.builder().collectionName("book")
+                        .ids(Collections.singletonList(1.0d)).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("must be integers or strings"));
+    }
+
+    @Test
+    void testDeleteRejectsEmptyIds() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.delete(DeleteReq.builder().collectionName("book")
+                        .ids(Collections.emptyList()).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("must not be empty"));
+    }
+
+    @Test
+    void testDeleteRejectsNestedIds() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.delete(DeleteReq.builder().collectionName("book")
+                        .ids(Collections.singletonList(Collections.singletonList(1L))).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("nested lists are not allowed"));
+    }
+
+    @Test
+    void testDeleteRejectsNullElementInIds() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.delete(DeleteReq.builder().collectionName("book")
+                        .ids(Arrays.asList(1L, null)).build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("got: null"));
+    }
+
+    @Test
+    void testQueryIteratorRejectsBatchSizeOutOfBounds() {
+        VectorService vectorService = new VectorService();
+        MilvusClientException tooLarge = Assertions.assertThrows(MilvusClientException.class,
+                () -> vectorService.queryIterator(null, QueryIteratorReq.builder().collectionName("book").batchSize(20000).build(), null));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, tooLarge.getErrorCode());
+
+        MilvusClientException zero = Assertions.assertThrows(MilvusClientException.class,
+                () -> vectorService.queryIterator(null, QueryIteratorReq.builder().collectionName("book").batchSize(0).build(), null));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, zero.getErrorCode());
+
+        MilvusClientException negative = Assertions.assertThrows(MilvusClientException.class,
+                () -> vectorService.queryIterator(null, QueryIteratorReq.builder().collectionName("book").batchSize(-1).build(), null));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, negative.getErrorCode());
+    }
+
+    @Test
     void testGetWithMultiplePartitions() {
         GetReq request = GetReq.builder()
                 .collectionName("book")
@@ -1073,6 +1188,20 @@ class VectorTest extends BaseTest {
         Assertions.assertNotNull(response);
         verify(futureStub).query(any(QueryRequest.class));
         verify(blockingStub, never()).query(any(QueryRequest.class));
+    }
+
+    @Test
+    void testGetAsyncWithEmptyIdsReturnsEmptyWithoutRpc() throws Exception {
+        GetReq request = GetReq.builder()
+                .collectionName("book")
+                .ids(Collections.emptyList())
+                .build();
+
+        GetResp resp = client_v2.getAsync(request).get(1, TimeUnit.SECONDS);
+
+        Assertions.assertNotNull(resp.getGetResults());
+        Assertions.assertTrue(resp.getGetResults().isEmpty());
+        verify(futureStub, never()).query(any(QueryRequest.class));
     }
 
     @Test

--- a/sdk-core/src/test/java/io/milvus/v2/utils/VectorUtilsTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/utils/VectorUtilsTest.java
@@ -86,6 +86,7 @@ class VectorUtilsTest {
         SearchRequest request = new VectorUtils().ConvertToGrpcSearchRequest(SearchReq.builder()
                 .collectionName("coll")
                 .ids(Collections.singletonList(1L))
+                .limit(1)
                 .functionScore(FunctionScore.builder().addFunction(function).build())
                 .build());
 


### PR DESCRIPTION
Cherry-picks commit `fe1db603809fb851578af9b7a34f052038019ab8` (fe1db603) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

* Align pymilvus client-side validation gaps

Signed-off-by: yhmo <yihua.mo@zilliz.com>

* Add unit tests for client-side validation branches (#2057)

Cover the pymilvus-parity validation branches added in this PR:
verify() null/invalid key data types, fast-path idType checks,
nested/empty/null-element delete ids, getAsync empty ids, and
search/hybrid search limit and round_decimal bounds.

Signed-off-by: yhmo <yihua.mo@zilliz.com>

---------

Signed-off-by: yhmo <yihua.mo@zilliz.com>
