### PR TITLE
Add beginner tutorials consuming the published milvus-sdk-java artifact

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -54,7 +54,7 @@ pull_request_rules:
         add:
           - ci-passed
 
-  - name: Remove ci-passed when required check is not successful
+  - name: Remove ci-passed when required check is not green
     conditions:
       - or:
         - base=master
@@ -62,8 +62,12 @@ pull_request_rules:
         - base~=2\.\d
       - 'files~=^(?!(doc/|benchmark/|examples/|.*\.md$|(.*/)?OWNERS$|LICENSE$))'
       - or:
-        - -status-success=Build and test on ubuntu
-        - -status-success=Build and test on windows
+          # Both pending and failure are checked so the label is removed as soon as a new commit
+          # triggers a re-run, instead of lingering until a check actually fails.
+          - "check-pending=Build and test on ubuntu"
+          - "check-pending=Build and test on windows"
+          - "check-failure=Build and test on ubuntu"
+          - "check-failure=Build and test on windows"
     actions:
       label:
         remove:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,8 +32,10 @@ jobs:
           cache: maven
       - name: Update submodule
         run: git submodule update --init
-      - name: sdk-core unit tests (ut)
-        run: mvn -pl sdk-core -Pcoverage "-Djacoco.destFile=target/jacoco-ut-core.exec" "-Djacoco.reportDir=target/site/jacoco-ut-core" --batch-mode --update-snapshots verify
+      # BulkWriter must be tested on linux: several unit tests write Parquet files locally and
+      # require Hadoop's native WinUtils, which is only bundled for linux. On windows these tests
+      # fail with "HADOOP_HOME and hadoop.home.dir are unset" (see PR #2075), so keep this step on
+      # the ubuntu job.
       - name: BulkWriter unit tests (ut)
         run: mvn -pl sdk-bulkwriter -Pcoverage "-Djacoco.destFile=target/jacoco-ut-bulk.exec" "-Djacoco.reportDir=target/site/jacoco-ut-bulk" --batch-mode --update-snapshots verify
       - name: System tests (st)
@@ -41,7 +43,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v5
         with:
-          files: ./sdk-core/target/site/jacoco-ut-core/jacoco.xml,./sdk-core/target/site/jacoco-st/jacoco.xml,./sdk-bulkwriter/target/site/jacoco-ut-bulk/jacoco.xml
+          files: ./sdk-core/target/site/jacoco-st/jacoco.xml,./sdk-bulkwriter/target/site/jacoco-ut-bulk/jacoco.xml
           name: ubuntu-jacoco-coverage
           disable_safe_directory: true
           verbose: true
@@ -60,6 +62,8 @@ jobs:
           cache: maven
       - name: Update submodule
         run: git submodule update --init
+      - name: Tutorials compile (published SDK)
+        run: mvn -f tutorial/pom.xml compile --batch-mode
       - name: Unit tests (ut)
         run: mvn -pl sdk-core -Pcoverage "-Djacoco.destFile=target/jacoco-ut.exec" "-Djacoco.reportDir=target/site/jacoco-ut" --batch-mode --update-snapshots verify
       - name: Integration tests (it)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,36 @@ mvn exec:java -Dexec.mainClass="io.milvus.v2.SimpleExample"
   header comment of each class for its prerequisites.
 - Prefer `io.milvus.v2.*` for new example code, matching the V2-first development policy below.
 
+## Tutorials
+
+`tutorial/` is a set of beginner-oriented, standalone Maven projects for learning the SDK, mirroring the
+`tutorial/` layout of the C++ and Rust SDKs. Unlike `examples/`, each tutorial depends on the **published**
+`milvus-sdk-java` artifact (from Maven Central), not the local source tree, so the learner's experience
+matches an application developer installing the SDK.
+
+```text
+tutorial/
+├── pom.xml                    # parent POM; single source of the milvus-sdk-java version
+├── 1_quickstart/
+├── 2_collection/
+├── 3_schema/
+├── 4_index/
+├── 5_dml/
+├── 6_dql/
+├── 7_database/
+└── 8_rbac/
+```
+
+- `tutorial/pom.xml` is the aggregator/parent POM. The `milvus-sdk-java` version is declared once there
+  (e.g. `<milvus.sdk.version>3.0.9</milvus.sdk.version>` in `<dependencyManagement>`) and inherited by the
+  eight child modules — it must **not** be duplicated in each child `pom.xml`.
+- **When releasing a new SDK version, update the `milvus-sdk-java` version in `tutorial/pom.xml`
+  (`milvus.sdk.version`) so tutorials keep consuming the latest published release.**
+- Each child module is runnable standalone: `cd tutorial/1_quickstart && mvn exec:java`.
+- Connection settings use `MILVUS_URI` / `MILVUS_TOKEN` env vars, defaulting to
+  `http://localhost:19530` / `root:Milvus` (same convention as the C++/Rust SDK tutorials).
+- The source-linked examples used for SDK development and testing remain under `examples/`.
+
 ## SDK generations
 
 Two API generations coexist inside `sdk-core`:
@@ -88,13 +118,20 @@ mvn install                          # builds sdk-core + sdk-bulkwriter
 
 ## Testing
 
