### PR TITLE
[cherry-pick] docs: fix typo in CreateCollectionParam Javadoc (#2072)

### DIFF
--- a/sdk-core/src/main/java/io/milvus/param/collection/CreateCollectionParam.java
+++ b/sdk-core/src/main/java/io/milvus/param/collection/CreateCollectionParam.java
@@ -179,7 +179,7 @@ public class CreateCollectionParam {
          *
          * @param enableDynamicField enableDynamicField of the collection
          * @return <code>Builder</code>
-         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} repace
+         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} replace
          */
         @Deprecated
         public Builder withEnableDynamicField(boolean enableDynamicField) {
@@ -207,7 +207,7 @@ public class CreateCollectionParam {
          * @param fieldTypes a <code>List</code> of {@link FieldType}
          * @return <code>Builder</code>
          * @see FieldType
-         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} repace
+         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} replace
          */
         @Deprecated
         public Builder withFieldTypes(List<FieldType> fieldTypes) {
@@ -224,7 +224,7 @@ public class CreateCollectionParam {
          * @param fieldType a {@link FieldType} object
          * @return <code>Builder</code>
          * @see FieldType
-         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} repace
+         * @deprecated Use {@link #withSchema(CollectionSchemaParam)} replace
          */
         @Deprecated
         public Builder addFieldType(FieldType fieldType) {


### PR DESCRIPTION
Cherry-picks commit `3ce298ae1a23ab2752c0b009bc6225aea2bf0090` (3ce298ae) from `master` to `3.0`.

Created by the cherry-pick workflow — please review and merge manually.

Signed-off-by: youbingb <101463742+youbingb@users.noreply.github.com>
