### PR TITLE
[cherry-pick] Short-circuit insert/upsert on empty data (#2059)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
+++ b/sdk-core/src/main/java/io/milvus/v2/service/vector/VectorService.java
@@ -129,6 +129,19 @@ public class VectorService extends BaseService {
      * @return the insert response
      */
     public InsertResp insert(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, InsertReq request) {
+        // A null data list is a programming error: reject it before issuing any RPC.
+        if (request.getData() == null) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Insert data cannot be null");
+        }
+        // An empty data list is a no-op: return an empty result without issuing the RPC
+        // (aligned with pymilvus, which short-circuits empty data to an empty insert result).
+        if (request.getData().isEmpty()) {
+            return InsertResp.builder()
+                    .InsertCnt(0L)
+                    .primaryKeys(new ArrayList<>())
+                    .cost(0L)
+                    .build();
+        }
         return insert(blockingStub, request, true);
     }
 
@@ -198,6 +211,19 @@ public class VectorService extends BaseService {
      * @return the upsert response
      */
     public UpsertResp upsert(MilvusServiceGrpc.MilvusServiceBlockingStub blockingStub, UpsertReq request) {
+        // A null data list is a programming error: reject it before issuing any RPC.
+        if (request.getData() == null) {
+            throw new MilvusClientException(ErrorCode.INVALID_PARAMS, "Upsert data cannot be null");
+        }
+        // An empty data list is a no-op: return an empty result without issuing the RPC
+        // (aligned with pymilvus, which short-circuits empty data to an empty upsert result).
+        if (request.getData().isEmpty()) {
+            return UpsertResp.builder()
+                    .upsertCnt(0L)
+                    .primaryKeys(new ArrayList<>())
+                    .cost(0L)
+                    .build();
+        }
         return upsert(blockingStub, request, true);
     }
 

--- a/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
+++ b/sdk-core/src/test/java/io/milvus/v2/service/vector/VectorTest.java
@@ -147,6 +147,60 @@ class VectorTest extends BaseTest {
     }
 
     @Test
+    void testInsertWithEmptyDataReturnsEmptyWithoutRpc() {
+        InsertResp resp = client_v2.insert(InsertReq.builder()
+                .collectionName("test")
+                .data(Collections.emptyList())
+                .build());
+
+        Assertions.assertEquals(0L, resp.getInsertCnt());
+        Assertions.assertTrue(resp.getPrimaryKeys().isEmpty());
+        Assertions.assertEquals(0L, resp.getCost());
+        verify(blockingStub, never()).insert(any(InsertRequest.class));
+        verify(blockingStub, never()).describeCollection(any());
+    }
+
+    @Test
+    void testInsertWithNullDataRejectsWithoutRpc() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.insert(InsertReq.builder()
+                        .collectionName("test")
+                        .data(null)
+                        .build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("data cannot be null"));
+        verify(blockingStub, never()).insert(any(InsertRequest.class));
+        verify(blockingStub, never()).describeCollection(any());
+    }
+
+    @Test
+    void testUpsertWithEmptyDataReturnsEmptyWithoutRpc() {
+        UpsertResp resp = client_v2.upsert(UpsertReq.builder()
+                .collectionName("test")
+                .data(Collections.emptyList())
+                .build());
+
+        Assertions.assertEquals(0L, resp.getUpsertCnt());
+        Assertions.assertTrue(resp.getPrimaryKeys().isEmpty());
+        Assertions.assertEquals(0L, resp.getCost());
+        verify(blockingStub, never()).upsert(any(UpsertRequest.class));
+        verify(blockingStub, never()).describeCollection(any());
+    }
+
+    @Test
+    void testUpsertWithNullDataRejectsWithoutRpc() {
+        MilvusClientException exception = Assertions.assertThrows(MilvusClientException.class,
+                () -> client_v2.upsert(UpsertReq.builder()
+                        .collectionName("test")
+                        .data(null)
+                        .build()));
+        Assertions.assertEquals(ErrorCode.INVALID_PARAMS, exception.getErrorCode());
+        Assertions.assertTrue(exception.getMessage().contains("data cannot be null"));
+        verify(blockingStub, never()).upsert(any(UpsertRequest.class));
+        verify(blockingStub, never()).describeCollection(any());
+    }
+
+    @Test
     void testDeleteExposesCost() {
         MutationResult result = MutationResult.newBuilder()
                 .setDeleteCnt(2L)


### PR DESCRIPTION
Cherry-picks commit `c280131b5625dfa8bce3f172bbe6bb444c28a2e3` (c280131b) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

Align with pymilvus: an empty data list returns an empty insert/upsert
result without issuing the RPC. A null data list is rejected with
INVALID_PARAMS before any RPC, and the no-op response sets cost to 0L
consistent with normal paths.

Signed-off-by: yhmo <yihua.mo@zilliz.com>