-Three layers under `sdk-core/src/test/java/io/milvus/`, tagged with JUnit 5 `@Tag`:
+Since the sdk-core test reorganization on `master` (#2070) the test tree is split into three layers
+under `sdk-core/src/test/java/io/milvus/`, tagged with JUnit 5 `@Tag`:
 
 | Layer | Tag | Depends on | Examples |
 |---|---|---|---|
 | Unit | `@Tag("unit")` | none | request/response DTO builders, utils, caches, enums, interceptors |
 | Integration | `@Tag("integration")` | mock gRPC stub (`support/v2/BaseTest` for V2, in-process `MockMilvusServer` for V1) | facade method forwarding, error mapping, ts/schema caches |
 | System | `@Tag("system")` | real Milvus standalone via Docker | end-to-end |
+
+Before the v3.0.9-era rework the tests lived in a single tree mirroring the `io.milvus.*` production
+packages (`v2/`, `client/`, `param/`, ...) with no type separation and no tag-driven
+filtering. The rework instead groups tests by layer (`unit/`, `integration/`,
+`system/`), then by SDK generation (`v1/`, `v2/`, `common/`), and makes each layer
+selectable via JUnit tags.
 
 Run a layer with:
 
@@ -119,7 +156,8 @@ mvn -pl sdk-core -Psystem test       # unit + integration + system (Docker)
 
 - `.github/workflows/maven.yml` splits into two jobs:
   - `Build and test on ubuntu` (`ubuntu-latest`): bulkwriter unit tests + system tests (`-Psystem`).
-  - `Build and test on windows` (`windows-2022`): sdk-core unit + integration tests (`-Pintegration`).
+  - `Build and test on windows` (`windows-2022`): tutorials compile + sdk-core unit + integration
+    tests (`-Pintegration`).
 - Coverage is collected with JaCoCo (`-Pcoverage`); each step writes a per-step exec/report via
   `-Djacoco.destFile` / `-Djacoco.reportDir`, and codecov uploads the ut/it/st reports.
 - The JaCoCo report excludes proto-generated packages (`io/milvus/grpc/**`, `milvus/proto/**`) so codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,7 @@ ignore:
   - benchmark
   - doc
   - examples
+  - tutorial
   - tests
   - "**/*.md"
   - "**/*.yml"

--- a/examples/src/main/java/io/milvus/v2/IteratorExample.java
+++ b/examples/src/main/java/io/milvus/v2/IteratorExample.java
@@ -381,7 +381,7 @@ public class IteratorExample {
 
         // set rpcTimeoutMs, just to verify it works for each call of query/search inside the iterator
         // in versions older than 2.5.16/2.6.11, iterator.next() will timeout after several calls if the rpcTimeoutMs is greater than 0
-        client.withTimeout(200, TimeUnit.MILLISECONDS);
+        client.withTimeout(2000, TimeUnit.MILLISECONDS);
 
         queryIterator("userID < 3000", 1, 5, 10000);
         queryIteratorWithTemplate(80);

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,10 @@
                                     <excludes>
                                         <exclude>io/milvus/grpc/**</exclude>
                                         <exclude>milvus/proto/**</exclude>
+                                        <!-- examples/, tutorial/, and test sources are outside the
+                                             reactor and are not compiled into these modules, so
+                                             they never produce class files for this report;
+                                             codecov additionally ignores those paths. -->
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/tutorial/1_quickstart/README.md
+++ b/tutorial/1_quickstart/README.md
@@ -1,0 +1,36 @@
+# Tutorial 1: Quick start
+
+The smallest complete `MilvusClientV2` application. It connects to Milvus, creates a collection
+with an integer primary key, a text field, and a float vector, inserts two rows, performs a
+vector search, and removes the collection.
+
+## What you learn
+
+1. Create and connect a `MilvusClientV2` instance.
+2. Define a collection schema with a primary key, a scalar field, and a vector field.
+3. Insert row-oriented data.
+4. Search for the nearest neighbors of a query vector.
+5. Drop the collection during cleanup.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.quickstart.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.quickstart.App"
+```

--- a/tutorial/1_quickstart/pom.xml
+++ b/tutorial/1_quickstart/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-quickstart</artifactId>
+    <name>Milvus Java SDK tutorial - 1 quickstart</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/1_quickstart/src/main/java/io/milvus/tutorial/quickstart/App.java
+++ b/tutorial/1_quickstart/src/main/java/io/milvus/tutorial/quickstart/App.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.quickstart;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.index.request.CreateIndexReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.response.InsertResp;
+import io.milvus.v2.service.vector.response.SearchResp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tutorial 1: Quick start.
+ *
+ * <p>The smallest complete MilvusClientV2 application. It connects to Milvus, creates a collection
+ * with an integer primary key, a text field, and a float vector, inserts two rows, performs a
+ * vector search, and removes the collection.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String collectionName = "tutorial_quickstart";
+
+            // Drop the collection if it already exists from a previous run.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+
+            // Define the schema: an integer primary key, a text field, and a 4-dim float vector.
+            CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("id")
+                    .dataType(DataType.Int64)
+                    .isPrimaryKey(true)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("text")
+                    .dataType(DataType.VarChar)
+                    .maxLength(256)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("vector")
+                    .dataType(DataType.FloatVector)
+                    .dimension(4)
+                    .build());
+
+            client.createCollection(CreateCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .collectionSchema(schema)
+                    .build());
+            System.out.printf("Collection '%s' created%n", collectionName);
+
+            // Create an index on the vector field. A collection must be indexed before it can be
+            // loaded into memory for search.
+            client.createIndex(CreateIndexReq.builder()
+                    .collectionName(collectionName)
+                    .indexParams(Collections.singletonList(IndexParam.builder()
+                            .fieldName("vector")
+                            .indexType(IndexParam.IndexType.AUTOINDEX)
+                            .build()))
+                    .build());
+
+            // Insert two rows.
+            Gson gson = new Gson();
+            List<JsonObject> rows = new ArrayList<>();
+            for (int i = 1; i <= 2; i++) {
+                JsonObject row = new JsonObject();
+                row.addProperty("id", i);
+                row.addProperty("text", "row " + i);
+                row.add("vector", gson.toJsonTree(new float[]{1.0f * i, 0.5f * i, 0.25f * i, 0.125f * i}));
+                rows.add(row);
+            }
+            InsertResp insertResp = client.insert(InsertReq.builder()
+                    .collectionName(collectionName)
+                    .data(rows)
+                    .build());
+            System.out.printf("%d rows inserted%n", insertResp.getInsertCnt());
+
+            // Load the collection into memory so search can read the data.
+            client.loadCollection(LoadCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+
+            // Search for the nearest neighbors of a query vector.
+            SearchResp searchResp = client.search(SearchReq.builder()
+                    .collectionName(collectionName)
+                    .data(Collections.singletonList(new FloatVec(new float[]{1.0f, 0.5f, 0.25f, 0.125f})))
+                    .limit(2)
+                    .build());
+            System.out.println("Search results:");
+            for (List<SearchResp.SearchResult> results : searchResp.getSearchResults()) {
+                for (SearchResp.SearchResult result : results) {
+                    System.out.printf("  id=%s score=%f%n", result.getId(), result.getScore());
+                }
+            }
+
+            // Clean up.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.printf("Collection '%s' dropped%n", collectionName);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/tutorial/2_collection/README.md
+++ b/tutorial/2_collection/README.md
@@ -1,0 +1,38 @@
+# Tutorial 2: Collection management
+
+Walks through the full collection lifecycle with `MilvusClientV2`: create a collection with a
+description and a vector index, inspect it, change its properties, load and release it, read its
+load state and row count, rename it, truncate it, and finally drop it.
+
+## What you learn
+
+1. Create a collection with a schema, a vector index, and a default consistency level.
+2. Check existence with `hasCollection` and inspect metadata with `describeCollection`.
+3. Add and remove collection properties such as TTL with
+   `alterCollectionProperties` / `dropCollectionProperties`.
+4. Load and release a collection and read its load state and row count.
+5. Rename and truncate a collection.
+6. Drop the collection during cleanup.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.collection.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.collection.App"
+```

--- a/tutorial/2_collection/pom.xml
+++ b/tutorial/2_collection/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-collection</artifactId>
+    <name>Milvus Java SDK tutorial - 2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/2_collection/src/main/java/io/milvus/tutorial/collection/App.java
+++ b/tutorial/2_collection/src/main/java/io/milvus/tutorial/collection/App.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.collection;
+
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.AlterCollectionPropertiesReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DescribeCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionPropertiesReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.GetCollectionStatsReq;
+import io.milvus.v2.service.collection.request.GetLoadStateReq;
+import io.milvus.v2.service.collection.request.HasCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.collection.request.ReleaseCollectionReq;
+import io.milvus.v2.service.collection.request.RenameCollectionReq;
+import io.milvus.v2.service.collection.request.TruncateCollectionReq;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+import io.milvus.v2.service.collection.response.GetCollectionStatsResp;
+import io.milvus.v2.service.collection.response.ListCollectionsResp;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tutorial 2: Collection management.
+ *
+ * <p>Walks through the full collection lifecycle: create with a description and vector index,
+ * inspect with {@code hasCollection} / {@code describeCollection}, change properties, load and
+ * release, get load state and row count, rename, truncate, and finally drop.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final String TTL_SECONDS = "collection.ttl.seconds";
+
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String collectionName = "tutorial_collection";
+            String renamedName = collectionName + "_renamed";
+
+            // Pre-drop any collection left behind by an interrupted run; dropping a non-existent
+            // collection succeeds, so this keeps the tutorial rerunnable.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(renamedName)
+                    .build());
+
+            printCollections(client, "Collections before the tutorial");
+
+            CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("id")
+                    .dataType(DataType.Int64)
+                    .isPrimaryKey(true)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("title")
+                    .dataType(DataType.VarChar)
+                    .maxLength(256)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("embedding")
+                    .dataType(DataType.FloatVector)
+                    .dimension(4)
+                    .build());
+
+            // createCollection creates the collection with its schema, a vector index, and a
+            // default consistency level.
+            client.createCollection(CreateCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .description("Collection created by tutorial/2_collection")
+                    .collectionSchema(schema)
+                    .indexParams(Arrays.asList(IndexParam.builder()
+                            .fieldName("embedding")
+                            .indexType(IndexParam.IndexType.AUTOINDEX)
+                            .build()))
+                    .consistencyLevel(ConsistencyLevel.BOUNDED)
+                    .build());
+            System.out.printf("Collection '%s' created%n", collectionName);
+
+            boolean exists = client.hasCollection(HasCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.printf("hasCollection('%s') = %s%n", collectionName, exists);
+
+            describeCollection(client, collectionName);
+
+            // alterCollectionProperties adds or replaces key/value settings. This property asks
+            // Milvus to expire entities after 3600 seconds.
+            client.alterCollectionProperties(AlterCollectionPropertiesReq.builder()
+                    .collectionName(collectionName)
+                    .property(TTL_SECONDS, "3600")
+                    .build());
+            System.out.println("Set " + TTL_SECONDS + " = 3600");
+            describeProperty(client, collectionName);
+
+            client.dropCollectionProperties(DropCollectionPropertiesReq.builder()
+                    .collectionName(collectionName)
+                    .propertyKeys(Arrays.asList(TTL_SECONDS))
+                    .build());
+            System.out.println("Removed " + TTL_SECONDS);
+            describeProperty(client, collectionName);
+
+            // loadCollection makes the data and index searchable in memory.
+            client.loadCollection(LoadCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.println("Collection loaded");
+
+            Boolean loadState = client.getLoadState(GetLoadStateReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.println("Load state: " + loadState);
+
+            GetCollectionStatsResp stats = client.getCollectionStats(GetCollectionStatsReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.println("Row count: " + stats.getNumOfEntities());
+
+            client.releaseCollection(ReleaseCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.println("Collection released");
+
+            // renameCollection moves the collection to a new name.
+            client.renameCollection(RenameCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .newCollectionName(renamedName)
+                    .build());
+            boolean oldExists = client.hasCollection(HasCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            boolean newExists = client.hasCollection(HasCollectionReq.builder()
+                    .collectionName(renamedName)
+                    .build());
+            System.out.printf("After rename: old name exists=%s, new name exists=%s%n",
+                    oldExists, newExists);
+
+            // truncateCollection removes all entities but keeps the schema and indexes.
+            client.truncateCollection(TruncateCollectionReq.builder()
+                    .collectionName(renamedName)
+                    .build());
+            System.out.println("Truncate removes all entities but preserves the collection schema and indexes.");
+
+            // Clean up: drop the renamed collection.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(renamedName)
+                    .build());
+            System.out.printf("Collection '%s' dropped%n", renamedName);
+
+            printCollections(client, "Collections after cleanup");
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void describeCollection(MilvusClientV2 client, String collectionName) {
+        DescribeCollectionResp resp = client.describeCollection(DescribeCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.printf("describeCollection: name=%s id=%d primaryField=%s vectorFields=%s%n",
+                resp.getCollectionName(), resp.getCollectionID(), resp.getPrimaryFieldName(),
+                resp.getVectorFieldNames());
+    }
+
+    private static void describeProperty(MilvusClientV2 client, String collectionName) {
+        DescribeCollectionResp resp = client.describeCollection(DescribeCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println("Property " + TTL_SECONDS + " = "
+                + resp.getProperties().getOrDefault(TTL_SECONDS, "<not set>"));
+    }
+
+    private static void printCollections(MilvusClientV2 client, String heading) {
+        ListCollectionsResp resp = client.listCollections();
+        List<String> names = resp.getCollectionNames();
+        System.out.printf("%s: %s%n", heading, names.isEmpty() ? "<none>" : String.join(", ", names));
+    }
+}

--- a/tutorial/3_schema/README.md
+++ b/tutorial/3_schema/README.md
@@ -1,0 +1,39 @@
+# Tutorial 3: Schema
+
+Shows the field data types that a collection schema can declare. Three collections are created and
+read back with `describeCollection` so the server's representation of each field is printed:
+scalar and container types, vector types, and sparse / struct types.
+
+## What you learn
+
+1. Build a `CreateCollectionReq.CollectionSchema` with `AddFieldReq` entries.
+2. Declare scalar fields: `Bool`, `Int8`, `Int32`, `Int64`, `Float`, `Double`, `VarChar`,
+   `JSON`, `Timestamptz`.
+3. Declare nullable and default-valued fields.
+4. Declare vector fields: `FloatVector`, `BinaryVector`, `Float16Vector`, `BFloat16Vector`,
+   `SparseFloatVector`, `Int8Vector`.
+5. Declare an array field with an element type and capacity.
+6. Declare a struct field (array of struct) with nested sub-fields.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.schema.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.schema.App"
+```

--- a/tutorial/3_schema/pom.xml
+++ b/tutorial/3_schema/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-schema</artifactId>
+    <name>Milvus Java SDK tutorial - 3</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/3_schema/src/main/java/io/milvus/tutorial/schema/App.java
+++ b/tutorial/3_schema/src/main/java/io/milvus/tutorial/schema/App.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.schema;
+
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DescribeCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.response.DescribeCollectionResp;
+
+import java.util.Arrays;
+
+/**
+ * Tutorial 3: Schema design.
+ *
+ * <p>Shows the field data types that a collection schema can declare: scalar and container types
+ * in one collection, vector types in another, and sparse / struct fields in a third. Each schema is
+ * created and then read back with {@code describeCollection} so the server's representation can be
+ * inspected.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String scalarCollection = "tutorial_schema_scalar";
+            String vectorCollection = "tutorial_schema_vector";
+            String structCollection = "tutorial_schema_struct";
+
+            // Pre-drop any collections left behind by an interrupted run; dropping non-existent
+            // collections succeeds, so this keeps the tutorial rerunnable.
+            for (String name : Arrays.asList(scalarCollection, vectorCollection, structCollection)) {
+                client.dropCollection(DropCollectionReq.builder()
+                        .collectionName(name)
+                        .build());
+            }
+
+            createAndDescribe(client, scalarCollection, "Scalar and container data types", scalarSchema());
+            createAndDescribe(client, vectorCollection, "Vector data types", vectorSchema());
+            createAndDescribe(client, structCollection, "Sparse and struct data types", structSchema());
+
+            for (String name : Arrays.asList(scalarCollection, vectorCollection, structCollection)) {
+                client.dropCollection(DropCollectionReq.builder()
+                        .collectionName(name)
+                        .build());
+                System.out.printf("Collection '%s' dropped%n", name);
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    private static CreateCollectionReq.CollectionSchema scalarSchema() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("vector")
+                .dataType(DataType.FloatVector)
+                .dimension(2)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("bool_value")
+                .dataType(DataType.Bool)
+                .isNullable(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int8_value")
+                .dataType(DataType.Int8)
+                .defaultValue((short) 0)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int32_value")
+                .dataType(DataType.Int32)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int64_value")
+                .dataType(DataType.Int64)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("float_value")
+                .dataType(DataType.Float)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("double_value")
+                .dataType(DataType.Double)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("varchar_value")
+                .dataType(DataType.VarChar)
+                .maxLength(512)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("json_value")
+                .dataType(DataType.JSON)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("timestamp_value")
+                .dataType(DataType.Timestamptz)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int64_array")
+                .dataType(DataType.Array)
+                .elementType(DataType.Int64)
+                .maxCapacity(32)
+                .build());
+        return schema;
+    }
+
+    private static CreateCollectionReq.CollectionSchema vectorSchema() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("float_vector")
+                .dataType(DataType.FloatVector)
+                .dimension(8)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("binary_vector")
+                .dataType(DataType.BinaryVector)
+                .dimension(64)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("float16_vector")
+                .dataType(DataType.Float16Vector)
+                .dimension(8)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("bfloat16_vector")
+                .dataType(DataType.BFloat16Vector)
+                .dimension(8)
+                .build());
+        return schema;
+    }
+
+    private static CreateCollectionReq.CollectionSchema structSchema() {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("sparse_vector")
+                .dataType(DataType.SparseFloatVector)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("int8_vector")
+                .dataType(DataType.Int8Vector)
+                .dimension(8)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("events")
+                .description("An entity may contain up to 16 event records")
+                .dataType(DataType.Array)
+                .elementType(DataType.Struct)
+                .maxCapacity(16)
+                .addStructField(AddFieldReq.builder()
+                        .fieldName("label")
+                        .dataType(DataType.VarChar)
+                        .maxLength(128)
+                        .build())
+                .addStructField(AddFieldReq.builder()
+                        .fieldName("position")
+                        .dataType(DataType.Int32)
+                        .build())
+                .addStructField(AddFieldReq.builder()
+                        .fieldName("embedding")
+                        .dataType(DataType.FloatVector)
+                        .dimension(8)
+                        .build())
+                .build());
+        return schema;
+    }
+
+    private static void createAndDescribe(MilvusClientV2 client, String collectionName,
+                                          String heading, CreateCollectionReq.CollectionSchema schema) {
+        System.out.println("\n" + heading);
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .description(heading)
+                .collectionSchema(schema)
+                .build());
+        System.out.printf("Collection '%s' created%n", collectionName);
+
+        DescribeCollectionResp resp = client.describeCollection(DescribeCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        CreateCollectionReq.CollectionSchema described = resp.getCollectionSchema();
+        for (CreateCollectionReq.FieldSchema field : described.getFieldSchemaList()) {
+            StringBuilder line = new StringBuilder();
+            line.append("  field=").append(String.format("%-18s", field.getName()))
+                    .append(" type=").append(field.getDataType());
+            if (field.getDimension() != null && field.getDimension() > 0) {
+                line.append(" dim=").append(field.getDimension());
+            }
+            if (field.getElementType() != null) {
+                line.append(" element_type=").append(field.getElementType())
+                        .append(" max_capacity=").append(field.getMaxCapacity());
+            }
+            if (Boolean.TRUE.equals(field.getIsPrimaryKey())) {
+                line.append(" primary_key");
+            }
+            if (Boolean.TRUE.equals(field.getIsNullable())) {
+                line.append(" nullable");
+            }
+            if (field.getDefaultValue() != null) {
+                line.append(" default=").append(field.getDefaultValue());
+            }
+            System.out.println(line);
+        }
+        for (CreateCollectionReq.StructFieldSchema structField : described.getStructFields()) {
+            System.out.printf("  field=%-18s type=Array element_type=Struct max_capacity=%d%n",
+                    structField.getName(), structField.getMaxCapacity());
+            for (CreateCollectionReq.FieldSchema subField : structField.getFields()) {
+                System.out.printf("    sub_field=%-14s type=%s", subField.getName(), subField.getDataType());
+                if (subField.getDimension() != null && subField.getDimension() > 0) {
+                    System.out.printf(" dim=%d", subField.getDimension());
+                }
+                System.out.println();
+            }
+        }
+    }
+}

--- a/tutorial/4_index/README.md
+++ b/tutorial/4_index/README.md
@@ -1,0 +1,37 @@
+# Tutorial 4: Index
+
+Demonstrates the index lifecycle with `MilvusClientV2`: create a collection without indexes, build
+one vector index (HNSW) and two scalar indexes with `createIndex`, list them, inspect one with
+`describeIndex`, and remove one with `dropIndex`.
+
+## What you learn
+
+1. Create a collection without supplying indexes at creation time.
+2. Build multiple indexes in one `createIndex` call with `IndexParam` entries.
+3. Configure an HNSW index with metric type and build parameters.
+4. List index names with `listIndexes`.
+5. Inspect index metadata such as type, metric, and build state with `describeIndex`.
+6. Remove a single index with `dropIndex` without affecting the other indexes.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.index.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.index.App"
+```

--- a/tutorial/4_index/pom.xml
+++ b/tutorial/4_index/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-index</artifactId>
+    <name>Milvus Java SDK tutorial - 4</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/4_index/src/main/java/io/milvus/tutorial/index/App.java
+++ b/tutorial/4_index/src/main/java/io/milvus/tutorial/index/App.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.index;
+
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.index.request.CreateIndexReq;
+import io.milvus.v2.service.index.request.DescribeIndexReq;
+import io.milvus.v2.service.index.request.DropIndexReq;
+import io.milvus.v2.service.index.request.ListIndexesReq;
+import io.milvus.v2.service.index.response.DescribeIndexResp;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tutorial 4: Index management.
+ *
+ * <p>Creates a collection without indexes, then demonstrates the index lifecycle: build one vector
+ * index and two scalar indexes with {@code createIndex}, list them, inspect one with
+ * {@code describeIndex}, and remove one with {@code dropIndex}.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final String CATEGORY_INDEX = "category_inverted_idx";
+    private static final String PRICE_INDEX = "price_sort_idx";
+    private static final String VECTOR_INDEX = "embedding_hnsw_idx";
+
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String collectionName = "tutorial_index";
+
+            // Pre-drop any collection left behind by an interrupted run; dropping a non-existent
+            // collection succeeds, so this keeps the tutorial rerunnable.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+
+            // createCollection creates the fields that the indexes will target. No index is
+            // supplied here because this tutorial demonstrates createIndex separately.
+            CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("id")
+                    .dataType(DataType.Int64)
+                    .isPrimaryKey(true)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("category")
+                    .dataType(DataType.VarChar)
+                    .maxLength(128)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("price")
+                    .dataType(DataType.Float)
+                    .build());
+            schema.addField(AddFieldReq.builder()
+                    .fieldName("embedding")
+                    .dataType(DataType.FloatVector)
+                    .dimension(8)
+                    .build());
+            client.createCollection(CreateCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .collectionSchema(schema)
+                    .build());
+            System.out.printf("Collection '%s' created without indexes%n", collectionName);
+
+            // createIndex builds all supplied index definitions. Each IndexParam identifies a
+            // field, index name/type, and any metric or build parameters.
+            Map<String, Object> hnswParams = new HashMap<>();
+            hnswParams.put("M", "16");
+            hnswParams.put("efConstruction", "100");
+            client.createIndex(CreateIndexReq.builder()
+                    .collectionName(collectionName)
+                    .indexParams(Arrays.asList(
+                            IndexParam.builder()
+                                    .fieldName("embedding")
+                                    .indexName(VECTOR_INDEX)
+                                    .indexType(IndexParam.IndexType.HNSW)
+                                    .metricType(IndexParam.MetricType.COSINE)
+                                    .extraParams(hnswParams)
+                                    .build(),
+                            IndexParam.builder()
+                                    .fieldName("category")
+                                    .indexName(CATEGORY_INDEX)
+                                    .indexType(IndexParam.IndexType.INVERTED)
+                                    .build(),
+                            IndexParam.builder()
+                                    .fieldName("price")
+                                    .indexName(PRICE_INDEX)
+                                    .indexType(IndexParam.IndexType.STL_SORT)
+                                    .build()))
+                    .build());
+            System.out.println("createIndex completed");
+
+            printIndexes(client, collectionName, "Created indexes");
+
+            // describeIndex returns detailed metadata for the selected field and index name.
+            DescribeIndexResp descResp = client.describeIndex(DescribeIndexReq.builder()
+                    .collectionName(collectionName)
+                    .fieldName("embedding")
+                    .indexName(VECTOR_INDEX)
+                    .build());
+            for (DescribeIndexResp.IndexDesc index : descResp.getIndexDescriptions()) {
+                System.out.printf("Vector index detail: name=%s, type=%s, metric=%s, state=%s%n",
+                        index.getIndexName(), index.getIndexType(), index.getMetricType(),
+                        index.getIndexState());
+            }
+
+            // dropIndex removes only the named index; it does not delete its field or collection.
+            client.dropIndex(DropIndexReq.builder()
+                    .collectionName(collectionName)
+                    .indexName(PRICE_INDEX)
+                    .build());
+            System.out.println("Dropped index " + PRICE_INDEX);
+
+            printIndexes(client, collectionName, "Indexes after dropping price index");
+
+            // Clean up.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.printf("Collection '%s' dropped%n", collectionName);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void printIndexes(MilvusClientV2 client, String collectionName, String heading) {
+        // listIndexes returns every index name defined on the selected collection.
+        List<String> indexNames = client.listIndexes(ListIndexesReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println(heading + ": " + indexNames);
+    }
+}

--- a/tutorial/5_dml/README.md
+++ b/tutorial/5_dml/README.md
@@ -1,0 +1,37 @@
+# Tutorial 5: Data manipulation (DML)
+
+Demonstrates writing and modifying data with `MilvusClientV2`: insert rows, upsert to replace or
+partially update an entity, delete by primary key or by filter, and verify the remaining rows with
+`query`.
+
+## What you learn
+
+1. Create and load a collection with a vector index.
+2. Insert row-oriented JSON entities with `insert`.
+3. Replace or insert entities with `upsert`.
+4. Partially update an entity with `upsert` plus `partialUpdate(true)`.
+5. Delete entities by primary key or by filter expression with `delete`.
+6. Read the remaining rows back with `query`.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.dml.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.dml.App"
+```

--- a/tutorial/5_dml/pom.xml
+++ b/tutorial/5_dml/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-dml</artifactId>
+    <name>Milvus Java SDK tutorial - 5</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/5_dml/src/main/java/io/milvus/tutorial/dml/App.java
+++ b/tutorial/5_dml/src/main/java/io/milvus/tutorial/dml/App.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.dml;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.vector.request.DeleteReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.UpsertReq;
+import io.milvus.v2.service.vector.response.DeleteResp;
+import io.milvus.v2.service.vector.response.InsertResp;
+import io.milvus.v2.service.vector.response.QueryResp;
+import io.milvus.v2.service.vector.response.UpsertResp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tutorial 5: Data manipulation language (DML).
+ *
+ * <p>Demonstrates writing and modifying data with {@code MilvusClientV2}: insert rows, upsert to
+ * replace or partially update an entity, delete by primary key or by filter, and verify the
+ * remaining rows with {@code query}.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final int DIMENSION = 4;
+
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String collectionName = "tutorial_dml";
+
+            // Pre-drop any collection left behind by an interrupted run; dropping a non-existent
+            // collection succeeds, so this keeps the tutorial rerunnable.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+
+            createAndLoadCollection(client, collectionName);
+
+            Gson gson = new Gson();
+
+            // insert writes row-oriented JSON entities. Each row follows the collection schema;
+            // the response reports how many entities were accepted.
+            List<JsonObject> rows = new ArrayList<>();
+            rows.add(row(gson, 1, "Java in Action", 35.0, new float[]{0.1f, 0.2f, 0.3f, 0.4f}));
+            rows.add(row(gson, 2, "Vector Search", 25.0, new float[]{0.2f, 0.3f, 0.4f, 0.5f}));
+            InsertResp insertResp = client.insert(InsertReq.builder()
+                    .collectionName(collectionName)
+                    .data(rows)
+                    .build());
+            System.out.printf("Inserted %d rows%n", insertResp.getInsertCnt());
+
+            // upsert replaces an existing entity or inserts it when the primary key is absent.
+            List<JsonObject> upsertRows = new ArrayList<>();
+            upsertRows.add(row(gson, 2, "Practical Vector Search", 27.5, new float[]{0.25f, 0.35f, 0.45f, 0.55f}));
+            upsertRows.add(row(gson, 3, "Milvus Guide", 30.0, new float[]{0.3f, 0.4f, 0.5f, 0.6f}));
+            UpsertResp upsertResp = client.upsert(UpsertReq.builder()
+                    .collectionName(collectionName)
+                    .data(upsertRows)
+                    .build());
+            System.out.printf("Upserted %d rows%n", upsertResp.getUpsertCnt());
+
+            // upsert with partialUpdate(true) changes only the supplied non-primary fields. The
+            // primary key still identifies which entity to update.
+            List<JsonObject> partialRows = new ArrayList<>();
+            JsonObject partial = new JsonObject();
+            partial.addProperty("id", 3);
+            partial.addProperty("title", "The Milvus Guide");
+            partialRows.add(partial);
+            UpsertResp partialResp = client.upsert(UpsertReq.builder()
+                    .collectionName(collectionName)
+                    .data(partialRows)
+                    .partialUpdate(true)
+                    .build());
+            System.out.printf("Partially updated %d rows%n", partialResp.getUpsertCnt());
+
+            // delete with ids removes entities by primary key.
+            DeleteResp deleteById = client.delete(DeleteReq.builder()
+                    .collectionName(collectionName)
+                    .ids(Arrays.asList(1))
+                    .build());
+            System.out.printf("Deleted %d rows by primary key%n", deleteById.getDeleteCnt());
+
+            // delete with filter removes all entities matching the Milvus boolean expression.
+            DeleteResp deleteByFilter = client.delete(DeleteReq.builder()
+                    .collectionName(collectionName)
+                    .filter("id >= 3")
+                    .build());
+            System.out.printf("Deleted %d rows by filter%n", deleteByFilter.getDeleteCnt());
+
+            printRemainingRows(client, collectionName);
+
+            // Clean up.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.printf("Collection '%s' dropped%n", collectionName);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static JsonObject row(Gson gson, int id, String title, double price, float[] vector) {
+        JsonObject row = new JsonObject();
+        row.addProperty("id", id);
+        row.addProperty("title", title);
+        row.addProperty("price", price);
+        row.add("embedding", gson.toJsonTree(vector));
+        return row;
+    }
+
+    private static void createAndLoadCollection(MilvusClientV2 client, String collectionName) {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("title")
+                .dataType(DataType.VarChar)
+                .maxLength(256)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("price")
+                .dataType(DataType.Float)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("embedding")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+
+        // createCollection creates the DML target. The index makes the vector field searchable.
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .indexParams(Arrays.asList(IndexParam.builder()
+                        .fieldName("embedding")
+                        .indexType(IndexParam.IndexType.AUTOINDEX)
+                        .build()))
+                .build());
+        System.out.printf("Collection '%s' created%n", collectionName);
+
+        // loadCollection prepares the collection for the verification query.
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println("Collection loaded");
+    }
+
+    private static void printRemainingRows(MilvusClientV2 client, String collectionName) {
+        // query reads the remaining entities. Strong consistency makes the preceding mutations
+        // visible to the query.
+        QueryResp queryResp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("id >= 0")
+                .outputFields(Arrays.asList("id", "title", "price"))
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        System.out.println("Remaining rows:");
+        for (QueryResp.QueryResult result : queryResp.getQueryResults()) {
+            Map<String, Object> entity = result.getEntity();
+            System.out.printf("  id=%s title=%s price=%s%n",
+                    entity.get("id"), entity.get("title"), entity.get("price"));
+        }
+    }
+}

--- a/tutorial/6_dql/README.md
+++ b/tutorial/6_dql/README.md
@@ -1,0 +1,37 @@
+# Tutorial 6: Data query language (DQL)
+
+Demonstrates reading data with `MilvusClientV2`: scalar filtering with `query`, dense
+nearest-neighbor search with `search`, combined dense + sparse retrieval with `hybridSearch`, and
+paged reads with `queryIterator` and `searchIterator`.
+
+## What you learn
+
+1. Create and load a collection with a dense index and a sparse inverted index.
+2. Filter rows with `query` and read the returned entities.
+3. Search nearest neighbors with `search`, optionally restricted by a filter.
+4. Combine dense and sparse sub-searches with `hybridSearch` and a weighted reranker.
+5. Page through query results with `queryIterator` (`batchSize` / `limit`).
+6. Page through search results with `searchIterator`, preserving one search session.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.dql.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.dql.App"
+```

--- a/tutorial/6_dql/pom.xml
+++ b/tutorial/6_dql/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-dql</artifactId>
+    <name>Milvus Java SDK tutorial - 6</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/6_dql/src/main/java/io/milvus/tutorial/dql/App.java
+++ b/tutorial/6_dql/src/main/java/io/milvus/tutorial/dql/App.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.dql;
+
+import io.milvus.orm.iterator.QueryIterator;
+import io.milvus.orm.iterator.SearchIterator;
+import io.milvus.response.QueryResultsWrapper;
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.ConsistencyLevel;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.common.IndexParam;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+import io.milvus.v2.service.collection.request.DropCollectionReq;
+import io.milvus.v2.service.collection.request.LoadCollectionReq;
+import io.milvus.v2.service.vector.request.AnnSearchReq;
+import io.milvus.v2.service.vector.request.FunctionScore;
+import io.milvus.v2.service.vector.request.HybridSearchReq;
+import io.milvus.v2.service.vector.request.InsertReq;
+import io.milvus.v2.service.vector.request.QueryIteratorReq;
+import io.milvus.v2.service.vector.request.QueryReq;
+import io.milvus.v2.service.vector.request.SearchIteratorReq;
+import io.milvus.v2.service.vector.request.SearchReq;
+import io.milvus.v2.service.vector.request.data.FloatVec;
+import io.milvus.v2.service.vector.request.data.SparseFloatVec;
+import io.milvus.v2.service.vector.request.ranker.WeightedRanker;
+import io.milvus.v2.service.vector.response.QueryResp;
+import io.milvus.v2.service.vector.response.SearchResp;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.milvus.v2.service.vector.response.QueryResp.QueryResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Tutorial 6: Data query language (DQL).
+ *
+ * <p>Demonstrates reading data with {@code MilvusClientV2}: scalar filtering with {@code query},
+ * dense nearest-neighbor search with {@code search}, combined dense + sparse retrieval with
+ * {@code hybridSearch}, and paged reads with {@code queryIterator} and {@code searchIterator}.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final int DIMENSION = 4;
+
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String collectionName = "tutorial_dql";
+
+            // Pre-drop any collection left behind by an interrupted run; dropping a non-existent
+            // collection succeeds, so this keeps the tutorial rerunnable.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+
+            createLoadAndInsert(client, collectionName);
+            runQuery(client, collectionName);
+            runSearch(client, collectionName);
+            runHybridSearch(client, collectionName);
+            runQueryIterator(client, collectionName);
+            runSearchIterator(client, collectionName);
+
+            // Clean up.
+            client.dropCollection(DropCollectionReq.builder()
+                    .collectionName(collectionName)
+                    .build());
+            System.out.printf("Collection '%s' dropped%n", collectionName);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void createLoadAndInsert(MilvusClientV2 client, String collectionName) {
+        CreateCollectionReq.CollectionSchema schema = CreateCollectionReq.CollectionSchema.builder().build();
+        schema.addField(AddFieldReq.builder()
+                .fieldName("id")
+                .dataType(DataType.Int64)
+                .isPrimaryKey(true)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("title")
+                .dataType(DataType.VarChar)
+                .maxLength(256)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("category")
+                .dataType(DataType.Int32)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("dense")
+                .dataType(DataType.FloatVector)
+                .dimension(DIMENSION)
+                .build());
+        schema.addField(AddFieldReq.builder()
+                .fieldName("sparse")
+                .dataType(DataType.SparseFloatVector)
+                .build());
+
+        // createCollection creates the query target and both indexes. Each IndexParam selects its
+        // vector field, index implementation, and similarity metric.
+        client.createCollection(CreateCollectionReq.builder()
+                .collectionName(collectionName)
+                .collectionSchema(schema)
+                .indexParams(Arrays.asList(
+                        IndexParam.builder()
+                                .fieldName("dense")
+                                .indexType(IndexParam.IndexType.AUTOINDEX)
+                                .metricType(IndexParam.MetricType.COSINE)
+                                .build(),
+                        IndexParam.builder()
+                                .fieldName("sparse")
+                                .indexType(IndexParam.IndexType.SPARSE_INVERTED_INDEX)
+                                .metricType(IndexParam.MetricType.IP)
+                                .build()))
+                .build());
+        System.out.printf("Collection '%s' created with dense and sparse indexes%n", collectionName);
+
+        // loadCollection prepares the collection for DQL.
+        client.loadCollection(LoadCollectionReq.builder()
+                .collectionName(collectionName)
+                .build());
+        System.out.println("Collection loaded");
+
+        // insert seeds the tutorial data with JSON entities matching the declared schema.
+        Gson gson = new Gson();
+        List<JsonObject> rows = new ArrayList<>();
+        for (int id = 0; id < 12; id++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("id", id);
+            row.addProperty("title", "document_" + id);
+            row.addProperty("category", id % 3);
+            row.add("dense", gson.toJsonTree(denseVector(id)));
+            row.add("sparse", gson.toJsonTree(sparseVector(id)));
+            rows.add(row);
+        }
+        int inserted = (int) client.insert(InsertReq.builder()
+                .collectionName(collectionName)
+                .data(rows)
+                .build()).getInsertCnt();
+        System.out.printf("Inserted %d tutorial rows%n", inserted);
+    }
+
+    private static void runQuery(MilvusClientV2 client, String collectionName) {
+        System.out.println("\nquery: category == 1");
+        // query performs scalar filtering. Strong consistency includes the recent insert.
+        QueryResp resp = client.query(QueryReq.builder()
+                .collectionName(collectionName)
+                .filter("category == 1")
+                .outputFields(Arrays.asList("id", "title", "category"))
+                .limit(5)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        System.out.println("Query results:");
+        for (QueryResult result : resp.getQueryResults()) {
+            Map<String, Object> entity = result.getEntity();
+            System.out.printf("  id=%s title=%s category=%s%n",
+                    entity.get("id"), entity.get("title"), entity.get("category"));
+        }
+    }
+
+    private static void runSearch(MilvusClientV2 client, String collectionName) {
+        System.out.println("\nsearch: nearest neighbors in the dense field");
+        // search performs nearest-neighbor search on the dense vector field.
+        SearchResp resp = client.search(SearchReq.builder()
+                .collectionName(collectionName)
+                .annsField("dense")
+                .data(Arrays.asList(new FloatVec(denseVector(2))))
+                .filter("category >= 0")
+                .outputFields(Arrays.asList("title", "category"))
+                .limit(3)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        System.out.println("Search results:");
+        for (List<SearchResp.SearchResult> results : resp.getSearchResults()) {
+            for (SearchResp.SearchResult result : results) {
+                System.out.printf("  id=%s score=%f title=%s%n",
+                        result.getId(), result.getScore(),
+                        result.getEntity().get("title"));
+            }
+        }
+    }
+
+    private static void runHybridSearch(MilvusClientV2 client, String collectionName) {
+        System.out.println("\nhybrid_search: combine dense and sparse similarities");
+        // hybridSearch combines the dense and sparse sub-searches. weights controls their
+        // relative contribution and limit caps the reranked matches.
+        AnnSearchReq dense = AnnSearchReq.builder()
+                .vectorFieldName("dense")
+                .vectors(Arrays.asList(new FloatVec(denseVector(2))))
+                .limit(6)
+                .build();
+        AnnSearchReq sparse = AnnSearchReq.builder()
+                .vectorFieldName("sparse")
+                .vectors(Arrays.asList(new SparseFloatVec(sparseVector(2))))
+                .limit(6)
+                .build();
+        SearchResp resp = client.hybridSearch(HybridSearchReq.builder()
+                .collectionName(collectionName)
+                .searchRequests(Arrays.asList(dense, sparse))
+                .functionScore(FunctionScore.builder()
+                        .addFunction(WeightedRanker.builder().weights(Arrays.asList(0.7f, 0.3f)).build())
+                        .build())
+                .outFields(Arrays.asList("title", "category"))
+                .limit(4)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        System.out.println("Hybrid search results:");
+        for (List<SearchResp.SearchResult> results : resp.getSearchResults()) {
+            for (SearchResp.SearchResult result : results) {
+                System.out.printf("  id=%s score=%f title=%s%n",
+                        result.getId(), result.getScore(),
+                        result.getEntity().get("title"));
+            }
+        }
+    }
+
+    private static void runQueryIterator(MilvusClientV2 client, String collectionName) {
+        System.out.println("\nquery_iterator: batch_size=3, limit=7");
+        // queryIterator paginates a query over the primary key. batch_size controls rows per page
+        // and limit controls the total rows returned across all pages.
+        QueryIterator iterator = client.queryIterator(QueryIteratorReq.builder()
+                .collectionName(collectionName)
+                .expr("id >= 0")
+                .outputFields(Arrays.asList("id", "title", "category"))
+                .batchSize(3)
+                .limit(7)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        int count = 0;
+        while (true) {
+            List<QueryResultsWrapper.RowRecord> page = iterator.next();
+            if (page.isEmpty()) {
+                iterator.close();
+                break;
+            }
+            for (QueryResultsWrapper.RowRecord record : page) {
+                Map<String, Object> values = record.getFieldValues();
+                System.out.printf("  id=%s title=%s category=%s%n",
+                        values.get("id"), values.get("title"), values.get("category"));
+                count++;
+            }
+        }
+        System.out.printf("%d query rows returned%n", count);
+    }
+
+    private static void runSearchIterator(MilvusClientV2 client, String collectionName) {
+        System.out.println("\nsearch_iterator: batch_size=3, limit=7");
+        // searchIterator paginates a search while preserving one search session.
+        SearchIterator iterator = client.searchIterator(SearchIteratorReq.builder()
+                .collectionName(collectionName)
+                .vectorFieldName("dense")
+                .metricType(IndexParam.MetricType.COSINE)
+                .vectors(Arrays.asList(new FloatVec(denseVector(2))))
+                .outputFields(Arrays.asList("title", "category"))
+                .batchSize(3)
+                .limit(7)
+                .consistencyLevel(ConsistencyLevel.STRONG)
+                .build());
+        int count = 0;
+        while (true) {
+            List<QueryResultsWrapper.RowRecord> page = iterator.next();
+            if (page.isEmpty()) {
+                iterator.close();
+                break;
+            }
+            for (QueryResultsWrapper.RowRecord record : page) {
+                Map<String, Object> values = record.getFieldValues();
+                System.out.printf("  id=%s title=%s category=%s%n",
+                        values.get("id"), values.get("title"), values.get("category"));
+                count++;
+            }
+        }
+        System.out.printf("%d search rows returned%n", count);
+    }
+
+    private static float[] denseVector(int id) {
+        float base = id / 10.0f;
+        return new float[]{base, base + 0.1f, base + 0.2f, base + 0.3f};
+    }
+
+    private static SortedMap<Long, Float> sparseVector(int id) {
+        SortedMap<Long, Float> vector = new TreeMap<>();
+        vector.put((long) (id % 8), 1.0f);
+        vector.put((long) ((id + 3) % 8), 0.5f);
+        return vector;
+    }
+}

--- a/tutorial/7_database/README.md
+++ b/tutorial/7_database/README.md
@@ -1,0 +1,37 @@
+# Tutorial 7: Database
+
+Walks through logical database administration with `MilvusClientV2`: list existing databases, create
+a database, inspect it with `describeDatabase`, set and remove a property, switch the client's
+selected database with `useDatabase`, and finally drop the tutorial database.
+
+## What you learn
+
+1. List databases with `listDatabases`.
+2. Create a logical database with `createDatabase`.
+3. Inspect database metadata with `describeDatabase`.
+4. Add and remove database properties such as the default replica number.
+5. Switch the database used by requests that omit a database name with `useDatabase`.
+6. Drop the database during cleanup.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.database.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.database.App"
+```

--- a/tutorial/7_database/pom.xml
+++ b/tutorial/7_database/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-database</artifactId>
+    <name>Milvus Java SDK tutorial - 7</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/7_database/src/main/java/io/milvus/tutorial/database/App.java
+++ b/tutorial/7_database/src/main/java/io/milvus/tutorial/database/App.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.database;
+
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.database.request.AlterDatabasePropertiesReq;
+import io.milvus.v2.service.database.request.CreateDatabaseReq;
+import io.milvus.v2.service.database.request.DescribeDatabaseReq;
+import io.milvus.v2.service.database.request.DropDatabasePropertiesReq;
+import io.milvus.v2.service.database.request.DropDatabaseReq;
+import io.milvus.v2.service.database.response.DescribeDatabaseResp;
+import io.milvus.v2.service.database.response.ListDatabasesResp;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tutorial 7: Database management.
+ *
+ * <p>Walks through logical database administration with {@code MilvusClientV2}: list existing
+ * databases, create a database, inspect it, set and remove a property, switch the client's
+ * selected database with {@code useDatabase}, and finally drop the tutorial database.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final String REPLICA_NUMBER = "database.replica.number";
+
+    public static void main(String[] args) throws InterruptedException {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            String databaseName = "tutorial_database";
+
+            // Pre-drop any database left behind by an interrupted run so the tutorial stays
+            // rerunnable. Drop only when it exists: dropDatabase is not idempotent on Milvus
+            // 2.6.0-2.6.5 (missing-database handling landed in 2.6.6), so an unconditional drop
+            // would abort the first run on those versions.
+            if (client.listDatabases().getDatabaseNames().contains(databaseName)) {
+                client.dropDatabase(DropDatabaseReq.builder()
+                        .databaseName(databaseName)
+                        .build());
+            }
+
+            printDatabases(client, "Databases before the tutorial");
+
+            // createDatabase creates a logical database. The name is used by later requests and by
+            // useDatabase.
+            client.createDatabase(CreateDatabaseReq.builder()
+                    .databaseName(databaseName)
+                    .build());
+            System.out.printf("Database '%s' created%n", databaseName);
+
+            // describeDatabase returns metadata for the named database.
+            DescribeDatabaseResp descResp = client.describeDatabase(DescribeDatabaseReq.builder()
+                    .databaseName(databaseName)
+                    .build());
+            System.out.printf("describeDatabase: name=%s properties=%s%n",
+                    descResp.getDatabaseName(), descResp.getProperties());
+
+            // alterDatabaseProperties adds or replaces property key/value pairs. This setting
+            // configures the default replica count for collections in the database.
+            client.alterDatabaseProperties(AlterDatabasePropertiesReq.builder()
+                    .databaseName(databaseName)
+                    .property(REPLICA_NUMBER, "1")
+                    .build());
+            System.out.println("Set " + REPLICA_NUMBER + " = 1");
+            printProperty(client, databaseName);
+
+            // dropDatabaseProperties removes the specified key while preserving other properties.
+            client.dropDatabaseProperties(DropDatabasePropertiesReq.builder()
+                    .databaseName(databaseName)
+                    .propertyKeys(Arrays.asList(REPLICA_NUMBER))
+                    .build());
+            System.out.println("Removed " + REPLICA_NUMBER);
+            printProperty(client, databaseName);
+
+            // useDatabase selects this database for requests that omit an explicit database name.
+            client.useDatabase(databaseName);
+            System.out.println("Selected database for subsequent requests: " + databaseName);
+
+            // Clean up: switch back to the default database, then drop the tutorial database.
+            client.useDatabase("default");
+            client.dropDatabase(DropDatabaseReq.builder()
+                    .databaseName(databaseName)
+                    .build());
+            System.out.printf("Database '%s' dropped%n", databaseName);
+
+            printDatabases(client, "Databases after cleanup");
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void printProperty(MilvusClientV2 client, String databaseName) {
+        DescribeDatabaseResp resp = client.describeDatabase(DescribeDatabaseReq.builder()
+                .databaseName(databaseName)
+                .build());
+        System.out.println("Property " + REPLICA_NUMBER + " = "
+                + resp.getProperties().getOrDefault(REPLICA_NUMBER, "<not set>"));
+    }
+
+    private static void printDatabases(MilvusClientV2 client, String heading) {
+        ListDatabasesResp resp = client.listDatabases();
+        List<String> names = resp.getDatabaseNames();
+        System.out.printf("%s: %s%n", heading, names.isEmpty() ? "<none>" : String.join(", ", names));
+    }
+}

--- a/tutorial/8_rbac/README.md
+++ b/tutorial/8_rbac/README.md
@@ -1,0 +1,42 @@
+# Tutorial 8: Role-based access control (RBAC)
+
+Demonstrates access management with `MilvusClientV2` using an administrator credential: create a
+user, a role, and a privilege group, add built-in privileges to the group, attach the group to the
+role, and grant the role to the user. The tutorial then inspects the assignments and cleans
+everything up.
+
+## What you learn
+
+1. Create a login identity with `createUser`.
+2. Create a permission container with `createRole`.
+3. Create a reusable privilege group with `createPrivilegeGroup`.
+4. Add built-in privileges such as `Query` and `Search` to a group.
+5. Attach a privilege group to a role with `grantPrivilegeV2`.
+6. Assign a role to a user with `grantRole`.
+7. Inspect assignments with `describeUser` and `describeRole`.
+8. Revoke and delete every created resource during cleanup.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- Milvus 2.6 or later running at an accessible endpoint
+- An administrator credential: the `MILVUS_TOKEN` must be allowed to create users, roles,
+  privilege groups, and grants
+
+The tutorial defaults to `MILVUS_URI=http://localhost:19530` and `MILVUS_TOKEN=root:Milvus`.
+Override them when needed:
+
+```bash
+MILVUS_URI="https://your-endpoint" MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.rbac.App"
+```
+
+## Build and run
+
+From this directory:
+
+```bash
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.rbac.App"
+```

--- a/tutorial/8_rbac/pom.xml
+++ b/tutorial/8_rbac/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.milvus</groupId>
+        <artifactId>milvus-sdk-java-tutorials</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>milvus-tutorial-rbac</artifactId>
+    <name>Milvus Java SDK tutorial - 8</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.milvus</groupId>
+            <artifactId>milvus-sdk-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tutorial/8_rbac/src/main/java/io/milvus/tutorial/rbac/App.java
+++ b/tutorial/8_rbac/src/main/java/io/milvus/tutorial/rbac/App.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milvus.tutorial.rbac;
+
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.service.rbac.PrivilegeGroup;
+import io.milvus.v2.service.rbac.request.AddPrivilegesToGroupReq;
+import io.milvus.v2.service.rbac.request.CreatePrivilegeGroupReq;
+import io.milvus.v2.service.rbac.request.CreateRoleReq;
+import io.milvus.v2.service.rbac.request.CreateUserReq;
+import io.milvus.v2.service.rbac.request.DescribeRoleReq;
+import io.milvus.v2.service.rbac.request.DescribeUserReq;
+import io.milvus.v2.service.rbac.request.DropPrivilegeGroupReq;
+import io.milvus.v2.service.rbac.request.DropRoleReq;
+import io.milvus.v2.service.rbac.request.DropUserReq;
+import io.milvus.v2.service.rbac.request.GrantPrivilegeReqV2;
+import io.milvus.v2.service.rbac.request.GrantRoleReq;
+import io.milvus.v2.service.rbac.request.ListPrivilegeGroupsReq;
+import io.milvus.v2.service.rbac.request.RemovePrivilegesFromGroupReq;
+import io.milvus.v2.service.rbac.request.RevokePrivilegeReqV2;
+import io.milvus.v2.service.rbac.request.RevokeRoleReq;
+import io.milvus.v2.service.rbac.response.DescribeRoleResp;
+import io.milvus.v2.service.rbac.response.DescribeUserResp;
+import io.milvus.v2.service.rbac.response.ListPrivilegeGroupsResp;
+
+import java.util.Arrays;
+
+/**
+ * Tutorial 8: Role-based access control (RBAC).
+ *
+ * <p>Demonstrates access management with {@code MilvusClientV2} using an administrator credential:
+ * create a user, a role, and a privilege group, add privileges to the group, attach the group to
+ * the role, and grant the role to the user. The tutorial then inspects the assignments with
+ * {@code describeUser} / {@code describeRole} and cleans everything up.
+ *
+ * <p>The {@code MILVUS_TOKEN} must identify an administrator allowed to create users, roles,
+ * privilege groups, and grants.
+ *
+ * <p>Connection defaults to {@code MILVUS_URI=http://localhost:19530} and
+ * {@code MILVUS_TOKEN=root:Milvus}. Override them with environment variables when needed.
+ */
+public class App {
+    private static final String DATABASE_NAME = "default";
+    private static final String COLLECTION_NAME = "*";
+
+    public static void main(String[] args) {
+        String uri = System.getenv().getOrDefault("MILVUS_URI", "http://localhost:19530");
+        String token = System.getenv().getOrDefault("MILVUS_TOKEN", "root:Milvus");
+
+        ConnectConfig config = ConnectConfig.builder()
+                .uri(uri)
+                .token(token)
+                .build();
+        MilvusClientV2 client = new MilvusClientV2(config);
+        try {
+            // Milvus 2.6 defaults maxUsernameLength to 32 bytes. Keep the username compact while
+            // retaining the thread ID and millisecond timestamp for uniqueness across runs.
+            String suffix = System.currentTimeMillis() + "_" + Thread.currentThread().getId();
+            String username = "u" + suffix;
+            String role = "java_tutorial_role_" + suffix;
+            String group = "java_tutorial_group_" + suffix;
+            // The tutorial never logs in as this user, so the password is a throwaway generated
+            // per run rather than a hard-coded literal.
+            String password = "JavaTutorial!" + suffix;
+
+            // createUser creates a login identity. The password is its secret and the description
+            // is optional administrator-facing metadata.
+            client.createUser(CreateUserReq.builder()
+                    .userName(username)
+                    .password(password)
+                    .description("temporary Java SDK tutorial user")
+                    .build());
+            System.out.println("Created user " + username);
+
+            // createRole creates a named permission container; privileges are attached in later
+            // calls.
+            client.createRole(CreateRoleReq.builder()
+                    .roleName(role)
+                    .description("temporary Java SDK tutorial role")
+                    .build());
+            System.out.println("Created role " + role);
+
+            // createPrivilegeGroup creates a reusable custom group identified by its name.
+            client.createPrivilegeGroup(CreatePrivilegeGroupReq.builder()
+                    .groupName(group)
+                    .build());
+            System.out.println("Created privilege group " + group);
+
+            // addPrivilegesToGroup adds built-in privileges to the group. Query permits scalar
+            // reads and Search permits vector searches.
+            client.addPrivilegesToGroup(AddPrivilegesToGroupReq.builder()
+                    .groupName(group)
+                    .privileges(Arrays.asList("Query", "Search"))
+                    .build());
+            System.out.println("Added Query and Search privileges to group");
+
+            // grantPrivilegeV2 attaches the custom group to the role. The collection name "*"
+            // covers all collections in the database.
+            client.grantPrivilegeV2(GrantPrivilegeReqV2.builder()
+                    .roleName(role)
+                    .privilege(group)
+                    .dbName(DATABASE_NAME)
+                    .collectionName(COLLECTION_NAME)
+                    .build());
+            System.out.println("Granted privilege group to role");
+
+            // grantRole assigns the named role to the named user.
+            client.grantRole(GrantRoleReq.builder()
+                    .userName(username)
+                    .roleName(role)
+                    .build());
+            System.out.println("Granted role to user");
+
+            // describeUser returns user metadata and assigned role names.
+            DescribeUserResp userResp = client.describeUser(DescribeUserReq.builder()
+                    .userName(username)
+                    .build());
+            System.out.println("User " + userResp.getUserName() + " roles=" + userResp.getRoles());
+
+            // describeRole returns role metadata and grants scoped to the database.
+            DescribeRoleResp roleResp = client.describeRole(DescribeRoleReq.builder()
+                    .roleName(role)
+                    .dbName(DATABASE_NAME)
+                    .build());
+            System.out.println("Role " + roleResp.getRoleName() + " grants=" + roleResp.getGrantInfos());
+
+            cleanup(client, username, role, group);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void cleanup(MilvusClientV2 client, String username, String role, String group) {
+        // revokeRole removes the user's role assignment before any resource deletion.
+        if (client.listUsers().contains(username)) {
+            DescribeUserResp userResp = client.describeUser(DescribeUserReq.builder()
+                    .userName(username)
+                    .build());
+            if (userResp.getRoles().contains(role)) {
+                client.revokeRole(RevokeRoleReq.builder()
+                        .userName(username)
+                        .roleName(role)
+                        .build());
+                System.out.println("Revoked role from user");
+            }
+        }
+
+        // revokePrivilegeV2 detaches the group from this role/database/collection scope.
+        if (client.listRoles().contains(role)) {
+            client.revokePrivilegeV2(RevokePrivilegeReqV2.builder()
+                    .roleName(role)
+                    .privilege(group)
+                    .dbName(DATABASE_NAME)
+                    .collectionName(COLLECTION_NAME)
+                    .build());
+            System.out.println("Revoked privilege group from role");
+        }
+
+        // removePrivilegesFromGroup removes the built-in privileges before deleting the group.
+        ListPrivilegeGroupsResp groupsResp = client.listPrivilegeGroups(ListPrivilegeGroupsReq.builder().build());
+        for (PrivilegeGroup privilegeGroup : groupsResp.getPrivilegeGroups()) {
+            if (group.equals(privilegeGroup.getGroupName())) {
+                client.removePrivilegesFromGroup(RemovePrivilegesFromGroupReq.builder()
+                        .groupName(group)
+                        .privileges(Arrays.asList("Query", "Search"))
+                        .build());
+                client.dropPrivilegeGroup(DropPrivilegeGroupReq.builder()
+                        .groupName(group)
+                        .build());
+                System.out.println("Removed and dropped privilege group");
+            }
+        }
+
+        if (client.listRoles().contains(role)) {
+            client.dropRole(DropRoleReq.builder()
+                    .roleName(role)
+                    .forceDrop(true)
+                    .build());
+            System.out.println("Dropped role");
+        }
+
+        if (client.listUsers().contains(username)) {
+            client.dropUser(DropUserReq.builder()
+                    .userName(username)
+                    .build());
+            System.out.println("Dropped user");
+        }
+    }
+}

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,0 +1,64 @@
+# Milvus Java SDK tutorials
+
+This directory contains beginner-oriented tutorials for the Milvus Java SDK. Each tutorial is an
+independent Maven project that depends on the **published** `milvus-sdk-java` artifact from Maven
+Central, rather than on this repository's source tree. This keeps the tutorials close to the
+experience of an application developer installing the SDK.
+
+## Prerequisites
+
+- Java 8 or higher
+- Apache Maven
+- A running Milvus server
+
+## Run a tutorial
+
+From the repository root:
+
+```bash
+cd tutorial/1_quickstart
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.quickstart.App"
+```
+
+Each tutorial expects Milvus at `http://localhost:19530` with the default `root:Milvus` credentials.
+To point at a different server, set the `MILVUS_URI` and `MILVUS_TOKEN` environment variables:
+
+```bash
+MILVUS_URI="https://your-milvus-endpoint" \
+MILVUS_TOKEN="your-token" \
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.quickstart.App"
+```
+
+## Start here
+
+If this is your first Milvus Java SDK program, start with the quickstart:
+
+```bash
+cd tutorial/1_quickstart
+mvn compile
+mvn exec:java -Dexec.mainClass="io.milvus.tutorial.quickstart.App"
+```
+
+## Beginner tutorials
+
+- [`1_quickstart`](1_quickstart/): connect, create a collection, insert data, search, and clean up.
+- [`2_collection`](2_collection/): manage the collection lifecycle.
+- [`3_schema`](3_schema/): define collection fields for the supported V2 data types.
+- [`4_index`](4_index/): create and inspect vector and scalar indexes.
+- [`5_dml`](5_dml/): insert, upsert, and delete collection data.
+- [`6_dql`](6_dql/): query, search, hybrid search, and iterate through results.
+
+## Advanced tutorials
+
+- [`7_database`](7_database/): create, configure, select, and remove databases.
+- [`8_rbac`](8_rbac/): manage users, roles, privilege groups, and grants.
+
+## SDK version
+
+The `milvus-sdk-java` version used by all tutorials is declared once in the parent
+[`pom.xml`](pom.xml) (`milvus.sdk.version`). When a new SDK version is released, update it there so
+the tutorials keep consuming the latest published artifact.
+
+The source-linked examples used for SDK development and testing remain under
+[`examples/`](../examples/README.md).

--- a/tutorial/pom.xml
+++ b/tutorial/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.milvus</groupId>
+    <artifactId>milvus-sdk-java-tutorials</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <name>Milvus Java SDK tutorials</name>
+    <description>Beginner-oriented, standalone tutorials that consume the published milvus-sdk-java artifact.</description>
+    <url>https://github.com/milvus-io/milvus-sdk-java</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <!-- Single source of the milvus-sdk-java version used by all tutorials.
+             Keep in sync with the latest published release; do not duplicate it
+             in the child pom.xml files. -->
+        <milvus.sdk.version>3.0.9</milvus.sdk.version>
+        <slf4j.version>1.7.36</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.milvus</groupId>
+                <artifactId>milvus-sdk-java</artifactId>
+                <version>${milvus.sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>1_quickstart</module>
+        <module>2_collection</module>
+        <module>3_schema</module>
+        <module>4_index</module>
+        <module>5_dml</module>
+        <module>6_dql</module>
+        <module>7_database</module>
+        <module>8_rbac</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
Introduce `tutorial/` as eight standalone Maven projects that depend on the **published** `milvus-sdk-java` from Maven Central instead of the local source tree, mirroring the C++/Rust SDK tutorial layout.

## Changes

- `tutorial/1_quickstart` — connect, create a collection, index, insert, search, clean up.
- `tutorial/2_collection` — full collection lifecycle (create/describe/properties/load/release/rename/truncate/drop).
- `tutorial/3_schema` — scalar, vector, and sparse/struct field data types.
- `tutorial/4_index` — vector and scalar index management (`createIndex`/`listIndexes`/`describeIndex`/`dropIndex`).
- `tutorial/5_dml` — insert, upsert (incl. partial update), delete by ids/filter, query.
- `tutorial/6_dql` — query, search, hybrid search, query/search iterators.
- `tutorial/7_database` — create, configure, select, and drop databases.
- `tutorial/8_rbac` — users, roles, privilege groups, and grants.
- Parent `tutorial/pom.xml` is the single source of the SDK version (`milvus.sdk.version`) and the `slf4j` runtime needed by the shaded artifact; each module is runnable standalone via `mvn exec:java`.
- `AGENTS.md`: document the tutorial layout and the release-time version bump.

Each tutorial is verified end-to-end against a Milvus standalone, and each ships its own `README.md` (What you learn / Prerequisites / Build and run).

DCO: commit carries a `Signed-off-by` trailer.